### PR TITLE
Enables custom Autotask API base URL

### DIFF
--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -323,7 +323,8 @@ export async function autotaskApiRequest<T = JsonObject>(
 	query: IRequestConfig['query'] = {},
 ): Promise<T> {
 	const credentials = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
-	const baseUrl = credentials.zone;
+	// Determine the correct base URL based on the zone selection
+	const baseUrl = credentials.zone === 'other' ? credentials.customZoneUrl : credentials.zone;
 
 	const options: IRequestOptions = {
 		method,

--- a/nodes/Autotask/types/base/auth.ts
+++ b/nodes/Autotask/types/base/auth.ts
@@ -3,6 +3,7 @@ export interface IAutotaskCredentials {
 	Username: string;
 	Secret: string;
 	zone: string;
+	customZoneUrl?: string;
 	timezone: string;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Allows users to specify a custom base URL for the Autotask API when the "other" zone is selected.

This enhances flexibility by allowing connections to Autotask instances with non-standard URLs.