### PR TITLE
Add optional JSONL debug trace for Autotask AI tools and wire tracing through builders and executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the n8n-nodes-autotask project will be documented in this
 
 ## [2.9.0] — 2026-04-10
 
+### Changed
+
+- **AI tools — optional debug trace (JSONL)**: Added a low-noise, code-togglable
+  debug trace system for `AutotaskAiTools` (`debug-trace.ts`). Tracing is off by
+  default and writes compact append-only JSONL events for tool build, schema/description
+  hints, execution/filter planning, label resolution, write blockers, response envelopes,
+  and error paths.
+
 ### Fixed
 
 - **AI tools — timezone-aware date handling**: Date values provided by the LLM are now

--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -508,17 +508,18 @@ export class AutotaskAiTools implements INodeType {
 					pairedItem: { item: itemIndex },
 				});
 			} catch (error) {
-				traceError({
-					phase: 'execute-agent-v3-item',
-					resource,
-					operation,
-					itemIndex,
-					summary: {
-						errorMessage: error instanceof Error ? error.message : String(error),
-						beforeApiCall: true,
-					},
-				});
 				const msg = error instanceof Error ? error.message : String(error);
+				try {
+					traceError({
+						phase: 'execute-agent-v3-item',
+						resource,
+						operation,
+						itemIndex,
+						summary: { errorMessage: msg, beforeApiCall: true },
+					});
+				} catch {
+					// best-effort: trace must not suppress the rethrow
+				}
 				throw new NodeOperationError(this.getNode(), msg, { itemIndex });
 			}
 		}

--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -1,14 +1,14 @@
 import { NodeOperationError } from 'n8n-workflow';
 import type {
-    IDataObject,
-    IExecuteFunctions,
-    ILoadOptionsFunctions,
-    INodeType,
-    INodeTypeDescription,
-    INodePropertyOptions,
-    INodeExecutionData,
-    ISupplyDataFunctions,
-    SupplyData,
+	IDataObject,
+	IExecuteFunctions,
+	ILoadOptionsFunctions,
+	INodeType,
+	INodeTypeDescription,
+	INodePropertyOptions,
+	INodeExecutionData,
+	ISupplyDataFunctions,
+	SupplyData,
 } from 'n8n-workflow';
 import { RESOURCE_OPERATIONS_MAP, getResourceOperations } from './constants/resource-operations';
 import { describeResource } from './helpers/aiHelper';
@@ -18,34 +18,58 @@ import { RuntimeDynamicStructuredTool, runtimeZod, getLazyLogWrapper } from './a
 import { getRuntimeSchemaBuilders } from './ai-tools/schema-generator';
 import { isNodeResourceImpersonationSupported } from './helpers/impersonation';
 import { wrapError, ERROR_TYPES } from './ai-tools/error-formatter';
+import {
+	AI_TOOL_DEBUG_VERBOSE,
+	redactForVerbose,
+	safeKeys,
+	traceError,
+	traceExecutor,
+	traceToolBuild,
+} from './ai-tools/debug-trace';
 
-const WRITE_OPERATIONS = ['create', 'createIfNotExists', 'moveToCompany', 'moveConfigurationItem', 'transferOwnership', 'update', 'approve', 'reject', 'delete'];
+const WRITE_OPERATIONS = [
+	'create',
+	'createIfNotExists',
+	'moveToCompany',
+	'moveConfigurationItem',
+	'transferOwnership',
+	'update',
+	'approve',
+	'reject',
+	'delete',
+];
 const SUPPORTED_TOOL_OPERATIONS = [
-    'get',
-    'getMany',
-    'searchByDomain',
-    'getPosted',
-    'getUnposted',
-    'getByResource',
-    'getByYear',
-    'count',
-    'create',
-    'moveToCompany',
-    'moveConfigurationItem',
-    'transferOwnership',
-    'update',
-    'delete',
-    'whoAmI',
-    'slaHealthCheck',
-    'summary',
-    'createIfNotExists',
-    'approve',
-    'reject',
+	'get',
+	'getMany',
+	'searchByDomain',
+	'getPosted',
+	'getUnposted',
+	'getByResource',
+	'getByYear',
+	'count',
+	'create',
+	'moveToCompany',
+	'moveConfigurationItem',
+	'transferOwnership',
+	'update',
+	'delete',
+	'whoAmI',
+	'slaHealthCheck',
+	'summary',
+	'createIfNotExists',
+	'approve',
+	'reject',
 ];
 const EXCLUDED_RESOURCES = ['aiHelper', 'apiThreshold'];
 
 function formatResourceName(value: string): string {
-    return value.charAt(0).toUpperCase() + value.slice(1).replace(/([A-Z])/g, ' $1').trim();
+	return (
+		value.charAt(0).toUpperCase() +
+		value
+			.slice(1)
+			.replace(/([A-Z])/g, ' $1')
+			.trim()
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -53,394 +77,514 @@ function formatResourceName(value: string): string {
 // ---------------------------------------------------------------------------
 
 export class AutotaskAiTools implements INodeType {
-    description: INodeTypeDescription = {
-        displayName: 'Autotask AI Tools',
-        name: 'autotaskAiTools',
-        icon: 'file:autotask.svg',
-        group: ['output'],
-        version: 1,
-        description: 'Expose Autotask operations as individual AI tools for the AI Agent',
-        codex: {
-            categories: ['AI'],
-            subcategories: {
-                AI: ['Tools'],
-            },
-            resources: {
-                primaryDocumentation: [
-                    {
-                        url: 'https://github.com/msoukhomlinov/n8n-nodes-autotask',
-                    },
-                    {
-                        url: 'https://ww6.autotask.net/help/developerhelp/Content/APIs/REST/REST_API_Home.htm',
-                    },
-                ],
-            },
-        },
-        defaults: {
-            name: 'Autotask AI Tools',
-        },
-        inputs: [],
-        outputs: [{ type: 'ai_tool', displayName: 'Tools' }],
-        credentials: [{ name: 'autotaskApi', required: true }],
-        properties: [
-            {
-                displayName: 'Resource Name or ID',
-                name: 'resource',
-                type: 'options',
-                required: true,
-                noDataExpression: true,
-                typeOptions: { loadOptionsMethod: 'getToolResources' },
-                default: '',
-                description: 'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
-            },
-            {
-                displayName: 'Operations Names or IDs',
-                name: 'operations',
-                type: 'multiOptions',
-                required: true,
-                typeOptions: {
-                    loadOptionsMethod: 'getToolResourceOperations',
-                    loadOptionsDependsOn: ['resource', 'allowWriteOperations'],
-                },
-                default: [],
-                description: 'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
-            },
-            {
-                displayName: 'Allow Write Operations',
-                name: 'allowWriteOperations',
-                type: 'boolean',
-                default: false,
-                description: 'Whether to enable mutating tools (create, createIfNotExists, moveToCompany, moveConfigurationItem, transferOwnership, update, delete). Disabled = read-only.',
-            },
-        ],
-    };
+	description: INodeTypeDescription = {
+		displayName: 'Autotask AI Tools',
+		name: 'autotaskAiTools',
+		icon: 'file:autotask.svg',
+		group: ['output'],
+		version: 1,
+		description: 'Expose Autotask operations as individual AI tools for the AI Agent',
+		codex: {
+			categories: ['AI'],
+			subcategories: {
+				AI: ['Tools'],
+			},
+			resources: {
+				primaryDocumentation: [
+					{
+						url: 'https://github.com/msoukhomlinov/n8n-nodes-autotask',
+					},
+					{
+						url: 'https://ww6.autotask.net/help/developerhelp/Content/APIs/REST/REST_API_Home.htm',
+					},
+				],
+			},
+		},
+		defaults: {
+			name: 'Autotask AI Tools',
+		},
+		inputs: [],
+		outputs: [{ type: 'ai_tool', displayName: 'Tools' }],
+		credentials: [{ name: 'autotaskApi', required: true }],
+		properties: [
+			{
+				displayName: 'Resource Name or ID',
+				name: 'resource',
+				type: 'options',
+				required: true,
+				noDataExpression: true,
+				typeOptions: { loadOptionsMethod: 'getToolResources' },
+				default: '',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			},
+			{
+				displayName: 'Operations Names or IDs',
+				name: 'operations',
+				type: 'multiOptions',
+				required: true,
+				typeOptions: {
+					loadOptionsMethod: 'getToolResourceOperations',
+					loadOptionsDependsOn: ['resource', 'allowWriteOperations'],
+				},
+				default: [],
+				description:
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			},
+			{
+				displayName: 'Allow Write Operations',
+				name: 'allowWriteOperations',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether to enable mutating tools (create, createIfNotExists, moveToCompany, moveConfigurationItem, transferOwnership, update, delete). Disabled = read-only.',
+			},
+		],
+	};
 
-    methods = {
-        loadOptions: {
-            getToolResources,
-            getToolResourceOperations,
-        },
-    };
+	methods = {
+		loadOptions: {
+			getToolResources,
+			getToolResourceOperations,
+		},
+	};
 
-    async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
-        const { buildUnifiedSchema } = getRuntimeSchemaBuilders(runtimeZod);
+	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
+		const { buildUnifiedSchema } = getRuntimeSchemaBuilders(runtimeZod);
 
-        const resource = this.getNodeParameter('resource', itemIndex) as string;
-        const operations = this.getNodeParameter('operations', itemIndex) as string[];
-        const allowWriteOperations = this.getNodeParameter('allowWriteOperations', itemIndex, false) as boolean;
+		const resource = this.getNodeParameter('resource', itemIndex) as string;
+		const operations = this.getNodeParameter('operations', itemIndex) as string[];
+		const allowWriteOperations = this.getNodeParameter(
+			'allowWriteOperations',
+			itemIndex,
+			false,
+		) as boolean;
 
-        if (!resource) {
-            throw new NodeOperationError(this.getNode(), 'Resource is required');
-        }
-        if (!operations?.length) {
-            throw new NodeOperationError(this.getNode(), 'At least one operation must be selected');
-        }
+		if (!resource) {
+			throw new NodeOperationError(this.getNode(), 'Resource is required');
+		}
+		if (!operations?.length) {
+			throw new NodeOperationError(this.getNode(), 'At least one operation must be selected');
+		}
 
-        const unsupportedOperations = operations.filter(
-            (operation) => !SUPPORTED_TOOL_OPERATIONS.includes(operation),
-        );
-        if (unsupportedOperations.length > 0) {
-            throw new NodeOperationError(
-                this.getNode(),
-                `Unsupported operation(s) for AI tools: ${unsupportedOperations.join(', ')}. ` +
-                    `Supported operations are: ${SUPPORTED_TOOL_OPERATIONS.join(', ')}.`,
-            );
-        }
+		const unsupportedOperations = operations.filter(
+			(operation) => !SUPPORTED_TOOL_OPERATIONS.includes(operation),
+		);
+		if (unsupportedOperations.length > 0) {
+			throw new NodeOperationError(
+				this.getNode(),
+				`Unsupported operation(s) for AI tools: ${unsupportedOperations.join(', ')}. ` +
+					`Supported operations are: ${SUPPORTED_TOOL_OPERATIONS.join(', ')}.`,
+			);
+		}
 
-        const effectiveOps = operations.filter(
-            (op) => !WRITE_OPERATIONS.includes(op) || allowWriteOperations,
-        );
-        if (effectiveOps.length === 0) {
-            throw new NodeOperationError(
-                this.getNode(),
-                'No permitted operations. Enable "Allow Write Operations" if write operations are needed.',
-            );
-        }
+		const effectiveOps = operations.filter(
+			(op) => !WRITE_OPERATIONS.includes(op) || allowWriteOperations,
+		);
+		if (effectiveOps.length === 0) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'No permitted operations. Enable "Allow Write Operations" if write operations are needed.',
+			);
+		}
 
-        const resourceLabel = formatResourceName(resource);
-        const referenceUtc = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
-        const supportsImpersonation = isNodeResourceImpersonationSupported(resource);
+		const resourceLabel = formatResourceName(resource);
+		const referenceUtc = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+		const supportsImpersonation = isNodeResourceImpersonationSupported(resource);
+		// Trace tool-construction decisions to understand what the AI can see.
+		traceToolBuild({
+			phase: 'supplyData-start',
+			resource,
+			itemIndex,
+			summary: {
+				selectedResource: resource,
+				configuredOperations: operations,
+				effectiveOperations: effectiveOps,
+				writeOpsAllowed: allowWriteOperations,
+				supportsImpersonation,
+			},
+		});
 
-        // Fetch field metadata once — reused by schema + description + executor
-        const needsReadFields = effectiveOps.some((op) =>
-            ['get', 'getMany', 'getPosted', 'getUnposted', 'count', 'whoAmI', 'searchByDomain', 'getByResource', 'getByYear'].includes(op),
-        );
-        const needsWriteFields = effectiveOps.some((op) => ['create', 'createIfNotExists', 'update'].includes(op));
+		// Fetch field metadata once — reused by schema + description + executor
+		const needsReadFields = effectiveOps.some((op) =>
+			[
+				'get',
+				'getMany',
+				'getPosted',
+				'getUnposted',
+				'count',
+				'whoAmI',
+				'searchByDomain',
+				'getByResource',
+				'getByYear',
+			].includes(op),
+		);
+		const needsWriteFields = effectiveOps.some((op) =>
+			['create', 'createIfNotExists', 'update'].includes(op),
+		);
 
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        const supplyDataContext = this;
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
+		const supplyDataContext = this;
 
-        const [readDescribe, writeDescribe] = await Promise.all([
-            needsReadFields
-                ? describeResource(supplyDataContext as unknown as ILoadOptionsFunctions, resource, 'read')
-                : Promise.resolve(undefined),
-            needsWriteFields
-                ? describeResource(supplyDataContext as unknown as ILoadOptionsFunctions, resource, 'write')
-                : Promise.resolve(undefined),
-        ]);
+		const [readDescribe, writeDescribe] = await Promise.all([
+			needsReadFields
+				? describeResource(supplyDataContext as unknown as ILoadOptionsFunctions, resource, 'read')
+				: Promise.resolve(undefined),
+			needsWriteFields
+				? describeResource(supplyDataContext as unknown as ILoadOptionsFunctions, resource, 'write')
+				: Promise.resolve(undefined),
+		]);
+		traceToolBuild({
+			phase: 'metadata-fetched',
+			resource,
+			itemIndex,
+			summary: {
+				readMetadataFetched: needsReadFields,
+				writeMetadataFetched: needsWriteFields,
+				readFieldCount: readDescribe?.fields?.length ?? 0,
+				writeFieldCount: writeDescribe?.fields?.length ?? 0,
+			},
+		});
 
-        const schema = buildUnifiedSchema(
-            resource,
-            effectiveOps,
-            readDescribe?.fields ?? [],
-            writeDescribe?.fields ?? [],
-        );
+		const schema = buildUnifiedSchema(
+			resource,
+			effectiveOps,
+			readDescribe?.fields ?? [],
+			writeDescribe?.fields ?? [],
+		);
 
-        const description = buildUnifiedDescription(
-            resourceLabel,
-            resource,
-            effectiveOps,
-            readDescribe?.fields ?? [],
-            writeDescribe?.fields ?? [],
-            referenceUtc,
-            supportsImpersonation,
-        );
+		const description = buildUnifiedDescription(
+			resourceLabel,
+			resource,
+			effectiveOps,
+			readDescribe?.fields ?? [],
+			writeDescribe?.fields ?? [],
+			referenceUtc,
+			supportsImpersonation,
+		);
 
-        const allAllowedOps = [...new Set([...effectiveOps, 'describeFields', 'listPicklistValues', 'describeOperation'])];
+		const allAllowedOps = [
+			...new Set([...effectiveOps, 'describeFields', 'listPicklistValues', 'describeOperation']),
+		];
+		traceToolBuild({
+			phase: 'tool-built',
+			resource,
+			itemIndex,
+			summary: {
+				toolName: `autotask_${resource}`,
+				allAllowedOps,
+				schemaFieldCount: safeKeys(schema).length,
+				schemaTopLevelKeys: safeKeys(schema),
+				descriptionLength: description.length,
+				...(AI_TOOL_DEBUG_VERBOSE ? { descriptionPreview: redactForVerbose(description) } : {}),
+			},
+		});
 
-        const unifiedTool = new RuntimeDynamicStructuredTool({
-            name: `autotask_${resource}`,
-            description,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            schema: schema as any,
-            func: async (rawParams: Record<string, unknown>) => {
-                const operation = rawParams.operation as string;
-                if (!operation || !allAllowedOps.includes(operation)) {
-                    if (operation && WRITE_OPERATIONS.includes(operation) && !allowWriteOperations) {
-                        return JSON.stringify(wrapError(
-                            resource, operation, ERROR_TYPES.WRITE_OPERATION_BLOCKED,
-                            `Write operation '${operation}' is blocked. Enable "Allow Write Operations" in the node configuration.`,
-                            `Use a read operation such as 'get' or 'getMany', or ask the user to enable write operations.`,
-                        ));
-                    }
-                    return JSON.stringify(wrapError(
-                        resource, operation ?? 'unknown', ERROR_TYPES.INVALID_OPERATION,
-                        `Unknown operation '${operation}'.`,
-                        `Use one of: ${allAllowedOps.join(', ')}`,
-                    ));
-                }
-                return executeAiTool(
-                    supplyDataContext as unknown as IExecuteFunctions,
-                    resource,
-                    operation,
-                    rawParams as unknown as ToolExecutorParams,
-                    {
-                        readFields: readDescribe?.fields ?? [],
-                        writeFields: writeDescribe?.fields ?? [],
-                        allAllowedOps,
-                    },
-                );
-            },
-        });
+		const unifiedTool = new RuntimeDynamicStructuredTool({
+			name: `autotask_${resource}`,
+			description,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			schema: schema as any,
+			func: async (rawParams: Record<string, unknown>) => {
+				const operation = rawParams.operation as string;
+				if (!operation || !allAllowedOps.includes(operation)) {
+					if (operation && WRITE_OPERATIONS.includes(operation) && !allowWriteOperations) {
+						return JSON.stringify(
+							wrapError(
+								resource,
+								operation,
+								ERROR_TYPES.WRITE_OPERATION_BLOCKED,
+								`Write operation '${operation}' is blocked. Enable "Allow Write Operations" in the node configuration.`,
+								`Use a read operation such as 'get' or 'getMany', or ask the user to enable write operations.`,
+							),
+						);
+					}
+					return JSON.stringify(
+						wrapError(
+							resource,
+							operation ?? 'unknown',
+							ERROR_TYPES.INVALID_OPERATION,
+							`Unknown operation '${operation}'.`,
+							`Use one of: ${allAllowedOps.join(', ')}`,
+						),
+					);
+				}
+				return executeAiTool(
+					supplyDataContext as unknown as IExecuteFunctions,
+					resource,
+					operation,
+					rawParams as unknown as ToolExecutorParams,
+					{
+						readFields: readDescribe?.fields ?? [],
+						writeFields: writeDescribe?.fields ?? [],
+						allAllowedOps,
+					},
+				);
+			},
+		});
 
-        // Wrap with logWrapper for n8n execution view visibility.
-        // getLazyLogWrapper() returns null if @n8n/ai-utilities is unavailable
-        // (graceful degradation — tool works without it).
-        // ensureRuntime() was already called above via runtimeZod/RuntimeDynamicStructuredTool.
-        const logWrapFn = getLazyLogWrapper();
-        const wrappedTool = logWrapFn ? logWrapFn(unifiedTool, this) : unifiedTool;
+		// Wrap with logWrapper for n8n execution view visibility.
+		// getLazyLogWrapper() returns null if @n8n/ai-utilities is unavailable
+		// (graceful degradation — tool works without it).
+		// ensureRuntime() was already called above via runtimeZod/RuntimeDynamicStructuredTool.
+		const logWrapFn = getLazyLogWrapper();
+		const wrappedTool = logWrapFn ? logWrapFn(unifiedTool, this) : unifiedTool;
 
-        return { response: wrappedTool };
-    }
+		return { response: wrappedTool };
+	}
 
-    /**
-     * execute() serves two purposes:
-     *
-     * 1. Prevents n8n 2.8+ from falling through to the declarative RoutingNode
-     *    test path (which causes ERR_INVALID_URL — no requestDefaults/routing).
-     *
-     * 2. Handles Agent V3 (n8n ~1.116+) EngineRequest-based tool execution.
-     *    Agent V3 routes ALL tool calls through execute() with params in
-     *    item.json (including 'operation'), bypassing supplyData() → func().
-     *    The supplyData() → func() path is still used by Agent V2 and
-     *    MCP Trigger queue-mode workers.
-     *
-     * Because tool construction is expensive (API calls to describeResource),
-     * we process item.json directly here rather than rebuilding the tool.
-     * Framework-injected fields (Prompt__*, sessionId, etc.) are stripped
-     * by N8N_METADATA_FIELDS / N8N_METADATA_PREFIXES in executeAiTool().
-     */
-    async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-        const items = this.getInputData();
-        const resource = this.getNodeParameter('resource', 0) as string;
-        const operations = this.getNodeParameter('operations', 0) as string[];
-        const allowWriteOperations = this.getNodeParameter('allowWriteOperations', 0, false) as boolean;
+	/**
+	 * execute() serves two purposes:
+	 *
+	 * 1. Prevents n8n 2.8+ from falling through to the declarative RoutingNode
+	 *    test path (which causes ERR_INVALID_URL — no requestDefaults/routing).
+	 *
+	 * 2. Handles Agent V3 (n8n ~1.116+) EngineRequest-based tool execution.
+	 *    Agent V3 routes ALL tool calls through execute() with params in
+	 *    item.json (including 'operation'), bypassing supplyData() → func().
+	 *    The supplyData() → func() path is still used by Agent V2 and
+	 *    MCP Trigger queue-mode workers.
+	 *
+	 * Because tool construction is expensive (API calls to describeResource),
+	 * we process item.json directly here rather than rebuilding the tool.
+	 * Framework-injected fields (Prompt__*, sessionId, etc.) are stripped
+	 * by N8N_METADATA_FIELDS / N8N_METADATA_PREFIXES in executeAiTool().
+	 */
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const resource = this.getNodeParameter('resource', 0) as string;
+		const operations = this.getNodeParameter('operations', 0) as string[];
+		const allowWriteOperations = this.getNodeParameter('allowWriteOperations', 0, false) as boolean;
 
-        if (!resource || !operations?.length) {
-            throw new NodeOperationError(
-                this.getNode(),
-                'Resource and at least one operation must be configured.',
-            );
-        }
+		if (!resource || !operations?.length) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'Resource and at least one operation must be configured.',
+			);
+		}
 
-        // Pick the first permitted operation as the default for test execution
-        const effectiveOps = operations.filter(
-            (op) => !WRITE_OPERATIONS.includes(op) || allowWriteOperations,
-        );
-        if (effectiveOps.length === 0) {
-            throw new NodeOperationError(
-                this.getNode(),
-                'No permitted operations. Enable "Allow Write Operations" if needed.',
-            );
-        }
+		// Pick the first permitted operation as the default for test execution
+		const effectiveOps = operations.filter(
+			(op) => !WRITE_OPERATIONS.includes(op) || allowWriteOperations,
+		);
+		if (effectiveOps.length === 0) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'No permitted operations. Enable "Allow Write Operations" if needed.',
+			);
+		}
 
-        // Detect real tool invocation vs "Test step" in the editor.
-        // n8n 2.14+ routes tool calls through execute() with params in item.json
-        // (including 'operation'). Older versions set a 'tool' field. If neither
-        // is present, this is an editor test step — return a friendly stub.
-        const firstItem = items[0]?.json ?? {};
-        const hasToolCall = !!(firstItem['tool'] || firstItem['operation']);
-        if (!hasToolCall) {
-            return [[{
-                json: {
-                    message: 'This is an AI Tool node. Connect it to an AI Agent node to use it.',
-                    configured: { resource, operations },
-                },
-                pairedItem: { item: 0 },
-            }]];
-        }
+		// Detect real tool invocation vs "Test step" in the editor.
+		// n8n 2.14+ routes tool calls through execute() with params in item.json
+		// (including 'operation'). Older versions set a 'tool' field. If neither
+		// is present, this is an editor test step — return a friendly stub.
+		const firstItem = items[0]?.json ?? {};
+		const hasToolCall = !!(firstItem['tool'] || firstItem['operation']);
+		if (!hasToolCall) {
+			traceExecutor({
+				phase: 'execute-test-step-stub',
+				resource,
+				summary: {
+					path: 'test-step-stub',
+				},
+			});
+			return [
+				[
+					{
+						json: {
+							message: 'This is an AI Tool node. Connect it to an AI Agent node to use it.',
+							configured: { resource, operations },
+						},
+						pairedItem: { item: 0 },
+					},
+				],
+			];
+		}
+		traceExecutor({
+			phase: 'execute-agent-v3-path',
+			resource,
+			summary: {
+				path: 'agent-v3',
+				itemCount: items.length,
+			},
+		});
 
-        // describeFields, listPicklistValues, and describeOperation are always available (same as supplyData path)
-        const allAllowedOps = [...new Set([...effectiveOps, 'describeFields', 'listPicklistValues', 'describeOperation'])];
+		// describeFields, listPicklistValues, and describeOperation are always available (same as supplyData path)
+		const allAllowedOps = [
+			...new Set([...effectiveOps, 'describeFields', 'listPicklistValues', 'describeOperation']),
+		];
 
-        // Fetch field metadata for label resolution and field validation (mirrors supplyData)
-        const needsReadFields = effectiveOps.some((op) =>
-            ['get', 'getMany', 'getPosted', 'getUnposted', 'count', 'whoAmI', 'searchByDomain', 'getByResource', 'getByYear'].includes(op),
-        );
-        const needsWriteFields = effectiveOps.some((op) => ['create', 'createIfNotExists', 'update'].includes(op));
+		// Fetch field metadata for label resolution and field validation (mirrors supplyData)
+		const needsReadFields = effectiveOps.some((op) =>
+			[
+				'get',
+				'getMany',
+				'getPosted',
+				'getUnposted',
+				'count',
+				'whoAmI',
+				'searchByDomain',
+				'getByResource',
+				'getByYear',
+			].includes(op),
+		);
+		const needsWriteFields = effectiveOps.some((op) =>
+			['create', 'createIfNotExists', 'update'].includes(op),
+		);
 
-        const [readDescribe, writeDescribe] = await Promise.all([
-            needsReadFields
-                ? describeResource(this as unknown as ILoadOptionsFunctions, resource, 'read')
-                : Promise.resolve(undefined),
-            needsWriteFields
-                ? describeResource(this as unknown as ILoadOptionsFunctions, resource, 'write')
-                : Promise.resolve(undefined),
-        ]);
+		const [readDescribe, writeDescribe] = await Promise.all([
+			needsReadFields
+				? describeResource(this as unknown as ILoadOptionsFunctions, resource, 'read')
+				: Promise.resolve(undefined),
+			needsWriteFields
+				? describeResource(this as unknown as ILoadOptionsFunctions, resource, 'write')
+				: Promise.resolve(undefined),
+		]);
 
-        const response: INodeExecutionData[] = [];
+		const response: INodeExecutionData[] = [];
 
-        for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-            const item = items[itemIndex];
-            if (!item) continue;
+		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+			const item = items[itemIndex];
+			if (!item) continue;
 
-            const requestedOp = (item.json.operation as string) || effectiveOps[0];
-            if (requestedOp && !allAllowedOps.includes(requestedOp)) {
-                if (WRITE_OPERATIONS.includes(requestedOp) && !allowWriteOperations) {
-                    response.push({
-                        json: { ...wrapError(
-                            resource, requestedOp, ERROR_TYPES.WRITE_OPERATION_BLOCKED,
-                            `Write operation '${requestedOp}' is blocked. Enable "Allow Write Operations" in the node configuration.`,
-                            `Use a read operation such as 'get' or 'getMany', or ask the user to enable write operations.`,
-                        ) },
-                        pairedItem: { item: itemIndex },
-                    });
-                    continue;
-                }
-                response.push({
-                    json: { ...wrapError(
-                        resource, requestedOp, ERROR_TYPES.INVALID_OPERATION,
-                        `Operation '${requestedOp}' is not configured for this node.`,
-                        `Use one of: ${allAllowedOps.join(', ')}`,
-                    ) },
-                    pairedItem: { item: itemIndex },
-                });
-                continue;
-            }
-            const operation = requestedOp;
+			const requestedOp = (item.json.operation as string) || effectiveOps[0];
+			if (requestedOp && !allAllowedOps.includes(requestedOp)) {
+				if (WRITE_OPERATIONS.includes(requestedOp) && !allowWriteOperations) {
+					response.push({
+						json: {
+							...wrapError(
+								resource,
+								requestedOp,
+								ERROR_TYPES.WRITE_OPERATION_BLOCKED,
+								`Write operation '${requestedOp}' is blocked. Enable "Allow Write Operations" in the node configuration.`,
+								`Use a read operation such as 'get' or 'getMany', or ask the user to enable write operations.`,
+							),
+						},
+						pairedItem: { item: itemIndex },
+					});
+					continue;
+				}
+				response.push({
+					json: {
+						...wrapError(
+							resource,
+							requestedOp,
+							ERROR_TYPES.INVALID_OPERATION,
+							`Operation '${requestedOp}' is not configured for this node.`,
+							`Use one of: ${allAllowedOps.join(', ')}`,
+						),
+					},
+					pairedItem: { item: itemIndex },
+				});
+				continue;
+			}
+			const operation = requestedOp;
 
-            try {
-                const params: ToolExecutorParams = {
-                    ...(item.json as Record<string, unknown>),
-                    resource,
-                    operation,
-                } as unknown as ToolExecutorParams;
+			try {
+				const params: ToolExecutorParams = {
+					...(item.json as Record<string, unknown>),
+					resource,
+					operation,
+				} as unknown as ToolExecutorParams;
 
-                const resultJson = await executeAiTool(this, resource, operation, params, {
-                    readFields: readDescribe?.fields ?? [],
-                    writeFields: writeDescribe?.fields ?? [],
-                    allAllowedOps,
-                });
-                let parsed: IDataObject;
-                if (typeof resultJson === 'string') {
-                    try {
-                        parsed = JSON.parse(resultJson);
-                    } catch {
-                        parsed = { error: resultJson };
-                    }
-                } else {
-                    parsed = resultJson;
-                }
+				const resultJson = await executeAiTool(this, resource, operation, params, {
+					readFields: readDescribe?.fields ?? [],
+					writeFields: writeDescribe?.fields ?? [],
+					allAllowedOps,
+				});
+				let parsed: IDataObject;
+				if (typeof resultJson === 'string') {
+					try {
+						parsed = JSON.parse(resultJson);
+					} catch {
+						parsed = { error: resultJson };
+					}
+				} else {
+					parsed = resultJson;
+				}
 
-                response.push({
-                    json: parsed,
-                    pairedItem: { item: itemIndex },
-                });
-            } catch (error) {
-                const msg = error instanceof Error ? error.message : String(error);
-                throw new NodeOperationError(this.getNode(), msg, { itemIndex });
-            }
-        }
+				response.push({
+					json: parsed,
+					pairedItem: { item: itemIndex },
+				});
+			} catch (error) {
+				traceError({
+					phase: 'execute-agent-v3-item',
+					resource,
+					operation,
+					itemIndex,
+					summary: {
+						errorMessage: error instanceof Error ? error.message : String(error),
+						beforeApiCall: true,
+					},
+				});
+				const msg = error instanceof Error ? error.message : String(error);
+				throw new NodeOperationError(this.getNode(), msg, { itemIndex });
+			}
+		}
 
-        return [response];
-    }
+		return [response];
+	}
 }
 
 async function getToolResources(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-    const options: INodePropertyOptions[] = [];
-    for (const [value, ops] of Object.entries(RESOURCE_OPERATIONS_MAP)) {
-        if (EXCLUDED_RESOURCES.includes(value)) continue;
-        const hasSupportedToolOps = ops.some((o) => SUPPORTED_TOOL_OPERATIONS.includes(o));
-        if (!hasSupportedToolOps) continue;
-        options.push({
-            name: formatResourceName(value),
-            value,
-            description: `${formatResourceName(value)} entity`,
-        });
-    }
-    return options.sort((a, b) => a.name.localeCompare(b.name));
+	const options: INodePropertyOptions[] = [];
+	for (const [value, ops] of Object.entries(RESOURCE_OPERATIONS_MAP)) {
+		if (EXCLUDED_RESOURCES.includes(value)) continue;
+		const hasSupportedToolOps = ops.some((o) => SUPPORTED_TOOL_OPERATIONS.includes(o));
+		if (!hasSupportedToolOps) continue;
+		options.push({
+			name: formatResourceName(value),
+			value,
+			description: `${formatResourceName(value)} entity`,
+		});
+	}
+	return options.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-async function getToolResourceOperations(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-    const resource = this.getCurrentNodeParameter('resource') as string;
-    const allowWriteOperations = (this.getCurrentNodeParameter('allowWriteOperations') ?? false) as boolean;
+async function getToolResourceOperations(
+	this: ILoadOptionsFunctions,
+): Promise<INodePropertyOptions[]> {
+	const resource = this.getCurrentNodeParameter('resource') as string;
+	const allowWriteOperations = (this.getCurrentNodeParameter('allowWriteOperations') ??
+		false) as boolean;
 
-    if (!resource) return [];
+	if (!resource) return [];
 
-    const ops = getResourceOperations(resource);
-    const options: INodePropertyOptions[] = [];
+	const ops = getResourceOperations(resource);
+	const options: INodePropertyOptions[] = [];
 
-    const opLabels: Record<string, string> = {
-        get: 'Get by ID',
-        whoAmI: 'Who am I',
-        getMany: 'Get many (with filters)',
-        searchByDomain: 'Search by domain',
-        slaHealthCheck: 'SLA health check',
-        summary: 'Ticket summary',
-        getPosted: 'Get posted time entries',
-        getUnposted: 'Get unposted time entries',
-        count: 'Count',
-        create: 'Create',
-        moveToCompany: 'Move contact to company',
-        moveConfigurationItem: 'Move configuration item (clone to company)',
-        transferOwnership: 'Transfer ownership',
-        update: 'Update',
-        delete: 'Delete',
-        createIfNotExists: 'Create If Not Exists (idempotent)',
-        getByResource: 'Get by resource',
-        getByYear: 'Get by resource and year',
-        approve: 'Approve time off request',
-        reject: 'Reject time off request',
-    };
+	const opLabels: Record<string, string> = {
+		get: 'Get by ID',
+		whoAmI: 'Who am I',
+		getMany: 'Get many (with filters)',
+		searchByDomain: 'Search by domain',
+		slaHealthCheck: 'SLA health check',
+		summary: 'Ticket summary',
+		getPosted: 'Get posted time entries',
+		getUnposted: 'Get unposted time entries',
+		count: 'Count',
+		create: 'Create',
+		moveToCompany: 'Move contact to company',
+		moveConfigurationItem: 'Move configuration item (clone to company)',
+		transferOwnership: 'Transfer ownership',
+		update: 'Update',
+		delete: 'Delete',
+		createIfNotExists: 'Create If Not Exists (idempotent)',
+		getByResource: 'Get by resource',
+		getByYear: 'Get by resource and year',
+		approve: 'Approve time off request',
+		reject: 'Reject time off request',
+	};
 
-    for (const op of ops) {
-        if (!SUPPORTED_TOOL_OPERATIONS.includes(op)) continue;
-        if (WRITE_OPERATIONS.includes(op) && !allowWriteOperations) continue;
-        options.push({
-            name: opLabels[op] ?? op,
-            value: op,
-            description: `${op} operation`,
-        });
-    }
-    return options;
+	for (const op of ops) {
+		if (!SUPPORTED_TOOL_OPERATIONS.includes(op)) continue;
+		if (WRITE_OPERATIONS.includes(op) && !allowWriteOperations) continue;
+		options.push({
+			name: opLabels[op] ?? op,
+			value: op,
+			description: `${op} operation`,
+		});
+	}
+	return options;
 }

--- a/nodes/Autotask/ai-tools/debug-trace.ts
+++ b/nodes/Autotask/ai-tools/debug-trace.ts
@@ -1,0 +1,153 @@
+import { appendFileSync } from 'node:fs';
+import type { FieldMeta } from '../helpers/aiHelper';
+
+export const AI_TOOL_DEBUG_ENABLED = false;
+export const AI_TOOL_DEBUG_VERBOSE = false;
+export const AI_TOOL_DEBUG_FILE_PATH = '/tmp/autotask-ai-tool-debug.jsonl';
+
+export interface AiTraceEvent {
+	ts: string;
+	area:
+		| 'tool-build'
+		| 'schema-build'
+		| 'description-build'
+		| 'tool-call'
+		| 'filter-build'
+		| 'label-resolution'
+		| 'write-guard'
+		| 'executor'
+		| 'response'
+		| 'error';
+	phase?: string;
+	resource?: string;
+	operation?: string;
+	correlationId?: string;
+	itemIndex?: number;
+	durationMs?: number;
+	summary: Record<string, unknown>;
+}
+
+export function writeAiTrace(event: Omit<AiTraceEvent, 'ts'>): void {
+	if (!AI_TOOL_DEBUG_ENABLED) return;
+	try {
+		appendFileSync(
+			AI_TOOL_DEBUG_FILE_PATH,
+			`${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`,
+			'utf8',
+		);
+	} catch {
+		// best-effort only: trace failures must never affect node execution
+	}
+}
+
+export function safeKeys(value: unknown): string[] {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return [];
+	return Object.keys(value as Record<string, unknown>).sort();
+}
+
+export function summariseFields(fields: FieldMeta[]): Record<string, unknown> {
+	const required = fields.filter((field) => field.required).map((field) => field.id);
+	return {
+		count: fields.length,
+		firstFieldIds: fields.slice(0, 10).map((field) => field.id),
+		requiredFieldIds: required.slice(0, 10),
+		picklistFieldCount: fields.filter((field) => field.isPickList).length,
+		referenceFieldCount: fields.filter((field) => field.isReference).length,
+	};
+}
+
+function redactScalar(value: unknown): unknown {
+	if (typeof value === 'string') {
+		if (value.length > 120) return `${value.slice(0, 120)}…`;
+		if (/token|secret|password|authorization|api[-_]?key/i.test(value)) return '[REDACTED]';
+		return value;
+	}
+	return value;
+}
+
+export function redactForVerbose(value: unknown, depth = 0): unknown {
+	if (!AI_TOOL_DEBUG_VERBOSE) return undefined;
+	if (depth > 3) return '[TRUNCATED_DEPTH]';
+	if (Array.isArray(value)) {
+		return value.slice(0, 20).map((item) => redactForVerbose(item, depth + 1));
+	}
+	if (!value || typeof value !== 'object') return redactScalar(value);
+	const input = value as Record<string, unknown>;
+	const out: Record<string, unknown> = {};
+	for (const [key, raw] of Object.entries(input).slice(0, 50)) {
+		if (/token|secret|password|authorization|api[-_]?key/i.test(key)) {
+			out[key] = '[REDACTED]';
+			continue;
+		}
+		out[key] = redactForVerbose(raw, depth + 1);
+	}
+	return out;
+}
+
+export function summariseFilters(
+	filters: Array<{ field?: unknown; op?: unknown; value?: unknown }>,
+): Record<string, unknown> {
+	const fieldNames = filters
+		.map((f) => (typeof f.field === 'string' ? f.field : undefined))
+		.filter(Boolean);
+	const ops = filters.map((f) => (typeof f.op === 'string' ? f.op : undefined)).filter(Boolean);
+	const valueTypes = filters.map((f) => (Array.isArray(f.value) ? 'array' : typeof f.value));
+	return {
+		count: filters.length,
+		fieldNames: Array.from(new Set(fieldNames)),
+		ops: Array.from(new Set(ops)),
+		valueTypes,
+	};
+}
+
+export function summariseResponseEnvelope(serialized: string): Record<string, unknown> {
+	try {
+		const parsed = JSON.parse(serialized) as Record<string, unknown>;
+		const payload = parsed.result as Record<string, unknown> | undefined;
+		const data = payload?.data as Record<string, unknown> | undefined;
+		const flags = (payload?.flags ?? {}) as Record<string, unknown>;
+		const error = parsed.error as Record<string, unknown> | undefined;
+		const items = Array.isArray(data?.items) ? data.items : [];
+		return {
+			resultKind: payload?.kind,
+			recordsReturnedCount: items.length,
+			recordsFetchedCount: typeof data?.count === 'number' ? data.count : undefined,
+			truncated: flags.truncated,
+			partial: flags.partial,
+			retryable: flags.retryable,
+			mutated: flags.mutated,
+			pendingConfirmationsCount: Array.isArray(payload?.pendingConfirmations)
+				? payload.pendingConfirmations.length
+				: 0,
+			warningsCount: Array.isArray(payload?.warnings) ? payload.warnings.length : 0,
+			appliedResolutionsCount: Array.isArray(payload?.appliedResolutions)
+				? payload.appliedResolutions.length
+				: 0,
+			errorType: error?.type,
+		};
+	} catch {
+		return { parseError: true };
+	}
+}
+
+function trace(area: AiTraceEvent['area'], event: Omit<AiTraceEvent, 'ts' | 'area'>): void {
+	writeAiTrace({ area, ...event });
+}
+
+export const traceToolBuild = (event: Omit<AiTraceEvent, 'ts' | 'area'>) =>
+	trace('tool-build', event);
+export const traceSchemaBuild = (event: Omit<AiTraceEvent, 'ts' | 'area'>) =>
+	trace('schema-build', event);
+export const traceDescriptionBuild = (event: Omit<AiTraceEvent, 'ts' | 'area'>) =>
+	trace('description-build', event);
+export const traceToolCall = (event: Omit<AiTraceEvent, 'ts' | 'area'>) =>
+	trace('tool-call', event);
+export const traceFilterBuild = (event: Omit<AiTraceEvent, 'ts' | 'area'>) =>
+	trace('filter-build', event);
+export const traceLabelResolution = (event: Omit<AiTraceEvent, 'ts' | 'area'>) =>
+	trace('label-resolution', event);
+export const traceWriteGuard = (event: Omit<AiTraceEvent, 'ts' | 'area'>) =>
+	trace('write-guard', event);
+export const traceResponse = (event: Omit<AiTraceEvent, 'ts' | 'area'>) => trace('response', event);
+export const traceExecutor = (event: Omit<AiTraceEvent, 'ts' | 'area'>) => trace('executor', event);
+export const traceError = (event: Omit<AiTraceEvent, 'ts' | 'area'>) => trace('error', event);

--- a/nodes/Autotask/ai-tools/debug-trace.ts
+++ b/nodes/Autotask/ai-tools/debug-trace.ts
@@ -1,9 +1,11 @@
-import { appendFileSync } from 'node:fs';
+import { appendFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { FieldMeta } from '../helpers/aiHelper';
 
 export const AI_TOOL_DEBUG_ENABLED = false;
 export const AI_TOOL_DEBUG_VERBOSE = false;
-export const AI_TOOL_DEBUG_FILE_PATH = '/tmp/autotask-ai-tool-debug.jsonl';
+export const AI_TOOL_DEBUG_FILE_PATH = join(tmpdir(), 'autotask-ai-tool-debug.jsonl');
 
 export interface AiTraceEvent {
 	ts: string;
@@ -30,13 +32,12 @@ export interface AiTraceEvent {
 export function writeAiTrace(event: Omit<AiTraceEvent, 'ts'>): void {
 	if (!AI_TOOL_DEBUG_ENABLED) return;
 	try {
-		appendFileSync(
-			AI_TOOL_DEBUG_FILE_PATH,
-			`${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`,
-			'utf8',
-		);
+		const line = `${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`;
+		appendFile(AI_TOOL_DEBUG_FILE_PATH, line, 'utf8').catch(() => {
+			// best-effort only: trace failures must never affect node execution
+		});
 	} catch {
-		// best-effort only: trace failures must never affect node execution
+		// best-effort only: JSON.stringify failures must never affect node execution
 	}
 }
 
@@ -58,8 +59,8 @@ export function summariseFields(fields: FieldMeta[]): Record<string, unknown> {
 
 function redactScalar(value: unknown): unknown {
 	if (typeof value === 'string') {
-		if (value.length > 120) return `${value.slice(0, 120)}…`;
 		if (/token|secret|password|authorization|api[-_]?key/i.test(value)) return '[REDACTED]';
+		if (value.length > 120) return `${value.slice(0, 120)}…`;
 		return value;
 	}
 	return value;

--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -1,76 +1,81 @@
 import type { FieldMeta } from '../helpers/aiHelper';
 import { getEntityMetadata } from '../constants/entities';
+import { AI_TOOL_DEBUG_VERBOSE, redactForVerbose, traceDescriptionBuild } from './debug-trace';
 
 function listFilterableFields(readFields: FieldMeta[], max = 12): string {
-    return readFields
-        .filter((field) => !field.udf)
-        .slice(0, max)
-        .map((field) => field.id)
-        .join(', ');
+	return readFields
+		.filter((field) => !field.udf)
+		.slice(0, max)
+		.map((field) => field.id)
+		.join(', ');
 }
 
 function getParentRequirement(resourceName: string): string | null {
-    const metadata = getEntityMetadata(resourceName);
-    return metadata?.parentIdField ?? null;
+	const metadata = getEntityMetadata(resourceName);
+	return metadata?.parentIdField ?? null;
 }
 
 /** Snippet injected into tool descriptions that reference date/time so the AI uses actual "now" instead of training cutoff. */
 export function dateTimeReferenceSnippet(referenceUtc: string): string {
-    return `Reference: current UTC date-time when these tools were loaded is ${referenceUtc}. Use this for "today", "recent", or when choosing since/until or recency — do not assume a different date. `;
+	return `Reference: current UTC date-time when these tools were loaded is ${referenceUtc}. Use this for "today", "recent", or when choosing since/until or recency — do not assume a different date. `;
 }
 
 /** Rule for getMany/count/getPosted/getUnposted: how recency and since/until interact. */
 const RECENCY_VS_SINCE_UNTIL_RULE =
-    'Date filtering: use EITHER recency OR since/until, not both. If you provide since or until, recency is ignored (since/until take precedence). Use recency for preset windows (e.g. last_7d, last_30d) or custom days as last_Nd with N from 1 to 365 (e.g. last_5d, last_45d) to limit how far back to look. Use since/until only when you need an explicit UTC range. ';
+	'Date filtering: use EITHER recency OR since/until, not both. If you provide since or until, recency is ignored (since/until take precedence). Use recency for preset windows (e.g. last_7d, last_30d) or custom days as last_Nd with N from 1 to 365 (e.g. last_5d, last_45d) to limit how far back to look. Use since/until only when you need an explicit UTC range. ';
 
 export function buildGetDescription(resourceLabel: string, resourceName: string): string {
-    return (
-        `Retrieve a single ${resourceLabel} record by numeric ID. ` +
-        `ONLY call this when you already have a numeric ID — never pass a name or text. ` +
-        `If you only have a name or description, call autotask_${resourceName} with operation 'getMany' with a filter first, extract the 'id' from results, then call this. ` +
-        `Optionally use 'fields' to return only selected columns. ` +
-        `If a record should exist but response is empty, verify API user permissions (including line-of-business access). ` +
-        `Do not guess field names. Call autotask_${resourceName} with operation 'describeFields' (mode 'read') first when unsure.`
-    );
+	return (
+		`Retrieve a single ${resourceLabel} record by numeric ID. ` +
+		`ONLY call this when you already have a numeric ID — never pass a name or text. ` +
+		`If you only have a name or description, call autotask_${resourceName} with operation 'getMany' with a filter first, extract the 'id' from results, then call this. ` +
+		`Optionally use 'fields' to return only selected columns. ` +
+		`If a record should exist but response is empty, verify API user permissions (including line-of-business access). ` +
+		`Do not guess field names. Call autotask_${resourceName} with operation 'describeFields' (mode 'read') first when unsure.`
+	);
 }
 
 export function buildGetManyDescription(
-    resourceLabel: string,
-    resourceName: string,
-    readFields: FieldMeta[],
-    referenceUtc?: string,
+	resourceLabel: string,
+	resourceName: string,
+	readFields: FieldMeta[],
+	referenceUtc?: string,
 ): string {
-    const fieldList = listFilterableFields(readFields);
-    const ref = referenceUtc ? dateTimeReferenceSnippet(referenceUtc) + RECENCY_VS_SINCE_UNTIL_RULE : '';
+	const fieldList = listFilterableFields(readFields);
+	const ref = referenceUtc
+		? dateTimeReferenceSnippet(referenceUtc) + RECENCY_VS_SINCE_UNTIL_RULE
+		: '';
 
-    return (
-        ref +
-        `Search ${resourceLabel} records with up to two filters (AND by default; set filter_logic='or' for either-match). ` +
-        `Example: filter_field='companyName', filter_op='contains', filter_value='Acme'. ` +
-        `Use filter_value as true/false for boolean fields, and use arrays (or comma-separated values) for in/notIn operators. ` +
-        `UDF filtering supports one UDF field per query. ` +
-        `Filterable fields include: ${fieldList}. ` +
-        `IMPORTANT: The Autotask API always returns records in ascending ID order (oldest first). Without recency or since, limit=1 returns the OLDEST record, not the newest. ` +
-        `To get the most recent or latest records, you MUST use recency (for example 'last_7d') or provide since/until in ISO-8601 UTC format (for example 2026-01-01T00:00:00Z). ` +
-        `When recency or since is used, the tool automatically filters by date, fetches a wide window, and returns the newest records first, trimmed to limit. ` +
-        `If results are unexpectedly empty, check API user security permissions before retrying. ` +
-        `Name-based filter resolution: for reference and picklist filter fields, you can pass a human-readable name as filter_value (e.g. filter_field='companyID', filter_value='Contoso') — the tool auto-resolves names to IDs. ` +
-        `API ordering: records always return in ascending ID order (oldest first). No server-side sort is available. ` +
-        `For all matching records, use returnAll=true with a tight filter. ` +
-        `For complex filters (3+ conditions, nested OR/IN), use filtersJson with the Autotask IFilterCondition JSON array. ` +
-        `Always provide at least one filter when possible. ` +
-        `If you are unsure about field names, call autotask_${resourceName} with operation 'describeFields' first.`
-    );
+	return (
+		ref +
+		`Search ${resourceLabel} records with up to two filters (AND by default; set filter_logic='or' for either-match). ` +
+		`Example: filter_field='companyName', filter_op='contains', filter_value='Acme'. ` +
+		`Use filter_value as true/false for boolean fields, and use arrays (or comma-separated values) for in/notIn operators. ` +
+		`UDF filtering supports one UDF field per query. ` +
+		`Filterable fields include: ${fieldList}. ` +
+		`IMPORTANT: The Autotask API always returns records in ascending ID order (oldest first). Without recency or since, limit=1 returns the OLDEST record, not the newest. ` +
+		`To get the most recent or latest records, you MUST use recency (for example 'last_7d') or provide since/until in ISO-8601 UTC format (for example 2026-01-01T00:00:00Z). ` +
+		`When recency or since is used, the tool automatically filters by date, fetches a wide window, and returns the newest records first, trimmed to limit. ` +
+		`If results are unexpectedly empty, check API user security permissions before retrying. ` +
+		`Name-based filter resolution: for reference and picklist filter fields, you can pass a human-readable name as filter_value (e.g. filter_field='companyID', filter_value='Contoso') — the tool auto-resolves names to IDs. ` +
+		`API ordering: records always return in ascending ID order (oldest first). No server-side sort is available. ` +
+		`For all matching records, use returnAll=true with a tight filter. ` +
+		`For complex filters (3+ conditions, nested OR/IN), use filtersJson with the Autotask IFilterCondition JSON array. ` +
+		`Always provide at least one filter when possible. ` +
+		`If you are unsure about field names, call autotask_${resourceName} with operation 'describeFields' first.`
+	);
 }
 
 export function buildCountDescription(resourceLabel: string, referenceUtc?: string): string {
-    const ref = referenceUtc ? dateTimeReferenceSnippet(referenceUtc) + RECENCY_VS_SINCE_UNTIL_RULE : '';
-    return (
-        ref +
-        `Count ${resourceLabel} records matching optional filters. ` +
-        `Use the same filter parameters as getMany and return only the count. ` +
-        `For efficient polling-style checks, prefer LastModifiedDate or LastActivityDate filters where available.`
-    );
+	const ref = referenceUtc
+		? dateTimeReferenceSnippet(referenceUtc) + RECENCY_VS_SINCE_UNTIL_RULE
+		: '';
+	return (
+		ref +
+		`Count ${resourceLabel} records matching optional filters. ` +
+		`Use the same filter parameters as getMany and return only the count. ` +
+		`For efficient polling-style checks, prefer LastModifiedDate or LastActivityDate filters where available.`
+	);
 }
 
 /** Max number of picklist values to inline in the required-fields summary */
@@ -81,224 +86,237 @@ const MAX_INLINE_REQUIRED_PICKLIST = 10;
  * For each required field, shows type info (reference target, picklist values, or data type).
  */
 function buildRequiredFieldsSummary(writeFields: FieldMeta[]): string {
-    const required = writeFields.filter((field) => field.required);
-    if (required.length === 0) return 'Required fields: none.';
+	const required = writeFields.filter((field) => field.required);
+	if (required.length === 0) return 'Required fields: none.';
 
-    const parts = required.map((field) => {
-        let info = field.id;
-        if (field.isReference && field.referencesEntity) {
-            info += ` (ref→${field.referencesEntity})`;
-        } else if (field.isPickList && field.allowedValues?.length) {
-            if (field.allowedValues.length <= MAX_INLINE_REQUIRED_PICKLIST) {
-                const vals = field.allowedValues.map((v) => v.label).join('|');
-                info += ` (picklist: ${vals})`;
-            } else {
-                info += ` (picklist, ${field.allowedValues.length} values — use listPicklistValues)`;
-            }
-        } else if (field.isPickList) {
-            info += ` (picklist — use listPicklistValues for options)`;
-        } else {
-            info += ` (${field.type})`;
-        }
-        return info;
-    });
-    return `Required fields: ${parts.join(', ')}.`;
+	const parts = required.map((field) => {
+		let info = field.id;
+		if (field.isReference && field.referencesEntity) {
+			info += ` (ref→${field.referencesEntity})`;
+		} else if (field.isPickList && field.allowedValues?.length) {
+			if (field.allowedValues.length <= MAX_INLINE_REQUIRED_PICKLIST) {
+				const vals = field.allowedValues.map((v) => v.label).join('|');
+				info += ` (picklist: ${vals})`;
+			} else {
+				info += ` (picklist, ${field.allowedValues.length} values — use listPicklistValues)`;
+			}
+		} else if (field.isPickList) {
+			info += ` (picklist — use listPicklistValues for options)`;
+		} else {
+			info += ` (${field.type})`;
+		}
+		return info;
+	});
+	return `Required fields: ${parts.join(', ')}.`;
 }
 
 export function buildCreateDescription(
-    resourceLabel: string,
-    resourceName: string,
-    writeFields: FieldMeta[],
-    supportsImpersonation = false,
-    referenceUtc?: string,
+	resourceLabel: string,
+	resourceName: string,
+	writeFields: FieldMeta[],
+	supportsImpersonation = false,
+	referenceUtc?: string,
 ): string {
-    const requiredSummary = buildRequiredFieldsSummary(writeFields);
-    const parentField = getParentRequirement(resourceName);
-    const parentHint = parentField
-        ? ` Parent relation required: include ${parentField}.`
-        : '';
-    const ref = referenceUtc ? dateTimeReferenceSnippet(referenceUtc) : '';
-    const impersonationNote = supportsImpersonation
+	const requiredSummary = buildRequiredFieldsSummary(writeFields);
+	const parentField = getParentRequirement(resourceName);
+	const parentHint = parentField ? ` Parent relation required: include ${parentField}.` : '';
+	const ref = referenceUtc ? dateTimeReferenceSnippet(referenceUtc) : '';
+	const impersonationNote = supportsImpersonation
 		? ' Optional impersonation is supported with impersonationResourceId (accepts name or ID). Impersonation is off by default unless that value is set. If proceedWithoutImpersonationIfDenied is true, denied impersonated writes retry once without impersonation.'
 		: '';
 
-    return (
-        ref +
-        `Create a new ${resourceLabel} record. ` +
-        `${requiredSummary}${parentHint} ` +
-        `Name-based resolution: you can pass human-readable names instead of numeric IDs for picklist and reference fields (e.g. resourceName "Will Spence" instead of resourceID 29683, or category name "Internal Meeting" instead of numeric billingCodeID). The tool auto-resolves names to IDs. ` +
-        `Date-time values must be ISO-8601 and UTC-safe (for example 2026-02-14T03:15:00Z). ` +
-        `Successful creates typically return an itemId and any resolvedLabels showing name→ID mappings. ` +
-        `Confirm field values with user before executing when acting autonomously. ` +
-        `If picklist values fail validation, call autotask_${resourceName} with operation 'listPicklistValues'.` +
+	return (
+		ref +
+		`Create a new ${resourceLabel} record. ` +
+		`${requiredSummary}${parentHint} ` +
+		`Name-based resolution: you can pass human-readable names instead of numeric IDs for picklist and reference fields (e.g. resourceName "Will Spence" instead of resourceID 29683, or category name "Internal Meeting" instead of numeric billingCodeID). The tool auto-resolves names to IDs. ` +
+		`Date-time values must be ISO-8601 and UTC-safe (for example 2026-02-14T03:15:00Z). ` +
+		`Successful creates typically return an itemId and any resolvedLabels showing name→ID mappings. ` +
+		`Confirm field values with user before executing when acting autonomously. ` +
+		`If picklist values fail validation, call autotask_${resourceName} with operation 'listPicklistValues'.` +
 		impersonationNote
-    );
+	);
 }
 
 export function buildUpdateDescription(
-    resourceLabel: string,
-    resourceName: string,
-    supportsImpersonation = false,
-    referenceUtc?: string,
+	resourceLabel: string,
+	resourceName: string,
+	supportsImpersonation = false,
+	referenceUtc?: string,
 ): string {
-    const ref = referenceUtc ? dateTimeReferenceSnippet(referenceUtc) : '';
-    const impersonationNote = supportsImpersonation
+	const ref = referenceUtc ? dateTimeReferenceSnippet(referenceUtc) : '';
+	const impersonationNote = supportsImpersonation
 		? ' Optional impersonation is supported with impersonationResourceId (accepts name or ID). Impersonation is off by default unless that value is set. If proceedWithoutImpersonationIfDenied is true, denied impersonated writes retry once without impersonation.'
 		: '';
-    return (
-        ref +
-        `Update an existing ${resourceLabel} record by numeric ID. ` +
-        `PREREQUISITE: you need the numeric ID. If you only have a name or text, call autotask_${resourceName} with operation 'getMany' with a filter to find the record and get its 'id' first. ` +
-        `Only provide fields to change (PATCH-style behaviour). ` +
-        `Do not assume PUT-style replacement where omitted fields become null. ` +
-        `Name-based resolution: you can pass human-readable names instead of numeric IDs for picklist and reference fields. The tool auto-resolves names to IDs. ` +
-        `Date-time values must be ISO-8601 and UTC-safe (for example 2026-02-14T03:15:00Z). ` +
-        `Confirm field values with user before executing when acting autonomously. ` +
-        `Call autotask_${resourceName} with operation 'describeFields' (mode 'write') to verify valid field names and required value types. ` +
-        `Use autotask_${resourceName} with operation 'listPicklistValues' for picklist fields.` +
+	return (
+		ref +
+		`Update an existing ${resourceLabel} record by numeric ID. ` +
+		`PREREQUISITE: you need the numeric ID. If you only have a name or text, call autotask_${resourceName} with operation 'getMany' with a filter to find the record and get its 'id' first. ` +
+		`Only provide fields to change (PATCH-style behaviour). ` +
+		`Do not assume PUT-style replacement where omitted fields become null. ` +
+		`Name-based resolution: you can pass human-readable names instead of numeric IDs for picklist and reference fields. The tool auto-resolves names to IDs. ` +
+		`Date-time values must be ISO-8601 and UTC-safe (for example 2026-02-14T03:15:00Z). ` +
+		`Confirm field values with user before executing when acting autonomously. ` +
+		`Call autotask_${resourceName} with operation 'describeFields' (mode 'write') to verify valid field names and required value types. ` +
+		`Use autotask_${resourceName} with operation 'listPicklistValues' for picklist fields.` +
 		impersonationNote
-    );
+	);
 }
 
 export function buildDeleteDescription(resourceLabel: string, resourceName: string): string {
-    return (
-        `Delete a ${resourceLabel} record by numeric ID. ` +
-        `ONLY on explicit user intent. Do not infer delete intent from context. Confirm ID is correct before proceeding. ` +
-        `Operational delete responses may be minimal, so treat non-200 outcomes as failures. ` +
-        `Use autotask_${resourceName} with operation 'getMany' or autotask_${resourceName} with operation 'get' first to confirm the correct ID before deletion.`
-    );
+	return (
+		`Delete a ${resourceLabel} record by numeric ID. ` +
+		`ONLY on explicit user intent. Do not infer delete intent from context. Confirm ID is correct before proceeding. ` +
+		`Operational delete responses may be minimal, so treat non-200 outcomes as failures. ` +
+		`Use autotask_${resourceName} with operation 'getMany' or autotask_${resourceName} with operation 'get' first to confirm the correct ID before deletion.`
+	);
 }
 
 export function buildWhoAmIDescription(resourceLabel: string): string {
-    return (
-        `Resolve the current authenticated ${resourceLabel} record from API credentials. ` +
-        `Use this to discover the active Autotask user context before running user-scoped actions. ` +
-        `Optionally use 'fields' to limit returned columns.`
-    );
+	return (
+		`Resolve the current authenticated ${resourceLabel} record from API credentials. ` +
+		`Use this to discover the active Autotask user context before running user-scoped actions. ` +
+		`Optionally use 'fields' to limit returned columns.`
+	);
 }
 
-export function buildPostedTimeEntriesDescription(resourceName: string, referenceUtc?: string): string {
-    const ref = referenceUtc ? dateTimeReferenceSnippet(referenceUtc) + RECENCY_VS_SINCE_UNTIL_RULE : '';
-    return (
-        ref +
-        `Get posted time entries (entries with matching Billing Items). ` +
-        `Supports the same optional filters as getMany (up to two filters, AND by default; set filter_logic='or' for either-match), plus 'limit', 'offset', and 'fields'. ` +
-        `IMPORTANT: The Autotask API returns records oldest first (ascending ID). Without recency or since, limit=1 returns the OLDEST entry, not the newest. ` +
-        `To get the most recent posted entries, you MUST use recency (for example 'last_24h' or 'last_7d'), or provide since/until in ISO-8601 UTC format. ` +
-        `For date-range and advanced posting filters, use the standard Time Entry node operation if needed. ` +
-        `If field names are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
-    );
+export function buildPostedTimeEntriesDescription(
+	resourceName: string,
+	referenceUtc?: string,
+): string {
+	const ref = referenceUtc
+		? dateTimeReferenceSnippet(referenceUtc) + RECENCY_VS_SINCE_UNTIL_RULE
+		: '';
+	return (
+		ref +
+		`Get posted time entries (entries with matching Billing Items). ` +
+		`Supports the same optional filters as getMany (up to two filters, AND by default; set filter_logic='or' for either-match), plus 'limit', 'offset', and 'fields'. ` +
+		`IMPORTANT: The Autotask API returns records oldest first (ascending ID). Without recency or since, limit=1 returns the OLDEST entry, not the newest. ` +
+		`To get the most recent posted entries, you MUST use recency (for example 'last_24h' or 'last_7d'), or provide since/until in ISO-8601 UTC format. ` +
+		`For date-range and advanced posting filters, use the standard Time Entry node operation if needed. ` +
+		`If field names are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
+	);
 }
 
-export function buildUnpostedTimeEntriesDescription(resourceName: string, referenceUtc?: string): string {
-    const ref = referenceUtc ? dateTimeReferenceSnippet(referenceUtc) + RECENCY_VS_SINCE_UNTIL_RULE : '';
-    return (
-        ref +
-        `Get unposted time entries (entries without matching Billing Items). ` +
-        `Supports the same optional filters as getMany (up to two filters, AND by default; set filter_logic='or' for either-match), plus 'limit', 'offset', and 'fields'. ` +
-        `IMPORTANT: The Autotask API returns records oldest first (ascending ID). Without recency or since, limit=1 returns the OLDEST entry, not the newest. ` +
-        `To get the most recent unposted entries, you MUST use recency (for example 'last_24h' or 'last_7d'), or provide since/until in ISO-8601 UTC format. ` +
-        `For date-range and advanced posting filters, use the standard Time Entry node operation if needed. ` +
-        `If field names are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
-    );
+export function buildUnpostedTimeEntriesDescription(
+	resourceName: string,
+	referenceUtc?: string,
+): string {
+	const ref = referenceUtc
+		? dateTimeReferenceSnippet(referenceUtc) + RECENCY_VS_SINCE_UNTIL_RULE
+		: '';
+	return (
+		ref +
+		`Get unposted time entries (entries without matching Billing Items). ` +
+		`Supports the same optional filters as getMany (up to two filters, AND by default; set filter_logic='or' for either-match), plus 'limit', 'offset', and 'fields'. ` +
+		`IMPORTANT: The Autotask API returns records oldest first (ascending ID). Without recency or since, limit=1 returns the OLDEST entry, not the newest. ` +
+		`To get the most recent unposted entries, you MUST use recency (for example 'last_24h' or 'last_7d'), or provide since/until in ISO-8601 UTC format. ` +
+		`For date-range and advanced posting filters, use the standard Time Entry node operation if needed. ` +
+		`If field names are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
+	);
 }
 
 export function buildCompanySearchByDomainDescription(resourceName: string): string {
-    return (
-        'Search companies by domain using website-style fields. ' +
-        "Input can be a bare domain or full URL; the tool normalises it to a domain fragment (for example autotask.net). " +
-        "IMPORTANT: Autotask typically stores company websites as full URLs (for example https://www.autotask.net/), so exact operator matches can fail on bare domain input. " +
-        "To avoid false negatives, eq/like semantics are handled safely for website matching. " +
-        "When searchContactEmails is true (default), if no company website matches exist, the tool searches Contact.emailAddress by domain and resolves the most common canonical company name from companyID references. " +
-        "Use the 'fields' parameter to limit which company fields are returned per result (comma-separated); omit to receive the full company entity. matchedField and matchedValue are always included to indicate which website field matched and its value. " +
-        `If field names are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
-    );
+	return (
+		'Search companies by domain using website-style fields. ' +
+		'Input can be a bare domain or full URL; the tool normalises it to a domain fragment (for example autotask.net). ' +
+		'IMPORTANT: Autotask typically stores company websites as full URLs (for example https://www.autotask.net/), so exact operator matches can fail on bare domain input. ' +
+		'To avoid false negatives, eq/like semantics are handled safely for website matching. ' +
+		'When searchContactEmails is true (default), if no company website matches exist, the tool searches Contact.emailAddress by domain and resolves the most common canonical company name from companyID references. ' +
+		"Use the 'fields' parameter to limit which company fields are returned per result (comma-separated); omit to receive the full company entity. matchedField and matchedValue are always included to indicate which website field matched and its value. " +
+		`If field names are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
+	);
 }
 
 export function buildTicketSummaryDescription(resourceName: string): string {
-    return (
-        'Get a compact, type-aware summary of any Autotask ticket. ' +
-        `Requires 'id' (numeric Ticket ID) or 'ticketNumber' (format T{date}.{seq}, e.g. T20240615.0001) — calls with neither identifier are rejected immediately. ` +
-        'Automatically detects ticket type (Service Request, Incident, Problem, Change Request, Alert) and prioritises the most relevant fields. ' +
-        'Filters out null and empty fields to reduce noise. ' +
-        "Includes a 'computed' block with pre-calculated values: ageHours, daysSinceLastActivity, isAssigned; for open tickets: isOverdue, plus hoursUntilDue (not yet overdue) or hoursOverdue (past due); when SLA is assigned: slaStatus, slaNextMilestoneDueHours, slaEarliestBreachHours. " +
-        "Optionally includes a 'childCounts' block with counts of: notes, timeEntries, attachments, additionalConfigurationItems, additionalContacts, checklistItems (with completed/remaining breakdown), and changeRequestLinks (Change Request tickets only). Set 'includeChildCounts=true' to fetch these counts (adds several parallel API calls; omitted by default). " +
-        "Includes a 'relationships' block when the ticket is linked to a project, problem ticket, or opportunity. " +
-        "Use 'summaryTextLimit' to cap description/resolution length (default 500 chars). " +
-        "Set 'includeRaw=true' to receive the full enriched payload before alias renaming — label/UDF enrichments intact, original changeInfoField{N} keys, no null filtering or text truncation. " +
-        "For full SLA milestone timing and elapsed hours, use slaHealthCheck instead. " +
-        `If field names are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
-    );
+	return (
+		'Get a compact, type-aware summary of any Autotask ticket. ' +
+		`Requires 'id' (numeric Ticket ID) or 'ticketNumber' (format T{date}.{seq}, e.g. T20240615.0001) — calls with neither identifier are rejected immediately. ` +
+		'Automatically detects ticket type (Service Request, Incident, Problem, Change Request, Alert) and prioritises the most relevant fields. ' +
+		'Filters out null and empty fields to reduce noise. ' +
+		"Includes a 'computed' block with pre-calculated values: ageHours, daysSinceLastActivity, isAssigned; for open tickets: isOverdue, plus hoursUntilDue (not yet overdue) or hoursOverdue (past due); when SLA is assigned: slaStatus, slaNextMilestoneDueHours, slaEarliestBreachHours. " +
+		"Optionally includes a 'childCounts' block with counts of: notes, timeEntries, attachments, additionalConfigurationItems, additionalContacts, checklistItems (with completed/remaining breakdown), and changeRequestLinks (Change Request tickets only). Set 'includeChildCounts=true' to fetch these counts (adds several parallel API calls; omitted by default). " +
+		"Includes a 'relationships' block when the ticket is linked to a project, problem ticket, or opportunity. " +
+		"Use 'summaryTextLimit' to cap description/resolution length (default 500 chars). " +
+		"Set 'includeRaw=true' to receive the full enriched payload before alias renaming — label/UDF enrichments intact, original changeInfoField{N} keys, no null filtering or text truncation. " +
+		'For full SLA milestone timing and elapsed hours, use slaHealthCheck instead. ' +
+		`If field names are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
+	);
 }
 
 export function buildTicketSlaHealthCheckDescription(resourceName: string): string {
-    return (
-        `Run an SLA health check on a ticket — provide either 'id' (numeric Ticket ID) or 'ticketNumber' (format T{date}.{seq}, e.g. T20240615.0001); calls with neither identifier are rejected immediately. ` +
-        'Returns first-response, resolution-plan, and resolution milestone timing and status in consistent hours (2 decimal places). ' +
-        "Use 'ticketFields' to limit which ticket fields are returned in the ticket section. " +
-        'Includes wallClockRemainingHours, where negative values indicate overdue milestones. ' +
-        'This operation combines data from Ticket and ServiceLevelAgreementResults entities. ' +
-        `If field names are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
-    );
+	return (
+		`Run an SLA health check on a ticket — provide either 'id' (numeric Ticket ID) or 'ticketNumber' (format T{date}.{seq}, e.g. T20240615.0001); calls with neither identifier are rejected immediately. ` +
+		'Returns first-response, resolution-plan, and resolution milestone timing and status in consistent hours (2 decimal places). ' +
+		"Use 'ticketFields' to limit which ticket fields are returned in the ticket section. " +
+		'Includes wallClockRemainingHours, where negative values indicate overdue milestones. ' +
+		'This operation combines data from Ticket and ServiceLevelAgreementResults entities. ' +
+		`If field names are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
+	);
 }
 
-export function buildConfigurationItemMoveConfigurationItemDescription(resourceName: string): string {
-    return (
-        'Clone a configuration item to a different company because companyID cannot be updated in place. ' +
-        'Copies CI core fields and optional UDFs, optional CI attachments, optional notes, and optional note attachments. ' +
-        'Always writes audit notes and can deactivate the source CI after safety checks. ' +
-        'Optionally provide impersonationResourceId so created records (CI, notes, attachments) are attributed to that resource. ' +
-        'Optionally set proceedWithoutImpersonationIfDenied (default on); this only applies when impersonationResourceId is set and retries without impersonation if write permissions are denied for the impersonated resource. ' +
-        'This operation does not migrate tickets, tasks, projects, contracts, related items, DNS records, or billing-product associations. ' +
-        `If field names or expected behaviour are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
-    );
+export function buildConfigurationItemMoveConfigurationItemDescription(
+	resourceName: string,
+): string {
+	return (
+		'Clone a configuration item to a different company because companyID cannot be updated in place. ' +
+		'Copies CI core fields and optional UDFs, optional CI attachments, optional notes, and optional note attachments. ' +
+		'Always writes audit notes and can deactivate the source CI after safety checks. ' +
+		'Optionally provide impersonationResourceId so created records (CI, notes, attachments) are attributed to that resource. ' +
+		'Optionally set proceedWithoutImpersonationIfDenied (default on); this only applies when impersonationResourceId is set and retries without impersonation if write permissions are denied for the impersonated resource. ' +
+		'This operation does not migrate tickets, tasks, projects, contracts, related items, DNS records, or billing-product associations. ' +
+		`If field names or expected behaviour are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
+	);
 }
 
 export function buildContactMoveToCompanyDescription(resourceName: string): string {
-    return (
-        'Move a contact to another company by cloning the contact record and optional related data. ' +
-        'Supports duplicate email safeguards, optional company note and attachment copy, contact group copy, and configurable source/destination audit notes. ' +
-        'Supports dry run planning which returns source contact details, the destination payload, location resolution, duplicate check result, and planned counts without writing. ' +
-        'Supports optional impersonation for write attribution with optional fallback when impersonation is denied. ' +
-        `If field names or expected behaviour are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
-    );
+	return (
+		'Move a contact to another company by cloning the contact record and optional related data. ' +
+		'Supports duplicate email safeguards, optional company note and attachment copy, contact group copy, and configurable source/destination audit notes. ' +
+		'Supports dry run planning which returns source contact details, the destination payload, location resolution, duplicate check result, and planned counts without writing. ' +
+		'Supports optional impersonation for write attribution with optional fallback when impersonation is denied. ' +
+		`If field names or expected behaviour are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
+	);
 }
 
 export function buildResourceTransferOwnershipDescription(resourceName: string): string {
-    return (
-        'Transfer ownership and assignments from a source resource to a receiving resource. ' +
-        'Supports companies, opportunities, tickets, tasks, projects, task secondary resources, service call assignments, and appointments. ' +
-        'Supports dry run planning, due-window filtering, status filtering, and optional audit notes. ' +
-        'Dry run returns full item lists per entity type with key identifying fields (e.g. id, title, status) plus source/destination resource context. ' +
-        "Use dueWindowPreset for convenient date ranges, or dueWindowPreset='custom' with dueBeforeCustom for exact cut-offs. " +
-        "By default, only open/active-style work is targeted by excluding terminal statuses. " +
-        `If field names or expected behaviour are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
-    );
+	return (
+		'Transfer ownership and assignments from a source resource to a receiving resource. ' +
+		'Supports companies, opportunities, tickets, tasks, projects, task secondary resources, service call assignments, and appointments. ' +
+		'Supports dry run planning, due-window filtering, status filtering, and optional audit notes. ' +
+		'Dry run returns full item lists per entity type with key identifying fields (e.g. id, title, status) plus source/destination resource context. ' +
+		"Use dueWindowPreset for convenient date ranges, or dueWindowPreset='custom' with dueBeforeCustom for exact cut-offs. " +
+		'By default, only open/active-style work is targeted by excluding terminal statuses. ' +
+		`If field names or expected behaviour are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
+	);
 }
 
 function buildCreateIfNotExistsDescription(resource: string): string {
-	return `Idempotent creation for ${resource}. Checks for duplicates using configurable dedupFields before creating. ` +
+	return (
+		`Idempotent creation for ${resource}. Checks for duplicates using configurable dedupFields before creating. ` +
 		`Pass the same fields as the create operation, plus dedupFields (array of API field names for duplicate detection) ` +
 		`and errorOnDuplicate (boolean, default false). Use describeFields first to discover available field names. ` +
 		`Use updateFields to specify fields to compare against the duplicate — when values differ the duplicate will be updated (outcome: updated). Requires errorOnDuplicate to be false. ` +
-		`Returns outcome: created, skipped, updated, or a resource-specific not_found variant.`;
+		`Returns outcome: created, skipped, updated, or a resource-specific not_found variant.`
+	);
 }
 
 export function buildDescribeFieldsDescription(resourceLabel: string): string {
-    return (
-        `Describe available ${resourceLabel} fields for AI usage. ` +
-        `Use mode 'read' for query fields and mode 'write' for create/update fields.`
-    );
+	return (
+		`Describe available ${resourceLabel} fields for AI usage. ` +
+		`Use mode 'read' for query fields and mode 'write' for create/update fields.`
+	);
 }
 
 export function buildListPicklistValuesDescription(resourceLabel: string): string {
-    return (
-        `List picklist values for a specific ${resourceLabel} field. ` +
-        `Use this when create or update fails due to invalid picklist values.`
-    );
+	return (
+		`List picklist values for a specific ${resourceLabel} field. ` +
+		`Use this when create or update fails due to invalid picklist values.`
+	);
 }
 
-const TRUNCATION_SUFFIX = "...[description truncated — call with operation='describeOperation' and targetOperation='<op>' for operation-specific detail, or operation='describeFields' for field metadata]";
+const TRUNCATION_SUFFIX =
+	"...[description truncated — call with operation='describeOperation' and targetOperation='<op>' for operation-specific detail, or operation='describeFields' for field metadata]";
 
 /**
  * Truncate a description to fit within the character budget.
@@ -306,451 +324,713 @@ const TRUNCATION_SUFFIX = "...[description truncated — call with operation='de
  * so the LLM knows content was removed.
  */
 function truncateDescription(text: string, limit = 2000): string {
-    if (text.length <= limit) return text;
-    const cutAt = Math.max(0, limit - TRUNCATION_SUFFIX.length);
-    const lastSpace = text.lastIndexOf(' ', cutAt);
-    const breakpoint = lastSpace >= 0 ? lastSpace : cutAt;
-    return text.slice(0, breakpoint) + TRUNCATION_SUFFIX;
+	if (text.length <= limit) return text;
+	const cutAt = Math.max(0, limit - TRUNCATION_SUFFIX.length);
+	const lastSpace = text.lastIndexOf(' ', cutAt);
+	const breakpoint = lastSpace >= 0 ? lastSpace : cutAt;
+	return text.slice(0, breakpoint) + TRUNCATION_SUFFIX;
 }
 
 export function buildUnifiedDescription(
-    resourceLabel: string,
-    resource: string,
-    operations: string[],
-    readFields: FieldMeta[],
-    writeFields: FieldMeta[],
-    referenceUtc: string,
-    supportsImpersonation: boolean,
+	resourceLabel: string,
+	resource: string,
+	operations: string[],
+	readFields: FieldMeta[],
+	writeFields: FieldMeta[],
+	referenceUtc: string,
+	supportsImpersonation: boolean,
 ): string {
-    const hasWriteOps = operations.some(op =>
-        op === 'create' || op === 'update' || op === 'delete'
-        || op === 'createIfNotExists' || op === 'approve' || op === 'reject'
-        || op === 'moveToCompany' || op === 'moveConfigurationItem' || op === 'transferOwnership',
-    );
-    const allOps = [...new Set([...operations, 'describeFields', 'listPicklistValues', 'describeOperation'])];
-    const sections: string[] = [];
+	traceDescriptionBuild({
+		phase: 'build-start',
+		resource,
+		summary: {
+			operations,
+			readFieldCount: readFields.length,
+			writeFieldCount: writeFields.length,
+			supportsImpersonation,
+		},
+	});
+	const hasWriteOps = operations.some(
+		(op) =>
+			op === 'create' ||
+			op === 'update' ||
+			op === 'delete' ||
+			op === 'createIfNotExists' ||
+			op === 'approve' ||
+			op === 'reject' ||
+			op === 'moveToCompany' ||
+			op === 'moveConfigurationItem' ||
+			op === 'transferOwnership',
+	);
+	const allOps = [
+		...new Set([...operations, 'describeFields', 'listPicklistValues', 'describeOperation']),
+	];
+	const sections: string[] = [];
 
-    // Safety-critical header — always first, guaranteed to survive truncation
-    if (hasWriteOps) {
-        sections.push(
-            'WRITE SAFETY: All write operations require field references to resolve exactly.' +
-            ' Ambiguous, unmatched, or infrastructure-failed resolutions block execution before any mutation occurs.',
-        );
-    }
+	// Safety-critical header — always first, guaranteed to survive truncation
+	if (hasWriteOps) {
+		sections.push(
+			'WRITE SAFETY: All write operations require field references to resolve exactly.' +
+				' Ambiguous, unmatched, or infrastructure-failed resolutions block execution before any mutation occurs.',
+		);
+	}
 
-    sections.push(
-        `Perform operations on Autotask ${resourceLabel} records.`,
-        `Required: 'operation' field — one of: ${allOps.join(', ')}.`,
-        dateTimeReferenceSnippet(referenceUtc),
-    );
+	sections.push(
+		`Perform operations on Autotask ${resourceLabel} records.`,
+		`Required: 'operation' field — one of: ${allOps.join(', ')}.`,
+		dateTimeReferenceSnippet(referenceUtc),
+	);
 
-    for (const op of operations) {
-        let summary: string;
-        switch (op) {
-            case 'get':
-                summary = `operation '${op}': Retrieve a single record by numeric 'id'.`;
-                break;
-            case 'whoAmI':
-                summary = `operation '${op}': Resolve the authenticated ${resourceLabel} record.`;
-                break;
-            case 'getMany':
-                summary = `operation '${op}': Search records with up to two filters (AND/OR via filter_logic). Use filter_field/filter_value. Supports name-based resolution for reference/picklist filter values.`;
-                break;
-            case 'count':
-                summary = `operation '${op}': Count records matching optional filters.`;
-                break;
-            case 'searchByDomain':
-                summary = `operation '${op}': Search companies by domain string.`;
-                break;
-            case 'slaHealthCheck':
-                summary = `operation '${op}': Run SLA health check for a ticket using 'id' or 'ticketNumber'.`;
-                break;
-            case 'summary':
-                summary = `operation '${op}': Get a compact ticket summary ('id' or 'ticketNumber' required). Computed values, child counts, relationships.`;
-                break;
-            case 'getPosted':
-                summary = `operation '${op}': Get posted time entries with optional filters.`;
-                break;
-            case 'getUnposted':
-                summary = `operation '${op}': Get unposted time entries with optional filters.`;
-                break;
-            case 'create': {
-                summary = `operation '${op}': Create a new record. ${buildRequiredFieldsSummary(writeFields)} Populate every optional field for which you already have data — do not omit known information. Supports name-based resolution for picklist/reference fields.`;
-                break;
-            }
-            case 'update':
-                if (resource === 'resourceTimeOffAdditional') {
-                    summary = `operation '${op}': Update time-off additional quotas for a resource. Provide 'resourceID' (name or numeric ID, auto-resolved) and the fields to change (annual/additional hours per category). Supports name-based resolution.`;
-                } else {
-                    summary = `operation '${op}': Update a record by numeric 'id'. Provide only fields to change. Supports name-based resolution for picklist/reference fields.`;
-                }
-                break;
-            case 'delete':
-                summary = `operation '${op}': Delete a record by numeric 'id'.`;
-                break;
-            case 'moveToCompany':
-                summary = `operation '${op}': Move a contact to another company.`;
-                break;
-            case 'moveConfigurationItem':
-                summary = `operation '${op}': Clone a configuration item to a different company.`;
-                break;
-            case 'transferOwnership':
-                summary = `operation '${op}': Transfer ownership from source resource to destination resource.`;
-                break;
-            case 'createIfNotExists':
-                summary = buildCreateIfNotExistsDescription(resource);
-                break;
-            case 'getByResource':
-                summary = `operation '${op}': Get record(s) for a specific resource. Provide 'resourceID' as a name or numeric ID (auto-resolved). Use for operations that are scoped to a parent resource rather than queried by their own ID.`;
-                break;
-            case 'getByYear':
-                summary = `operation '${op}': Get the time-off balance for a specific calendar year. Provide 'resourceID' (name or numeric ID, auto-resolved) and 'year' as an integer (e.g. 2024).`;
-                break;
-            case 'approve':
-                summary = `operation '${op}': Approve a pending time off request by numeric 'id'. Changes the request status to approved.`;
-                break;
-            case 'reject':
-                summary = `operation '${op}': Reject a pending time off request by numeric 'id'. Provide an optional 'rejectReason' string to record the reason for rejection.`;
-                break;
-            default:
-                summary = `operation '${op}': Perform ${op} on ${resourceLabel}.`;
-        }
-        sections.push(summary);
-    }
+	for (const op of operations) {
+		let summary: string;
+		switch (op) {
+			case 'get':
+				summary = `operation '${op}': Retrieve a single record by numeric 'id'.`;
+				break;
+			case 'whoAmI':
+				summary = `operation '${op}': Resolve the authenticated ${resourceLabel} record.`;
+				break;
+			case 'getMany':
+				summary = `operation '${op}': Search records with up to two filters (AND/OR via filter_logic). Use filter_field/filter_value. Supports name-based resolution for reference/picklist filter values.`;
+				break;
+			case 'count':
+				summary = `operation '${op}': Count records matching optional filters.`;
+				break;
+			case 'searchByDomain':
+				summary = `operation '${op}': Search companies by domain string.`;
+				break;
+			case 'slaHealthCheck':
+				summary = `operation '${op}': Run SLA health check for a ticket using 'id' or 'ticketNumber'.`;
+				break;
+			case 'summary':
+				summary = `operation '${op}': Get a compact ticket summary ('id' or 'ticketNumber' required). Computed values, child counts, relationships.`;
+				break;
+			case 'getPosted':
+				summary = `operation '${op}': Get posted time entries with optional filters.`;
+				break;
+			case 'getUnposted':
+				summary = `operation '${op}': Get unposted time entries with optional filters.`;
+				break;
+			case 'create': {
+				summary = `operation '${op}': Create a new record. ${buildRequiredFieldsSummary(writeFields)} Populate every optional field for which you already have data — do not omit known information. Supports name-based resolution for picklist/reference fields.`;
+				break;
+			}
+			case 'update':
+				if (resource === 'resourceTimeOffAdditional') {
+					summary = `operation '${op}': Update time-off additional quotas for a resource. Provide 'resourceID' (name or numeric ID, auto-resolved) and the fields to change (annual/additional hours per category). Supports name-based resolution.`;
+				} else {
+					summary = `operation '${op}': Update a record by numeric 'id'. Provide only fields to change. Supports name-based resolution for picklist/reference fields.`;
+				}
+				break;
+			case 'delete':
+				summary = `operation '${op}': Delete a record by numeric 'id'.`;
+				break;
+			case 'moveToCompany':
+				summary = `operation '${op}': Move a contact to another company.`;
+				break;
+			case 'moveConfigurationItem':
+				summary = `operation '${op}': Clone a configuration item to a different company.`;
+				break;
+			case 'transferOwnership':
+				summary = `operation '${op}': Transfer ownership from source resource to destination resource.`;
+				break;
+			case 'createIfNotExists':
+				summary = buildCreateIfNotExistsDescription(resource);
+				break;
+			case 'getByResource':
+				summary = `operation '${op}': Get record(s) for a specific resource. Provide 'resourceID' as a name or numeric ID (auto-resolved). Use for operations that are scoped to a parent resource rather than queried by their own ID.`;
+				break;
+			case 'getByYear':
+				summary = `operation '${op}': Get the time-off balance for a specific calendar year. Provide 'resourceID' (name or numeric ID, auto-resolved) and 'year' as an integer (e.g. 2024).`;
+				break;
+			case 'approve':
+				summary = `operation '${op}': Approve a pending time off request by numeric 'id'. Changes the request status to approved.`;
+				break;
+			case 'reject':
+				summary = `operation '${op}': Reject a pending time off request by numeric 'id'. Provide an optional 'rejectReason' string to record the reason for rejection.`;
+				break;
+			default:
+				summary = `operation '${op}': Perform ${op} on ${resourceLabel}.`;
+		}
+		sections.push(summary);
+	}
 
-    sections.push(`operation 'describeFields': List all field IDs, types, and metadata. Use mode 'read' or 'write'.`);
-    sections.push(`operation 'listPicklistValues': Get valid values for a picklist field. Use 'fieldId' parameter.`);
-    sections.push(`operation 'describeOperation': Get full documentation for a specific operation — purpose, parameters, and usage notes. Use 'targetOperation' parameter.`);
+	sections.push(
+		`operation 'describeFields': List all field IDs, types, and metadata. Use mode 'read' or 'write'.`,
+	);
+	sections.push(
+		`operation 'listPicklistValues': Get valid values for a picklist field. Use 'fieldId' parameter.`,
+	);
+	sections.push(
+		`operation 'describeOperation': Get full documentation for a specific operation — purpose, parameters, and usage notes. Use 'targetOperation' parameter.`,
+	);
 
-    if (supportsImpersonation) {
-        sections.push(`Impersonation supported: pass 'impersonationResourceId' for write attribution.`);
-    }
+	if (supportsImpersonation) {
+		sections.push(`Impersonation supported: pass 'impersonationResourceId' for write attribution.`);
+	}
 
-    return truncateDescription(sections.join(' '));
+	const combined = sections.join(' ');
+	const output = truncateDescription(combined);
+	traceDescriptionBuild({
+		phase: 'build-complete',
+		resource,
+		summary: {
+			operationsIncluded: operations,
+			writeSafetyHeaderAdded: hasWriteOps,
+			identifierPairNoteIncluded: operations.some(
+				(op) => op === 'slaHealthCheck' || op === 'summary',
+			),
+			impersonationNoteIncluded: supportsImpersonation,
+			truncationApplied: combined.length !== output.length,
+			finalLength: output.length,
+			...(AI_TOOL_DEBUG_VERBOSE ? { descriptionPreview: redactForVerbose(output) } : {}),
+		},
+	});
+	return output;
 }
 
 // ─── describeOperation builder ───────────────────────────────────────────────
 
 export interface OperationParam {
-    field: string;
-    type: string;
-    target?: string;    // for reference fields: referenced entity
-    values?: string[];  // for picklist fields with ≤10 values: id=label pairs
-    description?: string;
+	field: string;
+	type: string;
+	target?: string; // for reference fields: referenced entity
+	values?: string[]; // for picklist fields with ≤10 values: id=label pairs
+	description?: string;
 }
 
 export interface OperationDoc {
-    operation: string;
-    purpose: string;
-    parameters: {
-        required: OperationParam[];
-        optional: OperationParam[];
-    };
-    notes: string[];
+	operation: string;
+	purpose: string;
+	parameters: {
+		required: OperationParam[];
+		optional: OperationParam[];
+	};
+	notes: string[];
 }
 
 const WRITE_OPS_WITH_FIELD_METADATA = new Set(['create', 'update', 'createIfNotExists']);
 
 const LABEL_RESOLUTION_NOTES = [
-    'Name-based resolution: picklist and reference fields accept human-readable names (e.g. "Will Spence") — auto-resolved to numeric IDs before writing.',
-    "Use operation='describeFields' with mode='write' to discover available field names and types.",
-    'Pass dryRun=true to resolve labels and validate fields without making an API call.',
+	'Name-based resolution: picklist and reference fields accept human-readable names (e.g. "Will Spence") — auto-resolved to numeric IDs before writing.',
+	"Use operation='describeFields' with mode='write' to discover available field names and types.",
+	'Pass dryRun=true to resolve labels and validate fields without making an API call.',
 ];
 const DEDUP_NOTES = [
-    'dedupFields: array of field names for duplicate detection. Empty = skip dedup, always create.',
-    'errorOnDuplicate: when true, errors on duplicate instead of skipping. Default false.',
-    'updateFields: field names to compare against the duplicate — values that differ cause an update. Requires errorOnDuplicate=false.',
-    'Returns outcome: created, skipped, updated, or a resource-specific not_found variant.',
+	'dedupFields: array of field names for duplicate detection. Empty = skip dedup, always create.',
+	'errorOnDuplicate: when true, errors on duplicate instead of skipping. Default false.',
+	'updateFields: field names to compare against the duplicate — values that differ cause an update. Requires errorOnDuplicate=false.',
+	'Returns outcome: created, skipped, updated, or a resource-specific not_found variant.',
 ];
 const IDENTIFIER_PAIR_NOTES = [
-    "Requires either 'id' (numeric entity ID) or the alternative string identifier (e.g. 'ticketNumber' with format T{date}.{seq}).",
-    'Calls with neither identifier are rejected immediately with INVALID_FILTER_CONSTRAINT.',
+	"Requires either 'id' (numeric entity ID) or the alternative string identifier (e.g. 'ticketNumber' with format T{date}.{seq}).",
+	'Calls with neither identifier are rejected immediately with INVALID_FILTER_CONSTRAINT.',
 ];
 const LIST_ADVANCED_NOTES = [
-    "filtersJson: JSON array of Autotask IFilterCondition objects for 3+ conditions or nested OR. Mutually exclusive with flat filter_field triplets. No label resolution — pass numeric IDs.",
-    'returnAll=true: fetches ALL matching records via API-native pagination. Response truncated at 100 records — use fields param to reduce payload or narrow filters.',
-    'API ordering: records always return in ascending ID order (oldest first). No server-side sort is available.',
+	'filtersJson: JSON array of Autotask IFilterCondition objects for 3+ conditions or nested OR. Mutually exclusive with flat filter_field triplets. No label resolution — pass numeric IDs.',
+	'returnAll=true: fetches ALL matching records via API-native pagination. Response truncated at 100 records — use fields param to reduce payload or narrow filters.',
+	'API ordering: records always return in ascending ID order (oldest first). No server-side sort is available.',
 ];
 
 /** Static parameter map for read and metadata operations */
 const READ_OP_PARAMS: Record<string, { required: OperationParam[]; optional: OperationParam[] }> = {
-    get: {
-        required: [{ field: 'id', type: 'number', description: 'Numeric entity ID.' }],
-        optional: [{ field: 'fields', type: 'string', description: 'Comma-separated field names to return.' }],
-    },
-    getMany: {
-        required: [],
-        optional: [
-            { field: 'filter_field', type: 'string', description: 'Field to filter on.' },
-            { field: 'filter_op', type: 'string', description: 'Operator: eq, noteq, gt, gte, lt, lte, contains, beginsWith, endsWith, exist, notExist, in, notIn.' },
-            { field: 'filter_value', type: 'string | number | boolean | array', description: 'Filter value. Use arrays for in/notIn.' },
-            { field: 'filter_field_2', type: 'string', description: 'Second filter field.' },
-            { field: 'filter_op_2', type: 'string', description: 'Second filter operator.' },
-            { field: 'filter_value_2', type: 'string | number | boolean | array', description: 'Second filter value.' },
-            { field: 'filter_logic', type: 'string', description: "'and' (default) or 'or'." },
-            { field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array (mutually exclusive with flat filter_field triplets). No label resolution.' },
-            { field: 'returnAll', type: 'boolean', description: 'Fetch ALL matching records via API pagination. Response capped at 100 records.' },
-            { field: 'limit', type: 'number', description: 'Max records (1-500, default 10).' },
-            { field: 'offset', type: 'number', description: 'Skip first N records (max 499).' },
-            { field: 'recency', type: 'string', description: 'Preset window (last_7d, last_30d, etc.) or custom last_Nd.' },
-            { field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
-            { field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
-            { field: 'fields', type: 'string', description: 'Comma-separated field names to return.' },
-            { field: 'outputMode', type: 'string', description: "'idsAndLabels' (default) or 'rawIds'." },
-        ],
-    },
-    count: {
-        required: [],
-        optional: [
-            { field: 'filter_field', type: 'string', description: 'Field to filter on.' },
-            { field: 'filter_op', type: 'string', description: 'Filter operator.' },
-            { field: 'filter_value', type: 'string | number | boolean | array', description: 'Filter value.' },
-            { field: 'filter_field_2', type: 'string', description: 'Second filter field.' },
-            { field: 'filter_op_2', type: 'string', description: 'Second filter operator.' },
-            { field: 'filter_value_2', type: 'string | number | boolean | array', description: 'Second filter value.' },
-            { field: 'filter_logic', type: 'string', description: "'and' (default) or 'or'." },
-            { field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array.' },
-            { field: 'recency', type: 'string', description: 'Preset window.' },
-            { field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
-            { field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
-        ],
-    },
-    delete: {
-        required: [{ field: 'id', type: 'number', description: 'Numeric entity ID to delete.' }],
-        optional: [],
-    },
-    whoAmI: {
-        required: [],
-        optional: [{ field: 'fields', type: 'string', description: 'Comma-separated field names to return.' }],
-    },
-    getPosted: {
-        required: [],
-        optional: [
-            { field: 'filter_field', type: 'string', description: 'Field to filter on.' },
-            { field: 'filter_op', type: 'string', description: 'Filter operator.' },
-            { field: 'filter_value', type: 'string | number | boolean | array', description: 'Filter value.' },
-            { field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array.' },
-            { field: 'returnAll', type: 'boolean', description: 'Fetch ALL matching records.' },
-            { field: 'limit', type: 'number', description: 'Max records (1-500, default 10).' },
-            { field: 'recency', type: 'string', description: 'Preset window.' },
-            { field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
-            { field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
-            { field: 'fields', type: 'string', description: 'Comma-separated field names to return.' },
-        ],
-    },
-    getUnposted: {
-        required: [],
-        optional: [
-            { field: 'filter_field', type: 'string', description: 'Field to filter on.' },
-            { field: 'filter_op', type: 'string', description: 'Filter operator.' },
-            { field: 'filter_value', type: 'string | number | boolean | array', description: 'Filter value.' },
-            { field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array.' },
-            { field: 'returnAll', type: 'boolean', description: 'Fetch ALL matching records.' },
-            { field: 'limit', type: 'number', description: 'Max records (1-500, default 10).' },
-            { field: 'recency', type: 'string', description: 'Preset window.' },
-            { field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
-            { field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
-            { field: 'fields', type: 'string', description: 'Comma-separated field names to return.' },
-        ],
-    },
-    searchByDomain: {
-        required: [],
-        optional: [
-            { field: 'domain', type: 'string', description: 'Domain to search, e.g. autotask.net.' },
-            { field: 'domainOperator', type: 'string', description: "Operator: eq, beginsWith, endsWith, contains (default 'contains')." },
-            { field: 'searchContactEmails', type: 'boolean', description: 'Fall back to contact email search if no website match (default true).' },
-            { field: 'fields', type: 'string', description: 'Comma-separated company field names to return.' },
-        ],
-    },
-    slaHealthCheck: {
-        required: [],
-        optional: [
-            { field: 'id', type: 'number', description: 'Numeric Ticket ID (required if ticketNumber not provided).' },
-            { field: 'ticketNumber', type: 'string', description: 'Ticket number T{date}.{seq} (required if id not provided).' },
-            { field: 'ticketFields', type: 'string', description: 'Optional comma-separated ticket fields to return.' },
-        ],
-    },
-    summary: {
-        required: [],
-        optional: [
-            { field: 'id', type: 'number', description: 'Numeric Ticket ID (required if ticketNumber not provided).' },
-            { field: 'ticketNumber', type: 'string', description: 'Ticket number T{date}.{seq} (required if id not provided).' },
-            { field: 'includeRaw', type: 'boolean', description: 'Include full enriched pre-alias payload.' },
-            { field: 'summaryTextLimit', type: 'number', description: 'Max chars for description/resolution fields (default 500, 0=no limit).' },
-            { field: 'includeChildCounts', type: 'boolean', description: 'Include child entity counts (default false, adds API calls).' },
-        ],
-    },
-    moveConfigurationItem: {
-        required: [
-            { field: 'sourceConfigurationItemId', type: 'number', description: 'Source CI ID to clone.' },
-            { field: 'destinationCompanyId', type: 'number', description: 'Destination company ID.' },
-        ],
-        optional: [
-            { field: 'dryRun', type: 'boolean', description: 'Return plan without mutations (default false).' },
-            { field: 'destinationCompanyLocationId', type: 'number', description: 'Optional destination location ID.' },
-            { field: 'copyUdfs', type: 'boolean', description: 'Copy UDFs (default true).' },
-            { field: 'copyAttachments', type: 'boolean', description: 'Copy CI attachments (default true).' },
-            { field: 'copyNotes', type: 'boolean', description: 'Copy notes (default true).' },
-            { field: 'deactivateSource', type: 'boolean', description: 'Deactivate source CI after safety checks (default true).' },
-            { field: 'impersonationResourceId', type: 'number | string', description: 'Resource ID or name for write attribution.' },
-        ],
-    },
-    moveToCompany: {
-        required: [
-            { field: 'sourceContactId', type: 'number', description: 'Source contact ID to move.' },
-            { field: 'destinationCompanyId', type: 'number', description: 'Destination company ID.' },
-        ],
-        optional: [
-            { field: 'dryRun', type: 'boolean', description: 'Return plan without mutations (default false).' },
-            { field: 'skipIfDuplicateEmailFound', type: 'boolean', description: 'Skip move on duplicate email (default true).' },
-            { field: 'copyContactGroups', type: 'boolean', description: 'Copy contact group memberships (default true).' },
-            { field: 'copyCompanyNotes', type: 'boolean', description: 'Copy company notes linked to contact (default true).' },
-            { field: 'impersonationResourceId', type: 'number | string', description: 'Resource ID or name for write attribution.' },
-        ],
-    },
-    transferOwnership: {
-        required: [
-            { field: 'sourceResourceId', type: 'number', description: 'Source resource ID.' },
-            { field: 'destinationResourceId', type: 'number', description: 'Receiving resource ID (must be active).' },
-        ],
-        optional: [
-            { field: 'dryRun', type: 'boolean', description: 'Return plan without mutations (default false).' },
-            { field: 'includeTickets', type: 'boolean', description: 'Include tickets (default false).' },
-            { field: 'includeProjects', type: 'boolean', description: 'Include projects (default false).' },
-            { field: 'includeCompanies', type: 'boolean', description: 'Include companies (default false).' },
-            { field: 'dueWindowPreset', type: 'string', description: "Due window (today, tomorrow, plus7Days, etc. or 'custom' with dueBeforeCustom)." },
-            { field: 'impersonationResourceId', type: 'number | string', description: 'Resource ID or name for write attribution.' },
-        ],
-    },
-    getByResource: {
-        required: [{ field: 'resourceID', type: 'number | string', description: 'Resource ID or name (auto-resolved).' }],
-        optional: [{ field: 'fields', type: 'string', description: 'Comma-separated field names to return.' }],
-    },
-    getByYear: {
-        required: [
-            { field: 'resourceID', type: 'number | string', description: 'Resource ID or name (auto-resolved).' },
-            { field: 'year', type: 'number', description: 'Calendar year (e.g. 2024).' },
-        ],
-        optional: [],
-    },
-    approve: {
-        required: [{ field: 'id', type: 'number', description: 'Numeric entity ID to approve.' }],
-        optional: [],
-    },
-    reject: {
-        required: [{ field: 'id', type: 'number', description: 'Numeric entity ID to reject.' }],
-        optional: [{ field: 'rejectReason', type: 'string', description: 'Reason for rejection (recommended for audit trail).' }],
-    },
-    describeFields: {
-        required: [],
-        optional: [{ field: 'mode', type: 'string', description: "'read' or 'write'. Defaults to 'read'." }],
-    },
-    listPicklistValues: {
-        required: [{ field: 'fieldId', type: 'string', description: 'Field ID to list picklist values for.' }],
-        optional: [
-            { field: 'query', type: 'string', description: 'Optional search term.' },
-            { field: 'limit', type: 'number', description: 'Max results (default 50).' },
-            { field: 'page', type: 'number', description: 'Page number (default 1).' },
-        ],
-    },
-    describeOperation: {
-        required: [{ field: 'targetOperation', type: 'string', description: 'Operation name to document.' }],
-        optional: [],
-    },
+	get: {
+		required: [{ field: 'id', type: 'number', description: 'Numeric entity ID.' }],
+		optional: [
+			{ field: 'fields', type: 'string', description: 'Comma-separated field names to return.' },
+		],
+	},
+	getMany: {
+		required: [],
+		optional: [
+			{ field: 'filter_field', type: 'string', description: 'Field to filter on.' },
+			{
+				field: 'filter_op',
+				type: 'string',
+				description:
+					'Operator: eq, noteq, gt, gte, lt, lte, contains, beginsWith, endsWith, exist, notExist, in, notIn.',
+			},
+			{
+				field: 'filter_value',
+				type: 'string | number | boolean | array',
+				description: 'Filter value. Use arrays for in/notIn.',
+			},
+			{ field: 'filter_field_2', type: 'string', description: 'Second filter field.' },
+			{ field: 'filter_op_2', type: 'string', description: 'Second filter operator.' },
+			{
+				field: 'filter_value_2',
+				type: 'string | number | boolean | array',
+				description: 'Second filter value.',
+			},
+			{ field: 'filter_logic', type: 'string', description: "'and' (default) or 'or'." },
+			{
+				field: 'filtersJson',
+				type: 'string',
+				description:
+					'JSON IFilterCondition array (mutually exclusive with flat filter_field triplets). No label resolution.',
+			},
+			{
+				field: 'returnAll',
+				type: 'boolean',
+				description:
+					'Fetch ALL matching records via API pagination. Response capped at 100 records.',
+			},
+			{ field: 'limit', type: 'number', description: 'Max records (1-500, default 10).' },
+			{ field: 'offset', type: 'number', description: 'Skip first N records (max 499).' },
+			{
+				field: 'recency',
+				type: 'string',
+				description: 'Preset window (last_7d, last_30d, etc.) or custom last_Nd.',
+			},
+			{ field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
+			{ field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
+			{ field: 'fields', type: 'string', description: 'Comma-separated field names to return.' },
+			{ field: 'outputMode', type: 'string', description: "'idsAndLabels' (default) or 'rawIds'." },
+		],
+	},
+	count: {
+		required: [],
+		optional: [
+			{ field: 'filter_field', type: 'string', description: 'Field to filter on.' },
+			{ field: 'filter_op', type: 'string', description: 'Filter operator.' },
+			{
+				field: 'filter_value',
+				type: 'string | number | boolean | array',
+				description: 'Filter value.',
+			},
+			{ field: 'filter_field_2', type: 'string', description: 'Second filter field.' },
+			{ field: 'filter_op_2', type: 'string', description: 'Second filter operator.' },
+			{
+				field: 'filter_value_2',
+				type: 'string | number | boolean | array',
+				description: 'Second filter value.',
+			},
+			{ field: 'filter_logic', type: 'string', description: "'and' (default) or 'or'." },
+			{ field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array.' },
+			{ field: 'recency', type: 'string', description: 'Preset window.' },
+			{ field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
+			{ field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
+		],
+	},
+	delete: {
+		required: [{ field: 'id', type: 'number', description: 'Numeric entity ID to delete.' }],
+		optional: [],
+	},
+	whoAmI: {
+		required: [],
+		optional: [
+			{ field: 'fields', type: 'string', description: 'Comma-separated field names to return.' },
+		],
+	},
+	getPosted: {
+		required: [],
+		optional: [
+			{ field: 'filter_field', type: 'string', description: 'Field to filter on.' },
+			{ field: 'filter_op', type: 'string', description: 'Filter operator.' },
+			{
+				field: 'filter_value',
+				type: 'string | number | boolean | array',
+				description: 'Filter value.',
+			},
+			{ field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array.' },
+			{ field: 'returnAll', type: 'boolean', description: 'Fetch ALL matching records.' },
+			{ field: 'limit', type: 'number', description: 'Max records (1-500, default 10).' },
+			{ field: 'recency', type: 'string', description: 'Preset window.' },
+			{ field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
+			{ field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
+			{ field: 'fields', type: 'string', description: 'Comma-separated field names to return.' },
+		],
+	},
+	getUnposted: {
+		required: [],
+		optional: [
+			{ field: 'filter_field', type: 'string', description: 'Field to filter on.' },
+			{ field: 'filter_op', type: 'string', description: 'Filter operator.' },
+			{
+				field: 'filter_value',
+				type: 'string | number | boolean | array',
+				description: 'Filter value.',
+			},
+			{ field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array.' },
+			{ field: 'returnAll', type: 'boolean', description: 'Fetch ALL matching records.' },
+			{ field: 'limit', type: 'number', description: 'Max records (1-500, default 10).' },
+			{ field: 'recency', type: 'string', description: 'Preset window.' },
+			{ field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
+			{ field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
+			{ field: 'fields', type: 'string', description: 'Comma-separated field names to return.' },
+		],
+	},
+	searchByDomain: {
+		required: [],
+		optional: [
+			{ field: 'domain', type: 'string', description: 'Domain to search, e.g. autotask.net.' },
+			{
+				field: 'domainOperator',
+				type: 'string',
+				description: "Operator: eq, beginsWith, endsWith, contains (default 'contains').",
+			},
+			{
+				field: 'searchContactEmails',
+				type: 'boolean',
+				description: 'Fall back to contact email search if no website match (default true).',
+			},
+			{
+				field: 'fields',
+				type: 'string',
+				description: 'Comma-separated company field names to return.',
+			},
+		],
+	},
+	slaHealthCheck: {
+		required: [],
+		optional: [
+			{
+				field: 'id',
+				type: 'number',
+				description: 'Numeric Ticket ID (required if ticketNumber not provided).',
+			},
+			{
+				field: 'ticketNumber',
+				type: 'string',
+				description: 'Ticket number T{date}.{seq} (required if id not provided).',
+			},
+			{
+				field: 'ticketFields',
+				type: 'string',
+				description: 'Optional comma-separated ticket fields to return.',
+			},
+		],
+	},
+	summary: {
+		required: [],
+		optional: [
+			{
+				field: 'id',
+				type: 'number',
+				description: 'Numeric Ticket ID (required if ticketNumber not provided).',
+			},
+			{
+				field: 'ticketNumber',
+				type: 'string',
+				description: 'Ticket number T{date}.{seq} (required if id not provided).',
+			},
+			{
+				field: 'includeRaw',
+				type: 'boolean',
+				description: 'Include full enriched pre-alias payload.',
+			},
+			{
+				field: 'summaryTextLimit',
+				type: 'number',
+				description: 'Max chars for description/resolution fields (default 500, 0=no limit).',
+			},
+			{
+				field: 'includeChildCounts',
+				type: 'boolean',
+				description: 'Include child entity counts (default false, adds API calls).',
+			},
+		],
+	},
+	moveConfigurationItem: {
+		required: [
+			{ field: 'sourceConfigurationItemId', type: 'number', description: 'Source CI ID to clone.' },
+			{ field: 'destinationCompanyId', type: 'number', description: 'Destination company ID.' },
+		],
+		optional: [
+			{
+				field: 'dryRun',
+				type: 'boolean',
+				description: 'Return plan without mutations (default false).',
+			},
+			{
+				field: 'destinationCompanyLocationId',
+				type: 'number',
+				description: 'Optional destination location ID.',
+			},
+			{ field: 'copyUdfs', type: 'boolean', description: 'Copy UDFs (default true).' },
+			{
+				field: 'copyAttachments',
+				type: 'boolean',
+				description: 'Copy CI attachments (default true).',
+			},
+			{ field: 'copyNotes', type: 'boolean', description: 'Copy notes (default true).' },
+			{
+				field: 'deactivateSource',
+				type: 'boolean',
+				description: 'Deactivate source CI after safety checks (default true).',
+			},
+			{
+				field: 'impersonationResourceId',
+				type: 'number | string',
+				description: 'Resource ID or name for write attribution.',
+			},
+		],
+	},
+	moveToCompany: {
+		required: [
+			{ field: 'sourceContactId', type: 'number', description: 'Source contact ID to move.' },
+			{ field: 'destinationCompanyId', type: 'number', description: 'Destination company ID.' },
+		],
+		optional: [
+			{
+				field: 'dryRun',
+				type: 'boolean',
+				description: 'Return plan without mutations (default false).',
+			},
+			{
+				field: 'skipIfDuplicateEmailFound',
+				type: 'boolean',
+				description: 'Skip move on duplicate email (default true).',
+			},
+			{
+				field: 'copyContactGroups',
+				type: 'boolean',
+				description: 'Copy contact group memberships (default true).',
+			},
+			{
+				field: 'copyCompanyNotes',
+				type: 'boolean',
+				description: 'Copy company notes linked to contact (default true).',
+			},
+			{
+				field: 'impersonationResourceId',
+				type: 'number | string',
+				description: 'Resource ID or name for write attribution.',
+			},
+		],
+	},
+	transferOwnership: {
+		required: [
+			{ field: 'sourceResourceId', type: 'number', description: 'Source resource ID.' },
+			{
+				field: 'destinationResourceId',
+				type: 'number',
+				description: 'Receiving resource ID (must be active).',
+			},
+		],
+		optional: [
+			{
+				field: 'dryRun',
+				type: 'boolean',
+				description: 'Return plan without mutations (default false).',
+			},
+			{ field: 'includeTickets', type: 'boolean', description: 'Include tickets (default false).' },
+			{
+				field: 'includeProjects',
+				type: 'boolean',
+				description: 'Include projects (default false).',
+			},
+			{
+				field: 'includeCompanies',
+				type: 'boolean',
+				description: 'Include companies (default false).',
+			},
+			{
+				field: 'dueWindowPreset',
+				type: 'string',
+				description:
+					"Due window (today, tomorrow, plus7Days, etc. or 'custom' with dueBeforeCustom).",
+			},
+			{
+				field: 'impersonationResourceId',
+				type: 'number | string',
+				description: 'Resource ID or name for write attribution.',
+			},
+		],
+	},
+	getByResource: {
+		required: [
+			{
+				field: 'resourceID',
+				type: 'number | string',
+				description: 'Resource ID or name (auto-resolved).',
+			},
+		],
+		optional: [
+			{ field: 'fields', type: 'string', description: 'Comma-separated field names to return.' },
+		],
+	},
+	getByYear: {
+		required: [
+			{
+				field: 'resourceID',
+				type: 'number | string',
+				description: 'Resource ID or name (auto-resolved).',
+			},
+			{ field: 'year', type: 'number', description: 'Calendar year (e.g. 2024).' },
+		],
+		optional: [],
+	},
+	approve: {
+		required: [{ field: 'id', type: 'number', description: 'Numeric entity ID to approve.' }],
+		optional: [],
+	},
+	reject: {
+		required: [{ field: 'id', type: 'number', description: 'Numeric entity ID to reject.' }],
+		optional: [
+			{
+				field: 'rejectReason',
+				type: 'string',
+				description: 'Reason for rejection (recommended for audit trail).',
+			},
+		],
+	},
+	describeFields: {
+		required: [],
+		optional: [
+			{ field: 'mode', type: 'string', description: "'read' or 'write'. Defaults to 'read'." },
+		],
+	},
+	listPicklistValues: {
+		required: [
+			{ field: 'fieldId', type: 'string', description: 'Field ID to list picklist values for.' },
+		],
+		optional: [
+			{ field: 'query', type: 'string', description: 'Optional search term.' },
+			{ field: 'limit', type: 'number', description: 'Max results (default 50).' },
+			{ field: 'page', type: 'number', description: 'Page number (default 1).' },
+		],
+	},
+	describeOperation: {
+		required: [
+			{ field: 'targetOperation', type: 'string', description: 'Operation name to document.' },
+		],
+		optional: [],
+	},
 };
 
 function buildWriteParams(
-    writeFields: FieldMeta[],
-    includeDedup = false,
+	writeFields: FieldMeta[],
+	includeDedup = false,
 ): { required: OperationParam[]; optional: OperationParam[] } {
-    const required: OperationParam[] = [];
-    const optional: OperationParam[] = [];
-    for (const field of writeFields) {
-        if (field.id === 'id') continue;
-        const param: OperationParam = { field: field.id, type: field.type ?? 'string' };
-        if (field.isReference && field.referencesEntity) {
-            param.type = 'reference';
-            param.target = field.referencesEntity;
-        } else if (field.isPickList && field.allowedValues?.length) {
-            param.type = 'picklist';
-            if (field.allowedValues.length <= 10) {
-                param.values = field.allowedValues.map((v) => `${v.id}=${v.label}`);
-            } else {
-                param.description = `${field.allowedValues.length} values — use listPicklistValues`;
-            }
-        }
-        if (field.required) {
-            required.push(param);
-        } else {
-            optional.push(param);
-        }
-    }
-    if (includeDedup) {
-        optional.push(
-            { field: 'dedupFields', type: 'string[]', description: 'Field names for duplicate detection.' },
-            { field: 'errorOnDuplicate', type: 'boolean', description: 'Error on duplicate instead of skipping (default false).' },
-            { field: 'updateFields', type: 'string[]', description: 'Field names to update when duplicate value differs.' },
-        );
-    }
-    optional.push(
-        { field: 'impersonationResourceId', type: 'number | string', description: 'Resource ID or name for write attribution (auto-resolved).' },
-        { field: 'dryRun', type: 'boolean', description: 'Validate without writing (default false).' },
-    );
-    return { required, optional };
+	const required: OperationParam[] = [];
+	const optional: OperationParam[] = [];
+	for (const field of writeFields) {
+		if (field.id === 'id') continue;
+		const param: OperationParam = { field: field.id, type: field.type ?? 'string' };
+		if (field.isReference && field.referencesEntity) {
+			param.type = 'reference';
+			param.target = field.referencesEntity;
+		} else if (field.isPickList && field.allowedValues?.length) {
+			param.type = 'picklist';
+			if (field.allowedValues.length <= 10) {
+				param.values = field.allowedValues.map((v) => `${v.id}=${v.label}`);
+			} else {
+				param.description = `${field.allowedValues.length} values — use listPicklistValues`;
+			}
+		}
+		if (field.required) {
+			required.push(param);
+		} else {
+			optional.push(param);
+		}
+	}
+	if (includeDedup) {
+		optional.push(
+			{
+				field: 'dedupFields',
+				type: 'string[]',
+				description: 'Field names for duplicate detection.',
+			},
+			{
+				field: 'errorOnDuplicate',
+				type: 'boolean',
+				description: 'Error on duplicate instead of skipping (default false).',
+			},
+			{
+				field: 'updateFields',
+				type: 'string[]',
+				description: 'Field names to update when duplicate value differs.',
+			},
+		);
+	}
+	optional.push(
+		{
+			field: 'impersonationResourceId',
+			type: 'number | string',
+			description: 'Resource ID or name for write attribution (auto-resolved).',
+		},
+		{ field: 'dryRun', type: 'boolean', description: 'Validate without writing (default false).' },
+	);
+	return { required, optional };
 }
 
 function getOperationPurpose(
-    resource: string,
-    resourceLabel: string,
-    operation: string,
-    readFields: FieldMeta[],
-    writeFields: FieldMeta[],
+	resource: string,
+	resourceLabel: string,
+	operation: string,
+	readFields: FieldMeta[],
+	writeFields: FieldMeta[],
 ): string {
-    switch (operation) {
-        case 'get': return buildGetDescription(resourceLabel, resource);
-        case 'getMany': return buildGetManyDescription(resourceLabel, resource, readFields);
-        case 'count': return buildCountDescription(resourceLabel);
-        case 'create': return buildCreateDescription(resourceLabel, resource, writeFields, false);
-        case 'update': return buildUpdateDescription(resourceLabel, resource, false);
-        case 'delete': return buildDeleteDescription(resourceLabel, resource);
-        case 'whoAmI': return buildWhoAmIDescription(resourceLabel);
-        case 'getPosted': return buildPostedTimeEntriesDescription(resource);
-        case 'getUnposted': return buildUnpostedTimeEntriesDescription(resource);
-        case 'searchByDomain': return buildCompanySearchByDomainDescription(resource);
-        case 'slaHealthCheck': return buildTicketSlaHealthCheckDescription(resource);
-        case 'summary': return buildTicketSummaryDescription(resource);
-        case 'moveConfigurationItem': return buildConfigurationItemMoveConfigurationItemDescription(resource);
-        case 'moveToCompany': return buildContactMoveToCompanyDescription(resource);
-        case 'transferOwnership': return buildResourceTransferOwnershipDescription(resource);
-        case 'createIfNotExists': return `Idempotent creation for ${resourceLabel}: checks for duplicates using dedupFields before creating. Returns outcome: created, skipped, updated, or a resource-specific not_found variant.`;
-        case 'getByResource': return `Get ${resourceLabel} record(s) for a specific resource. Provide resourceID as a name or numeric ID (auto-resolved).`;
-        case 'getByYear': return `Get the time-off balance for a specific calendar year. Provide resourceID (name or ID) and year as an integer.`;
-        case 'approve': return `Approve a pending ${resourceLabel} request by numeric ID.`;
-        case 'reject': return `Reject a pending ${resourceLabel} request by numeric ID. Provide an optional rejectReason string.`;
-        case 'describeFields': return buildDescribeFieldsDescription(resourceLabel);
-        case 'listPicklistValues': return buildListPicklistValuesDescription(resourceLabel);
-        case 'describeOperation': return `Returns full documentation for a specific ${resourceLabel} operation — purpose, parameters, and usage notes.`;
-        default: return `Perform ${operation} on ${resourceLabel} records.`;
-    }
+	switch (operation) {
+		case 'get':
+			return buildGetDescription(resourceLabel, resource);
+		case 'getMany':
+			return buildGetManyDescription(resourceLabel, resource, readFields);
+		case 'count':
+			return buildCountDescription(resourceLabel);
+		case 'create':
+			return buildCreateDescription(resourceLabel, resource, writeFields, false);
+		case 'update':
+			return buildUpdateDescription(resourceLabel, resource, false);
+		case 'delete':
+			return buildDeleteDescription(resourceLabel, resource);
+		case 'whoAmI':
+			return buildWhoAmIDescription(resourceLabel);
+		case 'getPosted':
+			return buildPostedTimeEntriesDescription(resource);
+		case 'getUnposted':
+			return buildUnpostedTimeEntriesDescription(resource);
+		case 'searchByDomain':
+			return buildCompanySearchByDomainDescription(resource);
+		case 'slaHealthCheck':
+			return buildTicketSlaHealthCheckDescription(resource);
+		case 'summary':
+			return buildTicketSummaryDescription(resource);
+		case 'moveConfigurationItem':
+			return buildConfigurationItemMoveConfigurationItemDescription(resource);
+		case 'moveToCompany':
+			return buildContactMoveToCompanyDescription(resource);
+		case 'transferOwnership':
+			return buildResourceTransferOwnershipDescription(resource);
+		case 'createIfNotExists':
+			return `Idempotent creation for ${resourceLabel}: checks for duplicates using dedupFields before creating. Returns outcome: created, skipped, updated, or a resource-specific not_found variant.`;
+		case 'getByResource':
+			return `Get ${resourceLabel} record(s) for a specific resource. Provide resourceID as a name or numeric ID (auto-resolved).`;
+		case 'getByYear':
+			return `Get the time-off balance for a specific calendar year. Provide resourceID (name or ID) and year as an integer.`;
+		case 'approve':
+			return `Approve a pending ${resourceLabel} request by numeric ID.`;
+		case 'reject':
+			return `Reject a pending ${resourceLabel} request by numeric ID. Provide an optional rejectReason string.`;
+		case 'describeFields':
+			return buildDescribeFieldsDescription(resourceLabel);
+		case 'listPicklistValues':
+			return buildListPicklistValuesDescription(resourceLabel);
+		case 'describeOperation':
+			return `Returns full documentation for a specific ${resourceLabel} operation — purpose, parameters, and usage notes.`;
+		default:
+			return `Perform ${operation} on ${resourceLabel} records.`;
+	}
 }
 
 function getOperationNotes(operation: string): string[] {
-    switch (operation) {
-        case 'create':
-        case 'update':
-            return [...LABEL_RESOLUTION_NOTES];
-        case 'createIfNotExists':
-            return [...LABEL_RESOLUTION_NOTES, ...DEDUP_NOTES];
-        case 'slaHealthCheck':
-        case 'summary':
-            return [...IDENTIFIER_PAIR_NOTES];
-        case 'getMany':
-        case 'getPosted':
-        case 'getUnposted':
-            return [...LIST_ADVANCED_NOTES];
-        default:
-            return [];
-    }
+	switch (operation) {
+		case 'create':
+		case 'update':
+			return [...LABEL_RESOLUTION_NOTES];
+		case 'createIfNotExists':
+			return [...LABEL_RESOLUTION_NOTES, ...DEDUP_NOTES];
+		case 'slaHealthCheck':
+		case 'summary':
+			return [...IDENTIFIER_PAIR_NOTES];
+		case 'getMany':
+		case 'getPosted':
+		case 'getUnposted':
+			return [...LIST_ADVANCED_NOTES];
+		default:
+			return [];
+	}
 }
 
 /**
@@ -759,21 +1039,27 @@ function getOperationNotes(operation: string): string[] {
  * for write ops; static for read/metadata ops), and usage notes.
  */
 export function buildOperationDoc(
-    resource: string,
-    targetOperation: string,
-    readFields: FieldMeta[],
-    writeFields: FieldMeta[],
+	resource: string,
+	targetOperation: string,
+	readFields: FieldMeta[],
+	writeFields: FieldMeta[],
 ): OperationDoc {
-    const resourceLabel = resource.charAt(0).toUpperCase() + resource.slice(1);
-    const purpose = getOperationPurpose(resource, resourceLabel, targetOperation, readFields, writeFields);
+	const resourceLabel = resource.charAt(0).toUpperCase() + resource.slice(1);
+	const purpose = getOperationPurpose(
+		resource,
+		resourceLabel,
+		targetOperation,
+		readFields,
+		writeFields,
+	);
 
-    let parameters: { required: OperationParam[]; optional: OperationParam[] };
-    if (WRITE_OPS_WITH_FIELD_METADATA.has(targetOperation)) {
-        parameters = buildWriteParams(writeFields, targetOperation === 'createIfNotExists');
-    } else {
-        parameters = READ_OP_PARAMS[targetOperation] ?? { required: [], optional: [] };
-    }
+	let parameters: { required: OperationParam[]; optional: OperationParam[] };
+	if (WRITE_OPS_WITH_FIELD_METADATA.has(targetOperation)) {
+		parameters = buildWriteParams(writeFields, targetOperation === 'createIfNotExists');
+	} else {
+		parameters = READ_OP_PARAMS[targetOperation] ?? { required: [], optional: [] };
+	}
 
-    const notes = getOperationNotes(targetOperation);
-    return { operation: targetOperation, purpose, parameters, notes };
+	const notes = getOperationNotes(targetOperation);
+	return { operation: targetOperation, purpose, parameters, notes };
 }

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -2,6 +2,7 @@ import type { FieldMeta } from '../helpers/aiHelper';
 import { FilterOperators } from '../constants/filters';
 import type { RuntimeZod } from './runtime';
 import { IDENTIFIER_PAIR_OPERATIONS } from '../constants/resource-operations';
+import { safeKeys, summariseFields, traceSchemaBuild } from './debug-trace';
 
 /** Maximum number of picklist values to inline in a field description */
 const MAX_INLINE_PICKLIST_VALUES = 8;
@@ -13,408 +14,865 @@ const LARGE_PICKLIST_THRESHOLD = 15;
  * Build a description string for a field, including picklist value hints when applicable.
  */
 function buildFieldDescription(field: FieldMeta, prefix?: string): string {
-    const parts: string[] = [];
-    if (prefix) {
-        parts.push(prefix);
-    } else {
-        parts.push(field.name);
-    }
-    if (field.required) {
-        parts.push('(required)');
-    }
-    if (field.isPickList && field.allowedValues?.length) {
-        if (field.allowedValues.length <= LARGE_PICKLIST_THRESHOLD) {
-            const vals = field.allowedValues
-                .slice(0, MAX_INLINE_PICKLIST_VALUES)
-                .map((v) => `${v.id}=${v.label}`)
-                .join(', ');
-            const suffix = field.allowedValues.length > MAX_INLINE_PICKLIST_VALUES ? ', ...' : '';
-            parts.push(`[values: ${vals}${suffix}]`);
-        } else {
-            parts.push('[large picklist -- use listPicklistValues for options]');
-        }
-    }
-    if (field.isReference && field.referencesEntity) {
-        parts.push(`(references ${field.referencesEntity} — accepts ID or name)`);
-    }
-    return parts.join(' ');
+	const parts: string[] = [];
+	if (prefix) {
+		parts.push(prefix);
+	} else {
+		parts.push(field.name);
+	}
+	if (field.required) {
+		parts.push('(required)');
+	}
+	if (field.isPickList && field.allowedValues?.length) {
+		if (field.allowedValues.length <= LARGE_PICKLIST_THRESHOLD) {
+			const vals = field.allowedValues
+				.slice(0, MAX_INLINE_PICKLIST_VALUES)
+				.map((v) => `${v.id}=${v.label}`)
+				.join(', ');
+			const suffix = field.allowedValues.length > MAX_INLINE_PICKLIST_VALUES ? ', ...' : '';
+			parts.push(`[values: ${vals}${suffix}]`);
+		} else {
+			parts.push('[large picklist -- use listPicklistValues for options]');
+		}
+	}
+	if (field.isReference && field.referencesEntity) {
+		parts.push(`(references ${field.referencesEntity} — accepts ID or name)`);
+	}
+	return parts.join(' ');
 }
 
 /**
  * Map schema filter_op string to Autotask FilterOperators.
  */
 export function mapFilterOp(op: string): string {
-    const lower = op?.toLowerCase();
-    if (lower === 'like') {
-        return FilterOperators.contains;
-    }
-    // 'and'/'or' are grouping operators, not field-level comparison operators
-    if (lower === 'and' || lower === 'or') {
-        throw new Error(`'${op}' is a grouping operator and cannot be used as a filter_op. Use filter_logic='or' for OR queries between filter pairs.`);
-    }
-    const validKeys = (Object.keys(FilterOperators) as string[]).filter(k => k !== 'and' && k !== 'or');
-    const matchedKey = validKeys.find(k => k.toLowerCase() === lower);
-    if (!matchedKey) {
-        throw new Error(`Unsupported filter operator: '${op}'. Valid operators are: ${validKeys.join(', ')}`);
-    }
-    return (FilterOperators as Record<string, string>)[matchedKey];
+	const lower = op?.toLowerCase();
+	if (lower === 'like') {
+		return FilterOperators.contains;
+	}
+	// 'and'/'or' are grouping operators, not field-level comparison operators
+	if (lower === 'and' || lower === 'or') {
+		throw new Error(
+			`'${op}' is a grouping operator and cannot be used as a filter_op. Use filter_logic='or' for OR queries between filter pairs.`,
+		);
+	}
+	const validKeys = (Object.keys(FilterOperators) as string[]).filter(
+		(k) => k !== 'and' && k !== 'or',
+	);
+	const matchedKey = validKeys.find((k) => k.toLowerCase() === lower);
+	if (!matchedKey) {
+		throw new Error(
+			`Unsupported filter operator: '${op}'. Valid operators are: ${validKeys.join(', ')}`,
+		);
+	}
+	return (FilterOperators as Record<string, string>)[matchedKey];
 }
 
 export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
-    // Enum constants using runtime zod (ensures instanceof checks pass in all n8n versions)
-    const rFilterOpEnum = rz.enum([
-        'eq', 'noteq', 'gt', 'gte', 'lt', 'lte',
-        'contains', 'beginsWith', 'endsWith',
-        'exist', 'notExist', 'in', 'notIn',
-    ]);
-    const rFilterValueSchema = rz.union([
-        rz.string(),
-        rz.number(),
-        rz.boolean(),
-        rz.array(rz.union([rz.string(), rz.number(), rz.boolean()])),
-    ]).describe('Filter value. Use number for numeric fields, true/false for booleans, and arrays or comma-separated values for in/notIn.');
-    const rRecencyEnum = rz.enum([
-        'last_15m', 'last_1h', 'last_4h', 'last_12h', 'last_24h',
-        'last_3d', 'last_7d', 'last_14d', 'last_30d', 'last_90d',
-    ]);
-    const rRecencyCustomDays = rz.string().regex(/^last_\d+d$/).refine(
-        (s) => {
-            const n = parseInt(s.replace(/^last_(\d+)d$/, '$1'), 10);
-            return Number.isFinite(n) && n >= 1 && n <= 365;
-        },
-        { message: 'Custom recency must be last_Nd with N between 1 and 365 (e.g. last_5d, last_45d).' },
-    );
-    const rRecencySchema = rz.union([rRecencyEnum, rRecencyCustomDays]).optional()
-        .describe("Preset time window (e.g. last_7d, last_30d) or custom days as last_Nd with N from 1 to 365 (e.g. last_5d, last_45d). Use EITHER recency OR since/until.");
+	// Enum constants using runtime zod (ensures instanceof checks pass in all n8n versions)
+	const rFilterOpEnum = rz.enum([
+		'eq',
+		'noteq',
+		'gt',
+		'gte',
+		'lt',
+		'lte',
+		'contains',
+		'beginsWith',
+		'endsWith',
+		'exist',
+		'notExist',
+		'in',
+		'notIn',
+	]);
+	const rFilterValueSchema = rz
+		.union([
+			rz.string(),
+			rz.number(),
+			rz.boolean(),
+			rz.array(rz.union([rz.string(), rz.number(), rz.boolean()])),
+		])
+		.describe(
+			'Filter value. Use number for numeric fields, true/false for booleans, and arrays or comma-separated values for in/notIn.',
+		);
+	const rRecencyEnum = rz.enum([
+		'last_15m',
+		'last_1h',
+		'last_4h',
+		'last_12h',
+		'last_24h',
+		'last_3d',
+		'last_7d',
+		'last_14d',
+		'last_30d',
+		'last_90d',
+	]);
+	const rRecencyCustomDays = rz
+		.string()
+		.regex(/^last_\d+d$/)
+		.refine(
+			(s) => {
+				const n = parseInt(s.replace(/^last_(\d+)d$/, '$1'), 10);
+				return Number.isFinite(n) && n >= 1 && n <= 365;
+			},
+			{
+				message:
+					'Custom recency must be last_Nd with N between 1 and 365 (e.g. last_5d, last_45d).',
+			},
+		);
+	const rRecencySchema = rz
+		.union([rRecencyEnum, rRecencyCustomDays])
+		.optional()
+		.describe(
+			'Preset time window (e.g. last_7d, last_30d) or custom days as last_Nd with N from 1 to 365 (e.g. last_5d, last_45d). Use EITHER recency OR since/until.',
+		);
 
-    function buildUnifiedSchema(
-        resource: string,
-        operations: string[],
-        readFields: FieldMeta[],
-        writeFields: FieldMeta[],
-    ) {
-        const allOps = [...new Set([...operations, 'describeFields', 'listPicklistValues', 'describeOperation'])] as [string, ...string[]];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const shape: Record<string, any> = {};
+	function buildUnifiedSchema(
+		resource: string,
+		operations: string[],
+		readFields: FieldMeta[],
+		writeFields: FieldMeta[],
+	) {
+		traceSchemaBuild({
+			phase: 'build-start',
+			resource,
+			summary: {
+				operations,
+				hasListFamilyOps: operations.some((op) =>
+					['getMany', 'count', 'getPosted', 'getUnposted'].includes(op),
+				),
+				hasWriteFamilyOps: operations.some((op) =>
+					['create', 'createIfNotExists', 'update', 'delete'].includes(op),
+				),
+				hasIdentifierPairOps: Boolean(IDENTIFIER_PAIR_OPERATIONS[resource]),
+				readFields: summariseFields(readFields),
+				writeFields: summariseFields(writeFields),
+			},
+		});
+		const allOps = [
+			...new Set([...operations, 'describeFields', 'listPicklistValues', 'describeOperation']),
+		] as [string, ...string[]];
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const shape: Record<string, any> = {};
 
-        const hasGetFamily = operations.some(op =>
-            ['get', 'whoAmI', 'getMany', 'count', 'getPosted', 'getUnposted', 'searchByDomain'].includes(op)
-        );
-        const hasListFamily = operations.some(op =>
-            ['getMany', 'count', 'getPosted', 'getUnposted'].includes(op)
-        );
-        const hasGetOrDelete = operations.some(op => ['get', 'delete'].includes(op));
-        const hasUpdate = operations.includes('update');
-        const hasCreate = operations.includes('create');
-        const hasSlaHealthCheck = operations.includes('slaHealthCheck');
-        const hasSummary = operations.includes('summary');
-        const idPairConfig = IDENTIFIER_PAIR_OPERATIONS[resource];
-        const idPairOps = idPairConfig ? idPairConfig.operations.filter(op => operations.includes(op)) : [];
-        const hasIdPairOps = idPairOps.length > 0;
+		const hasGetFamily = operations.some((op) =>
+			['get', 'whoAmI', 'getMany', 'count', 'getPosted', 'getUnposted', 'searchByDomain'].includes(
+				op,
+			),
+		);
+		const hasListFamily = operations.some((op) =>
+			['getMany', 'count', 'getPosted', 'getUnposted'].includes(op),
+		);
+		const hasGetOrDelete = operations.some((op) => ['get', 'delete'].includes(op));
+		const hasUpdate = operations.includes('update');
+		const hasCreate = operations.includes('create');
+		const hasSlaHealthCheck = operations.includes('slaHealthCheck');
+		const hasSummary = operations.includes('summary');
+		const idPairConfig = IDENTIFIER_PAIR_OPERATIONS[resource];
+		const idPairOps = idPairConfig
+			? idPairConfig.operations.filter((op) => operations.includes(op))
+			: [];
+		const hasIdPairOps = idPairOps.length > 0;
 
-        // operation — required enum
-        let operationDesc = `Operation to perform. One of: ${allOps.join(', ')}`;
-        if (hasIdPairOps && idPairConfig) {
-            operationDesc += ` — NOTE: ${idPairOps.join(' and ')} each require either 'id' (numeric) or '${idPairConfig.altIdField}' (${idPairConfig.altIdFormat}); calls with neither identifier are rejected immediately.`;
-        }
-        shape.operation = rz.enum(allOps).describe(operationDesc);
-        const hasSearchByDomain = operations.includes('searchByDomain');
-        const hasMoveConfigItem = operations.includes('moveConfigurationItem');
-        const hasMoveToCompany = operations.includes('moveToCompany');
-        const hasTransferOwnership = operations.includes('transferOwnership');
-        const hasApproveOrReject = operations.includes('approve') || operations.includes('reject');
-        const hasReject = operations.includes('reject');
-        const hasGetByResource = operations.includes('getByResource');
-        const hasGetByYear = operations.includes('getByYear');
+		// operation — required enum
+		let operationDesc = `Operation to perform. One of: ${allOps.join(', ')}`;
+		if (hasIdPairOps && idPairConfig) {
+			operationDesc += ` — NOTE: ${idPairOps.join(' and ')} each require either 'id' (numeric) or '${idPairConfig.altIdField}' (${idPairConfig.altIdFormat}); calls with neither identifier are rejected immediately.`;
+		}
+		shape.operation = rz.enum(allOps).describe(operationDesc);
+		const hasSearchByDomain = operations.includes('searchByDomain');
+		const hasMoveConfigItem = operations.includes('moveConfigurationItem');
+		const hasMoveToCompany = operations.includes('moveToCompany');
+		const hasTransferOwnership = operations.includes('transferOwnership');
+		const hasApproveOrReject = operations.includes('approve') || operations.includes('reject');
+		const hasReject = operations.includes('reject');
+		const hasGetByResource = operations.includes('getByResource');
+		const hasGetByYear = operations.includes('getByYear');
 
-        // id — used by get, delete, update, identifier-pair ops (e.g. slaHealthCheck, summary), approve, reject
-        if (hasGetOrDelete || hasUpdate || hasIdPairOps || hasApproveOrReject) {
-            const strictIdOps: string[] = [];
-            if (hasGetOrDelete) strictIdOps.push('get', 'delete');
-            if (hasUpdate) strictIdOps.push('update');
-            if (hasApproveOrReject) strictIdOps.push('approve', 'reject');
-            let idDesc = 'Numeric entity ID.';
-            if (strictIdOps.length > 0) {
-                idDesc += ` Required for: ${strictIdOps.join(', ')}.`;
-            }
-            if (hasIdPairOps && idPairConfig) {
-                idDesc += ` For ${idPairOps.join(', ')}: provide 'id' OR '${idPairConfig.altIdField}' — exactly one must be present; calls with neither identifier are rejected immediately with INVALID_FILTER_CONSTRAINT.`;
-            }
-            shape.id = rz.number().optional().describe(idDesc);
-        }
+		// id — used by get, delete, update, identifier-pair ops (e.g. slaHealthCheck, summary), approve, reject
+		if (hasGetOrDelete || hasUpdate || hasIdPairOps || hasApproveOrReject) {
+			const strictIdOps: string[] = [];
+			if (hasGetOrDelete) strictIdOps.push('get', 'delete');
+			if (hasUpdate) strictIdOps.push('update');
+			if (hasApproveOrReject) strictIdOps.push('approve', 'reject');
+			let idDesc = 'Numeric entity ID.';
+			if (strictIdOps.length > 0) {
+				idDesc += ` Required for: ${strictIdOps.join(', ')}.`;
+			}
+			if (hasIdPairOps && idPairConfig) {
+				idDesc += ` For ${idPairOps.join(', ')}: provide 'id' OR '${idPairConfig.altIdField}' — exactly one must be present; calls with neither identifier are rejected immediately with INVALID_FILTER_CONSTRAINT.`;
+			}
+			shape.id = rz.number().optional().describe(idDesc);
+		}
 
-        // resourceID — used by getByResource and getByYear (parent-path operations)
-        if (hasGetByResource || hasGetByYear) {
-            shape.resourceID = rz.union([rz.number(), rz.string()]).optional().describe(
-                'Resource ID or name. Required for getByResource and getByYear operations. Accepts a numeric ID or a human-readable name (auto-resolved).',
-            );
-        }
+		// resourceID — used by getByResource and getByYear (parent-path operations)
+		if (hasGetByResource || hasGetByYear) {
+			shape.resourceID = rz
+				.union([rz.number(), rz.string()])
+				.optional()
+				.describe(
+					'Resource ID or name. Required for getByResource and getByYear operations. Accepts a numeric ID or a human-readable name (auto-resolved).',
+				);
+		}
 
-        // year — used by getByYear
-        if (hasGetByYear) {
-            shape.year = rz.number().int().optional().describe(
-                'Calendar year (e.g. 2024). Required for getByYear operation.',
-            );
-        }
+		// year — used by getByYear
+		if (hasGetByYear) {
+			shape.year = rz
+				.number()
+				.int()
+				.optional()
+				.describe('Calendar year (e.g. 2024). Required for getByYear operation.');
+		}
 
-        // rejectReason — used only by reject
-        if (hasReject) {
-            shape.rejectReason = rz.string().optional().describe('Reason for rejecting the time off request. Recommended for audit trail.');
-        }
+		// rejectReason — used only by reject
+		if (hasReject) {
+			shape.rejectReason = rz
+				.string()
+				.optional()
+				.describe('Reason for rejecting the time off request. Recommended for audit trail.');
+		}
 
-        // fields — column selection
-        if (hasGetFamily || hasCreate) {
-            shape.fields = rz.string().optional().describe(
-                `Comma-separated field names to return. Omit for all fields. Call autotask_${resource} with operation 'describeFields' if unsure.`,
-            );
-        }
+		// fields — column selection
+		if (hasGetFamily || hasCreate) {
+			shape.fields = rz
+				.string()
+				.optional()
+				.describe(
+					`Comma-separated field names to return. Omit for all fields. Call autotask_${resource} with operation 'describeFields' if unsure.`,
+				);
+		}
 
-        // Filter fields for list operations
-        if (hasListFamily) {
-            const fieldNames = readFields.filter(f => !f.udf).map(f => f.id);
-            const filterFieldDesc = "Field to filter on. Use operation 'describeFields' to see valid field names.";
-            shape.filter_field = fieldNames.length > 0
-                ? rz.enum(fieldNames as [string, ...string[]]).optional().describe('Field to filter on')
-                : rz.string().optional().describe(filterFieldDesc);
-            shape.filter_op = rFilterOpEnum.optional().describe('Filter operator (default: eq)');
-            shape.filter_value = rFilterValueSchema.optional();
-            shape.filter_field_2 = fieldNames.length > 0
-                ? rz.enum(fieldNames as [string, ...string[]]).optional().describe('Second field to filter on (optional)')
-                : rz.string().optional().describe('Second field to filter on (optional)');
-            shape.filter_op_2 = rFilterOpEnum.optional().describe('Second filter operator');
-            shape.filter_value_2 = rFilterValueSchema.optional().describe('Second filter value');
-            shape.filter_logic = rz.enum(['and', 'or']).optional().describe(
-                "Logic between filter pairs. Default 'and' (both must match). Use 'or' for either-match queries (e.g. status='Open' OR status='In Progress').",
-            );
-            shape.limit = rz.number().int().min(1).max(500).optional().describe('Max results (1-500, default 10)');
-            shape.offset = rz.number().int().min(0).optional().describe('Skip first N records (for pagination, max 499). Use with limit. Response includes hasMore and nextOffset. Limited to first 500 total records — use narrower filters for larger datasets.');
-            shape.recency = rRecencySchema;
-            shape.since = rz.string().optional().describe(
-                'Range start as a date/time string in your configured timezone (e.g. 2026-01-01T09:00:00). ' +
-                'An explicit UTC offset is also accepted and respected (e.g. 2026-01-01T09:00:00Z). ' +
-                'When set, recency is ignored.',
-            );
-            shape.until = rz.string().optional().describe(
-                'Range end as a date/time string in your configured timezone (e.g. 2026-01-31T17:00:00). ' +
-                'An explicit UTC offset is also accepted and respected (e.g. 2026-01-31T17:00:00Z). ' +
-                'Requires since or recency.',
-            );
-            shape.filtersJson = rz.string().optional().describe(
-                'Advanced filter: JSON array of Autotask IFilterCondition objects. ' +
-                'Mutually exclusive with filter_field/filter_field_2. ' +
-                'Recency/since/until still apply on top when provided. ' +
-                'Label resolution is NOT applied to filtersJson values — pass numeric IDs. ' +
-                'Date/time values in filtersJson must be in UTC (e.g. 2026-01-01T00:00:00Z) — filtersJson bypasses automatic timezone conversion. ' +
-                "Example: '[{\"field\":\"status\",\"op\":\"in\",\"value\":[1,2,3]},{\"op\":\"or\",\"items\":[{\"field\":\"companyID\",\"op\":\"eq\",\"value\":123},{\"field\":\"companyID\",\"op\":\"eq\",\"value\":456}]}]'",
-            );
-            shape.returnAll = rz.boolean().optional().describe(
-                'When true, fetches ALL records matching the filter using API-native pagination. ' +
-                'Default false returns up to limit records. Use with a tight filter — broad queries may return thousands of records. ' +
-                'Response is still subject to MAX_RESPONSE_RECORDS truncation with a note when hit.',
-            );
-            shape.outputMode = rz.enum(['idsAndLabels', 'rawIds']).optional().describe(
-                "Output format. 'idsAndLabels' (default) returns IDs enriched with human-readable labels and resolved picklist values. Use 'rawIds' for lighter responses when processing high-cardinality data or when labels are not needed.",
-            );
-        }
+		// Filter fields for list operations
+		if (hasListFamily) {
+			const fieldNames = readFields.filter((f) => !f.udf).map((f) => f.id);
+			const filterFieldDesc =
+				"Field to filter on. Use operation 'describeFields' to see valid field names.";
+			shape.filter_field =
+				fieldNames.length > 0
+					? rz
+							.enum(fieldNames as [string, ...string[]])
+							.optional()
+							.describe('Field to filter on')
+					: rz.string().optional().describe(filterFieldDesc);
+			shape.filter_op = rFilterOpEnum.optional().describe('Filter operator (default: eq)');
+			shape.filter_value = rFilterValueSchema.optional();
+			shape.filter_field_2 =
+				fieldNames.length > 0
+					? rz
+							.enum(fieldNames as [string, ...string[]])
+							.optional()
+							.describe('Second field to filter on (optional)')
+					: rz.string().optional().describe('Second field to filter on (optional)');
+			shape.filter_op_2 = rFilterOpEnum.optional().describe('Second filter operator');
+			shape.filter_value_2 = rFilterValueSchema.optional().describe('Second filter value');
+			shape.filter_logic = rz
+				.enum(['and', 'or'])
+				.optional()
+				.describe(
+					"Logic between filter pairs. Default 'and' (both must match). Use 'or' for either-match queries (e.g. status='Open' OR status='In Progress').",
+				);
+			shape.limit = rz
+				.number()
+				.int()
+				.min(1)
+				.max(500)
+				.optional()
+				.describe('Max results (1-500, default 10)');
+			shape.offset = rz
+				.number()
+				.int()
+				.min(0)
+				.optional()
+				.describe(
+					'Skip first N records (for pagination, max 499). Use with limit. Response includes hasMore and nextOffset. Limited to first 500 total records — use narrower filters for larger datasets.',
+				);
+			shape.recency = rRecencySchema;
+			shape.since = rz
+				.string()
+				.optional()
+				.describe(
+					'Range start as a date/time string in your configured timezone (e.g. 2026-01-01T09:00:00). ' +
+						'An explicit UTC offset is also accepted and respected (e.g. 2026-01-01T09:00:00Z). ' +
+						'When set, recency is ignored.',
+				);
+			shape.until = rz
+				.string()
+				.optional()
+				.describe(
+					'Range end as a date/time string in your configured timezone (e.g. 2026-01-31T17:00:00). ' +
+						'An explicit UTC offset is also accepted and respected (e.g. 2026-01-31T17:00:00Z). ' +
+						'Requires since or recency.',
+				);
+			shape.filtersJson = rz
+				.string()
+				.optional()
+				.describe(
+					'Advanced filter: JSON array of Autotask IFilterCondition objects. ' +
+						'Mutually exclusive with filter_field/filter_field_2. ' +
+						'Recency/since/until still apply on top when provided. ' +
+						'Label resolution is NOT applied to filtersJson values — pass numeric IDs. ' +
+						'Date/time values in filtersJson must be in UTC (e.g. 2026-01-01T00:00:00Z) — filtersJson bypasses automatic timezone conversion. ' +
+						'Example: \'[{"field":"status","op":"in","value":[1,2,3]},{"op":"or","items":[{"field":"companyID","op":"eq","value":123},{"field":"companyID","op":"eq","value":456}]}]\'',
+				);
+			shape.returnAll = rz
+				.boolean()
+				.optional()
+				.describe(
+					'When true, fetches ALL records matching the filter using API-native pagination. ' +
+						'Default false returns up to limit records. Use with a tight filter — broad queries may return thousands of records. ' +
+						'Response is still subject to MAX_RESPONSE_RECORDS truncation with a note when hit.',
+				);
+			shape.outputMode = rz
+				.enum(['idsAndLabels', 'rawIds'])
+				.optional()
+				.describe(
+					"Output format. 'idsAndLabels' (default) returns IDs enriched with human-readable labels and resolved picklist values. Use 'rawIds' for lighter responses when processing high-cardinality data or when labels are not needed.",
+				);
+		}
 
-        // searchByDomain fields
-        if (hasSearchByDomain) {
-            shape.domain = rz.string().min(1).optional().describe('Domain to search, e.g. autotask.net or https://www.autotask.net/');
-            shape.domainOperator = rz.enum(['eq', 'beginsWith', 'endsWith', 'contains']).optional()
-                .describe("Domain comparison operator (default 'contains').");
-            shape.searchContactEmails = rz.boolean().optional()
-                .describe('When true (default), fall back to contact email search if no website match.');
-        }
+		// searchByDomain fields
+		if (hasSearchByDomain) {
+			shape.domain = rz
+				.string()
+				.min(1)
+				.optional()
+				.describe('Domain to search, e.g. autotask.net or https://www.autotask.net/');
+			shape.domainOperator = rz
+				.enum(['eq', 'beginsWith', 'endsWith', 'contains'])
+				.optional()
+				.describe("Domain comparison operator (default 'contains').");
+			shape.searchContactEmails = rz
+				.boolean()
+				.optional()
+				.describe('When true (default), fall back to contact email search if no website match.');
+		}
 
-        // slaHealthCheck fields
-        if (hasSlaHealthCheck) {
-            shape.ticketFields = rz.string().optional().describe('Optional comma-separated ticket fields to return.');
-        }
+		// slaHealthCheck fields
+		if (hasSlaHealthCheck) {
+			shape.ticketFields = rz
+				.string()
+				.optional()
+				.describe('Optional comma-separated ticket fields to return.');
+		}
 
-        // summary fields
-        if (hasSummary) {
-            shape.includeRaw = rz.boolean().optional().describe('When true, includes the enriched pre-alias-rename payload: label and UDF enrichments intact, original changeInfoField{N} keys (not aliased names), no null filtering or truncation. Use _meta.aliasMap for changeInfo key mapping.');
-            shape.summaryTextLimit = rz.number().optional().describe('Maximum characters for description and resolution fields in the summary. Default 500. Pass 0 for no limit.');
-            shape.includeChildCounts = rz.boolean().optional().describe('When true, fetches child entity counts (notes, time entries, attachments, etc.) and includes the childCounts block. Default false. Set true when counts are needed — adds several parallel API calls.');
-        }
+		// summary fields
+		if (hasSummary) {
+			shape.includeRaw = rz
+				.boolean()
+				.optional()
+				.describe(
+					'When true, includes the enriched pre-alias-rename payload: label and UDF enrichments intact, original changeInfoField{N} keys (not aliased names), no null filtering or truncation. Use _meta.aliasMap for changeInfo key mapping.',
+				);
+			shape.summaryTextLimit = rz
+				.number()
+				.optional()
+				.describe(
+					'Maximum characters for description and resolution fields in the summary. Default 500. Pass 0 for no limit.',
+				);
+			shape.includeChildCounts = rz
+				.boolean()
+				.optional()
+				.describe(
+					'When true, fetches child entity counts (notes, time entries, attachments, etc.) and includes the childCounts block. Default false. Set true when counts are needed — adds several parallel API calls.',
+				);
+		}
 
-        // Identifier-pair altIdField (e.g. ticketNumber for slaHealthCheck + summary)
-        if (hasIdPairOps && idPairConfig && !shape[idPairConfig.altIdField]) {
-            shape[idPairConfig.altIdField] = rz.string().optional().describe(
-                `Alternative identifier for ${idPairOps.join(', ')}. Format: ${idPairConfig.altIdFormat} (e.g. ${idPairConfig.altIdExample}). Provide this OR numeric 'id' — exactly one MUST be present for these operations; calls with neither identifier are rejected immediately.`,
-            );
-        }
+		// Identifier-pair altIdField (e.g. ticketNumber for slaHealthCheck + summary)
+		if (hasIdPairOps && idPairConfig && !shape[idPairConfig.altIdField]) {
+			shape[idPairConfig.altIdField] = rz
+				.string()
+				.optional()
+				.describe(
+					`Alternative identifier for ${idPairOps.join(', ')}. Format: ${idPairConfig.altIdFormat} (e.g. ${idPairConfig.altIdExample}). Provide this OR numeric 'id' — exactly one MUST be present for these operations; calls with neither identifier are rejected immediately.`,
+				);
+		}
 
-        // create / update fields from metadata
-        if (hasCreate || hasUpdate) {
-            for (const field of writeFields) {
-                if (field.id === 'id') continue;
-                if (shape[field.id]) continue;
-                const desc = buildFieldDescription(field);
-                // Picklist and reference fields accept string|number so the LLM can pass
-                // human-readable labels (e.g. "Will Spence") which the executor auto-resolves to IDs.
-                const needsLabelResolution = field.isPickList || field.isReference;
-                const base = needsLabelResolution ? rz.union([rz.number(), rz.string()])
-                    : field.type === 'number' ? rz.number()
-                    : field.type === 'boolean' ? rz.boolean()
-                    : rz.string();
-                shape[field.id] = base.optional().describe(desc);
-            }
-            if (!shape.impersonationResourceId) {
-                shape.impersonationResourceId = rz.union([rz.number(), rz.string()]).optional()
-                    .describe('Optional resource ID or name to impersonate for write attribution. Accepts a numeric ID, full name (e.g. "Bob Smith"), or email address — names and emails are auto-resolved to resource IDs.');
-                shape.proceedWithoutImpersonationIfDenied = rz.boolean().optional()
-                    .describe('When true and impersonation is set, retry without impersonation if denied (default true).');
-            }
-            if (!shape.dryRun)
-                shape.dryRun = rz.boolean().optional().describe('When true, resolves labels and validates fields but makes no API call (default false). Returns a summary of resolved field values.');
-        }
+		// create / update fields from metadata
+		if (hasCreate || hasUpdate) {
+			for (const field of writeFields) {
+				if (field.id === 'id') continue;
+				if (shape[field.id]) continue;
+				const desc = buildFieldDescription(field);
+				// Picklist and reference fields accept string|number so the LLM can pass
+				// human-readable labels (e.g. "Will Spence") which the executor auto-resolves to IDs.
+				const needsLabelResolution = field.isPickList || field.isReference;
+				const base = needsLabelResolution
+					? rz.union([rz.number(), rz.string()])
+					: field.type === 'number'
+						? rz.number()
+						: field.type === 'boolean'
+							? rz.boolean()
+							: rz.string();
+				shape[field.id] = base.optional().describe(desc);
+			}
+			if (!shape.impersonationResourceId) {
+				shape.impersonationResourceId = rz
+					.union([rz.number(), rz.string()])
+					.optional()
+					.describe(
+						'Optional resource ID or name to impersonate for write attribution. Accepts a numeric ID, full name (e.g. "Bob Smith"), or email address — names and emails are auto-resolved to resource IDs.',
+					);
+				shape.proceedWithoutImpersonationIfDenied = rz
+					.boolean()
+					.optional()
+					.describe(
+						'When true and impersonation is set, retry without impersonation if denied (default true).',
+					);
+			}
+			if (!shape.dryRun)
+				shape.dryRun = rz
+					.boolean()
+					.optional()
+					.describe(
+						'When true, resolves labels and validates fields but makes no API call (default false). Returns a summary of resolved field values.',
+					);
+		}
 
-        // moveConfigurationItem fields
-        if (hasMoveConfigItem) {
-            if (!shape.sourceConfigurationItemId)
-                shape.sourceConfigurationItemId = rz.number().int().positive().optional().describe('Source configuration item ID to clone.');
-            if (!shape.destinationCompanyId)
-                shape.destinationCompanyId = rz.number().int().positive().optional().describe('Destination company ID.');
-            if (!shape.dryRun)
-                shape.dryRun = rz.boolean().optional().describe('When true, return a plan without mutations (default false).');
-            shape.destinationCompanyLocationId = rz.number().int().positive().optional().describe('Optional destination company location ID.');
-            shape.destinationContactId = rz.number().int().positive().optional().describe('Optional destination contact ID.');
-            shape.copyUdfs = rz.boolean().optional().describe('Whether to copy user-defined fields (default true).');
-            shape.copyAttachments = rz.boolean().optional().describe('Whether to copy CI attachments (default true).');
-            shape.copyNotes = rz.boolean().optional().describe('Whether to copy notes (default true).');
-            shape.copyNoteAttachments = rz.boolean().optional().describe('Whether to copy note attachments (default true).');
-            shape.deactivateSource = rz.boolean().optional().describe('Whether to deactivate the source CI after safety checks (default true).');
-            shape.idempotencyKey = rz.string().optional().describe('Optional run key for traceability.');
-            shape.includeMaskedUdfsPolicy = rz.enum(['omit', 'fail']).optional().describe("How to handle masked UDFs: 'omit' (default) or 'fail'.");
-            shape.attachmentOversizePolicy = rz.enum(['skip+note', 'fail']).optional().describe("How to handle oversize attachments: 'skip+note' (default) or 'fail'.");
-            shape.partialFailureStrategy = rz.enum(['deactivateDestination', 'leaveActiveWithNote']).optional()
-                .describe("How to handle partial failure after destination create: 'deactivateDestination' (default) or 'leaveActiveWithNote'.");
-            shape.retryMaxRetries = rz.number().int().min(0).max(10).optional().describe('Retry max attempts for transient errors (default 3).');
-            shape.retryBaseDelayMs = rz.number().int().min(50).max(60000).optional().describe('Retry base delay in milliseconds (default 500).');
-            shape.retryJitter = rz.boolean().optional().describe('Whether to use jitter in retry backoff (default true).');
-            shape.throttleMaxBytesPer5Min = rz.number().int().min(1).optional().describe('Upload throughput limit in bytes per 5 minutes (default 10000000).');
-            shape.throttleMaxSingleFileBytes = rz.number().int().min(1).optional().describe('Maximum attachment size per file in bytes (default 6291456).');
-            if (!shape.impersonationResourceId) {
-                shape.impersonationResourceId = rz.union([rz.number(), rz.string()]).optional().describe('Optional resource ID or name to impersonate for write attribution. Accepts a numeric ID, full name, or email — auto-resolved.');
-                shape.proceedWithoutImpersonationIfDenied = rz.boolean().optional().describe('When true and impersonation is set, retry without impersonation if denied (default true).');
-            }
-        }
+		// moveConfigurationItem fields
+		if (hasMoveConfigItem) {
+			if (!shape.sourceConfigurationItemId)
+				shape.sourceConfigurationItemId = rz
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.describe('Source configuration item ID to clone.');
+			if (!shape.destinationCompanyId)
+				shape.destinationCompanyId = rz
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.describe('Destination company ID.');
+			if (!shape.dryRun)
+				shape.dryRun = rz
+					.boolean()
+					.optional()
+					.describe('When true, return a plan without mutations (default false).');
+			shape.destinationCompanyLocationId = rz
+				.number()
+				.int()
+				.positive()
+				.optional()
+				.describe('Optional destination company location ID.');
+			shape.destinationContactId = rz
+				.number()
+				.int()
+				.positive()
+				.optional()
+				.describe('Optional destination contact ID.');
+			shape.copyUdfs = rz
+				.boolean()
+				.optional()
+				.describe('Whether to copy user-defined fields (default true).');
+			shape.copyAttachments = rz
+				.boolean()
+				.optional()
+				.describe('Whether to copy CI attachments (default true).');
+			shape.copyNotes = rz.boolean().optional().describe('Whether to copy notes (default true).');
+			shape.copyNoteAttachments = rz
+				.boolean()
+				.optional()
+				.describe('Whether to copy note attachments (default true).');
+			shape.deactivateSource = rz
+				.boolean()
+				.optional()
+				.describe('Whether to deactivate the source CI after safety checks (default true).');
+			shape.idempotencyKey = rz.string().optional().describe('Optional run key for traceability.');
+			shape.includeMaskedUdfsPolicy = rz
+				.enum(['omit', 'fail'])
+				.optional()
+				.describe("How to handle masked UDFs: 'omit' (default) or 'fail'.");
+			shape.attachmentOversizePolicy = rz
+				.enum(['skip+note', 'fail'])
+				.optional()
+				.describe("How to handle oversize attachments: 'skip+note' (default) or 'fail'.");
+			shape.partialFailureStrategy = rz
+				.enum(['deactivateDestination', 'leaveActiveWithNote'])
+				.optional()
+				.describe(
+					"How to handle partial failure after destination create: 'deactivateDestination' (default) or 'leaveActiveWithNote'.",
+				);
+			shape.retryMaxRetries = rz
+				.number()
+				.int()
+				.min(0)
+				.max(10)
+				.optional()
+				.describe('Retry max attempts for transient errors (default 3).');
+			shape.retryBaseDelayMs = rz
+				.number()
+				.int()
+				.min(50)
+				.max(60000)
+				.optional()
+				.describe('Retry base delay in milliseconds (default 500).');
+			shape.retryJitter = rz
+				.boolean()
+				.optional()
+				.describe('Whether to use jitter in retry backoff (default true).');
+			shape.throttleMaxBytesPer5Min = rz
+				.number()
+				.int()
+				.min(1)
+				.optional()
+				.describe('Upload throughput limit in bytes per 5 minutes (default 10000000).');
+			shape.throttleMaxSingleFileBytes = rz
+				.number()
+				.int()
+				.min(1)
+				.optional()
+				.describe('Maximum attachment size per file in bytes (default 6291456).');
+			if (!shape.impersonationResourceId) {
+				shape.impersonationResourceId = rz
+					.union([rz.number(), rz.string()])
+					.optional()
+					.describe(
+						'Optional resource ID or name to impersonate for write attribution. Accepts a numeric ID, full name, or email — auto-resolved.',
+					);
+				shape.proceedWithoutImpersonationIfDenied = rz
+					.boolean()
+					.optional()
+					.describe(
+						'When true and impersonation is set, retry without impersonation if denied (default true).',
+					);
+			}
+		}
 
-        // moveToCompany fields
-        if (hasMoveToCompany) {
-            if (!shape.sourceContactId)
-                shape.sourceContactId = rz.number().int().positive().optional().describe('Source contact ID to move.');
-            if (!shape.destinationCompanyId)
-                shape.destinationCompanyId = rz.number().int().positive().optional().describe('Destination company ID for the cloned contact.');
-            if (!shape.dryRun)
-                shape.dryRun = rz.boolean().optional().describe('When true, returns a plan without mutations (default false).');
-            shape.destinationCompanyLocationId = rz.number().int().positive().optional().describe('Optional destination company location ID.');
-            shape.skipIfDuplicateEmailFound = rz.boolean().optional().describe('Whether to skip move when duplicate email exists on destination (default true).');
-            shape.copyContactGroups = rz.boolean().optional().describe('Whether to copy contact group memberships (default true).');
-            shape.copyCompanyNotes = rz.boolean().optional().describe('Whether to copy company notes linked to the contact (default true).');
-            shape.copyNoteAttachments = rz.boolean().optional().describe('Whether to copy attachments for copied notes (default true).');
-            shape.sourceAuditNote = rz.string().optional().describe('Optional audit note written to the source company context.');
-            shape.destinationAuditNote = rz.string().optional().describe('Optional audit note written to the destination company context.');
-            if (!shape.impersonationResourceId) {
-                shape.impersonationResourceId = rz.union([rz.number(), rz.string()]).optional().describe('Optional resource ID or name to impersonate for write attribution. Accepts a numeric ID, full name, or email — auto-resolved.');
-                shape.proceedWithoutImpersonationIfDenied = rz.boolean().optional().describe('When true and impersonation is set, retry without impersonation if denied (default true).');
-            }
-        }
+		// moveToCompany fields
+		if (hasMoveToCompany) {
+			if (!shape.sourceContactId)
+				shape.sourceContactId = rz
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.describe('Source contact ID to move.');
+			if (!shape.destinationCompanyId)
+				shape.destinationCompanyId = rz
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.describe('Destination company ID for the cloned contact.');
+			if (!shape.dryRun)
+				shape.dryRun = rz
+					.boolean()
+					.optional()
+					.describe('When true, returns a plan without mutations (default false).');
+			shape.destinationCompanyLocationId = rz
+				.number()
+				.int()
+				.positive()
+				.optional()
+				.describe('Optional destination company location ID.');
+			shape.skipIfDuplicateEmailFound = rz
+				.boolean()
+				.optional()
+				.describe(
+					'Whether to skip move when duplicate email exists on destination (default true).',
+				);
+			shape.copyContactGroups = rz
+				.boolean()
+				.optional()
+				.describe('Whether to copy contact group memberships (default true).');
+			shape.copyCompanyNotes = rz
+				.boolean()
+				.optional()
+				.describe('Whether to copy company notes linked to the contact (default true).');
+			shape.copyNoteAttachments = rz
+				.boolean()
+				.optional()
+				.describe('Whether to copy attachments for copied notes (default true).');
+			shape.sourceAuditNote = rz
+				.string()
+				.optional()
+				.describe('Optional audit note written to the source company context.');
+			shape.destinationAuditNote = rz
+				.string()
+				.optional()
+				.describe('Optional audit note written to the destination company context.');
+			if (!shape.impersonationResourceId) {
+				shape.impersonationResourceId = rz
+					.union([rz.number(), rz.string()])
+					.optional()
+					.describe(
+						'Optional resource ID or name to impersonate for write attribution. Accepts a numeric ID, full name, or email — auto-resolved.',
+					);
+				shape.proceedWithoutImpersonationIfDenied = rz
+					.boolean()
+					.optional()
+					.describe(
+						'When true and impersonation is set, retry without impersonation if denied (default true).',
+					);
+			}
+		}
 
-        // transferOwnership fields
-        if (hasTransferOwnership) {
-            if (!shape.sourceResourceId)
-                shape.sourceResourceId = rz.number().int().positive().optional().describe('Source resource ID currently assigned to work. Can be inactive.');
-            if (!shape.destinationResourceId)
-                shape.destinationResourceId = rz.number().int().positive().optional().describe('Receiving resource ID. Must be active.');
-            if (!shape.dryRun)
-                shape.dryRun = rz.boolean().optional().describe('When true, returns a plan without mutations (default false).');
-            shape.includeTickets = rz.boolean().optional().describe('Whether to include tickets (default false).');
-            shape.includeProjects = rz.boolean().optional().describe('Whether to include projects (default false).');
-            shape.includeServiceCallAssignments = rz.boolean().optional().describe('Whether to reassign service call task/ticket resources (default false).');
-            shape.includeAppointments = rz.boolean().optional().describe('Whether to reassign appointments (default false).');
-            shape.includeCompanies = rz.boolean().optional().describe('Whether to transfer companies owned by the source resource (default false).');
-            shape.companyIdAllowlist = rz.string().optional().describe('Optional comma-separated company IDs to scope company transfer.');
-            shape.includeOpportunities = rz.boolean().optional().describe('Whether to transfer opportunities owned by the source resource (default false).');
-            shape.dueWindowPreset = rz.enum(['today','tomorrow','plus2Days','plus3Days','plus4Days','plus5Days','plus7Days','plus14Days','plus30Days','custom']).optional()
-                .describe("Optional due window preset. Use 'custom' with dueBeforeCustom.");
-            shape.dueBeforeCustom = rz.string().optional().describe("Required when dueWindowPreset is 'custom'. Accepts YYYY-MM-DD or ISO-8601 datetime.");
-            shape.onlyOpenActive = rz.boolean().optional().describe('When true, excludes terminal statuses (default true).');
-            shape.includeItemsWithNoDueDate = rz.boolean().optional().describe('Whether items with no due date are included (default true, unless due window is set).');
-            shape.ticketAssignmentMode = rz.enum(['primaryOnly', 'primaryAndSecondary']).optional().describe('Ticket assignment scope (default primaryOnly).');
-            shape.projectReassignMode = rz.enum(['leadOnly','leadAndTasks','leadTasksAndSecondary','tasksOnly','tasksAndSecondary']).optional()
-                .describe('Project reassignment scope (default leadAndTasks).');
-            shape.maxItemsPerEntity = rz.number().int().min(1).max(10000).optional().describe('Safety cap per entity type (default 500).');
-            shape.maxCompanies = rz.number().int().min(1).max(10000).optional().describe('Safety cap for companies (default 500).');
-            shape.statusAllowlistByLabel = rz.string().optional().describe('Optional comma-separated status labels to include.');
-            shape.statusAllowlistByValue = rz.string().optional().describe('Optional comma-separated status integer values to include.');
-            shape.addAuditNotes = rz.boolean().optional().describe('Whether to create per-entity audit notes (default false).');
-            shape.auditNoteTemplate = rz.string().optional()
-                .describe('Audit note template with placeholders: {sourceResourceName}, {sourceResourceId}, {destinationResourceName}, {destinationResourceId}, {date}, {entityType}, {entityId}.');
-            if (!shape.impersonationResourceId) {
-                shape.impersonationResourceId = rz.union([rz.number(), rz.string()]).optional().describe('Optional resource ID or name to impersonate for write attribution. Accepts a numeric ID, full name, or email — auto-resolved.');
-                shape.proceedWithoutImpersonationIfDenied = rz.boolean().optional().describe('When true and impersonation is set, retry without impersonation if denied (default true).');
-            }
-        }
+		// transferOwnership fields
+		if (hasTransferOwnership) {
+			if (!shape.sourceResourceId)
+				shape.sourceResourceId = rz
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.describe('Source resource ID currently assigned to work. Can be inactive.');
+			if (!shape.destinationResourceId)
+				shape.destinationResourceId = rz
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.describe('Receiving resource ID. Must be active.');
+			if (!shape.dryRun)
+				shape.dryRun = rz
+					.boolean()
+					.optional()
+					.describe('When true, returns a plan without mutations (default false).');
+			shape.includeTickets = rz
+				.boolean()
+				.optional()
+				.describe('Whether to include tickets (default false).');
+			shape.includeProjects = rz
+				.boolean()
+				.optional()
+				.describe('Whether to include projects (default false).');
+			shape.includeServiceCallAssignments = rz
+				.boolean()
+				.optional()
+				.describe('Whether to reassign service call task/ticket resources (default false).');
+			shape.includeAppointments = rz
+				.boolean()
+				.optional()
+				.describe('Whether to reassign appointments (default false).');
+			shape.includeCompanies = rz
+				.boolean()
+				.optional()
+				.describe('Whether to transfer companies owned by the source resource (default false).');
+			shape.companyIdAllowlist = rz
+				.string()
+				.optional()
+				.describe('Optional comma-separated company IDs to scope company transfer.');
+			shape.includeOpportunities = rz
+				.boolean()
+				.optional()
+				.describe(
+					'Whether to transfer opportunities owned by the source resource (default false).',
+				);
+			shape.dueWindowPreset = rz
+				.enum([
+					'today',
+					'tomorrow',
+					'plus2Days',
+					'plus3Days',
+					'plus4Days',
+					'plus5Days',
+					'plus7Days',
+					'plus14Days',
+					'plus30Days',
+					'custom',
+				])
+				.optional()
+				.describe("Optional due window preset. Use 'custom' with dueBeforeCustom.");
+			shape.dueBeforeCustom = rz
+				.string()
+				.optional()
+				.describe(
+					"Required when dueWindowPreset is 'custom'. Accepts YYYY-MM-DD or ISO-8601 datetime.",
+				);
+			shape.onlyOpenActive = rz
+				.boolean()
+				.optional()
+				.describe('When true, excludes terminal statuses (default true).');
+			shape.includeItemsWithNoDueDate = rz
+				.boolean()
+				.optional()
+				.describe(
+					'Whether items with no due date are included (default true, unless due window is set).',
+				);
+			shape.ticketAssignmentMode = rz
+				.enum(['primaryOnly', 'primaryAndSecondary'])
+				.optional()
+				.describe('Ticket assignment scope (default primaryOnly).');
+			shape.projectReassignMode = rz
+				.enum([
+					'leadOnly',
+					'leadAndTasks',
+					'leadTasksAndSecondary',
+					'tasksOnly',
+					'tasksAndSecondary',
+				])
+				.optional()
+				.describe('Project reassignment scope (default leadAndTasks).');
+			shape.maxItemsPerEntity = rz
+				.number()
+				.int()
+				.min(1)
+				.max(10000)
+				.optional()
+				.describe('Safety cap per entity type (default 500).');
+			shape.maxCompanies = rz
+				.number()
+				.int()
+				.min(1)
+				.max(10000)
+				.optional()
+				.describe('Safety cap for companies (default 500).');
+			shape.statusAllowlistByLabel = rz
+				.string()
+				.optional()
+				.describe('Optional comma-separated status labels to include.');
+			shape.statusAllowlistByValue = rz
+				.string()
+				.optional()
+				.describe('Optional comma-separated status integer values to include.');
+			shape.addAuditNotes = rz
+				.boolean()
+				.optional()
+				.describe('Whether to create per-entity audit notes (default false).');
+			shape.auditNoteTemplate = rz
+				.string()
+				.optional()
+				.describe(
+					'Audit note template with placeholders: {sourceResourceName}, {sourceResourceId}, {destinationResourceName}, {destinationResourceId}, {date}, {entityType}, {entityId}.',
+				);
+			if (!shape.impersonationResourceId) {
+				shape.impersonationResourceId = rz
+					.union([rz.number(), rz.string()])
+					.optional()
+					.describe(
+						'Optional resource ID or name to impersonate for write attribution. Accepts a numeric ID, full name, or email — auto-resolved.',
+					);
+				shape.proceedWithoutImpersonationIfDenied = rz
+					.boolean()
+					.optional()
+					.describe(
+						'When true and impersonation is set, retry without impersonation if denied (default true).',
+					);
+			}
+		}
 
-        // createIfNotExists — reuse dynamic writeFields + add dedup/error fields
-        const hasCreateIfNotExists = operations.includes('createIfNotExists');
-        if (hasCreateIfNotExists) {
-            // If create/update already ran, writeFields are already in shape.
-            // Otherwise, populate them now using the same dynamic loop.
-            if (!hasCreate && !hasUpdate) {
-                for (const field of writeFields) {
-                    if (field.id === 'id') continue;
-                    if (shape[field.id]) continue;
-                    const desc = buildFieldDescription(field);
-                    const needsLabelResolution = field.isPickList || field.isReference;
-                    const base = needsLabelResolution ? rz.union([rz.number(), rz.string()])
-                        : field.type === 'number' ? rz.number()
-                        : field.type === 'boolean' ? rz.boolean()
-                        : rz.string();
-                    shape[field.id] = base.optional().describe(desc);
-                }
-            }
-            // createIfNotExists-specific fields
-            if (!shape.dedupFields)
-                shape.dedupFields = rz.array(rz.string()).optional()
-                    .describe('Field names for duplicate detection. Use describeFields to discover available field names. Empty = skip dedup, always create.');
-            if (!shape.updateFields)
-                shape.updateFields = rz.array(rz.string()).optional()
-                    .describe('Field names to compare against the duplicate record. If a value differs from the desired value, the duplicate will be updated. Leave empty to skip update comparison. Ignored when errorOnDuplicate is true.');
-            if (!shape.errorOnDuplicate)
-                shape.errorOnDuplicate = rz.boolean().optional()
-                    .describe('When true, throw an error if a duplicate is found instead of returning a skipped outcome. Default false.');
-            if (!shape.impersonationResourceId) {
-                shape.impersonationResourceId = rz.union([rz.number(), rz.string()]).optional()
-                    .describe('Optional resource ID or name to impersonate for write attribution. Accepts a numeric ID, full name, or email — auto-resolved.');
-                shape.proceedWithoutImpersonationIfDenied = rz.boolean().optional()
-                    .describe('When true and impersonation is set, retry without impersonation if denied (default true).');
-            }
-            if (!shape.dryRun)
-                shape.dryRun = rz.boolean().optional().describe('When true, resolves labels and validates fields but makes no API call (default false). Returns a summary of resolved field values.');
-        }
+		// createIfNotExists — reuse dynamic writeFields + add dedup/error fields
+		const hasCreateIfNotExists = operations.includes('createIfNotExists');
+		if (hasCreateIfNotExists) {
+			// If create/update already ran, writeFields are already in shape.
+			// Otherwise, populate them now using the same dynamic loop.
+			if (!hasCreate && !hasUpdate) {
+				for (const field of writeFields) {
+					if (field.id === 'id') continue;
+					if (shape[field.id]) continue;
+					const desc = buildFieldDescription(field);
+					const needsLabelResolution = field.isPickList || field.isReference;
+					const base = needsLabelResolution
+						? rz.union([rz.number(), rz.string()])
+						: field.type === 'number'
+							? rz.number()
+							: field.type === 'boolean'
+								? rz.boolean()
+								: rz.string();
+					shape[field.id] = base.optional().describe(desc);
+				}
+			}
+			// createIfNotExists-specific fields
+			if (!shape.dedupFields)
+				shape.dedupFields = rz
+					.array(rz.string())
+					.optional()
+					.describe(
+						'Field names for duplicate detection. Use describeFields to discover available field names. Empty = skip dedup, always create.',
+					);
+			if (!shape.updateFields)
+				shape.updateFields = rz
+					.array(rz.string())
+					.optional()
+					.describe(
+						'Field names to compare against the duplicate record. If a value differs from the desired value, the duplicate will be updated. Leave empty to skip update comparison. Ignored when errorOnDuplicate is true.',
+					);
+			if (!shape.errorOnDuplicate)
+				shape.errorOnDuplicate = rz
+					.boolean()
+					.optional()
+					.describe(
+						'When true, throw an error if a duplicate is found instead of returning a skipped outcome. Default false.',
+					);
+			if (!shape.impersonationResourceId) {
+				shape.impersonationResourceId = rz
+					.union([rz.number(), rz.string()])
+					.optional()
+					.describe(
+						'Optional resource ID or name to impersonate for write attribution. Accepts a numeric ID, full name, or email — auto-resolved.',
+					);
+				shape.proceedWithoutImpersonationIfDenied = rz
+					.boolean()
+					.optional()
+					.describe(
+						'When true and impersonation is set, retry without impersonation if denied (default true).',
+					);
+			}
+			if (!shape.dryRun)
+				shape.dryRun = rz
+					.boolean()
+					.optional()
+					.describe(
+						'When true, resolves labels and validates fields but makes no API call (default false). Returns a summary of resolved field values.',
+					);
+		}
 
-        // describeFields fields
-        shape.mode = rz.enum(['read', 'write']).optional()
-            .describe("Field mode for describeFields. Use 'read' for get/getMany fields; 'write' for create/update fields.");
+		// describeFields fields
+		shape.mode = rz
+			.enum(['read', 'write'])
+			.optional()
+			.describe(
+				"Field mode for describeFields. Use 'read' for get/getMany fields; 'write' for create/update fields.",
+			);
 
-        // listPicklistValues fields
-        shape.fieldId = rz.string().optional()
-            .describe('Field ID for listPicklistValues. Required when using listPicklistValues operation.');
-        shape.query = rz.string().optional()
-            .describe('Optional search term to filter picklist values. Used by listPicklistValues.');
-        if (!shape.limit) {
-            shape.limit = rz.number().optional().describe('Max results (used by listPicklistValues for pagination, default 50).');
-        }
-        shape.page = rz.number().optional().describe('Page number for listPicklistValues pagination (default 1).');
-        shape.targetOperation = rz.string().optional().describe(
-            "For describeOperation: the operation name to document (e.g. 'create', 'createIfNotExists', 'getMany', 'slaHealthCheck').",
-        );
+		// listPicklistValues fields
+		shape.fieldId = rz
+			.string()
+			.optional()
+			.describe(
+				'Field ID for listPicklistValues. Required when using listPicklistValues operation.',
+			);
+		shape.query = rz
+			.string()
+			.optional()
+			.describe('Optional search term to filter picklist values. Used by listPicklistValues.');
+		if (!shape.limit) {
+			shape.limit = rz
+				.number()
+				.optional()
+				.describe('Max results (used by listPicklistValues for pagination, default 50).');
+		}
+		shape.page = rz
+			.number()
+			.optional()
+			.describe('Page number for listPicklistValues pagination (default 1).');
+		shape.targetOperation = rz
+			.string()
+			.optional()
+			.describe(
+				"For describeOperation: the operation name to document (e.g. 'create', 'createIfNotExists', 'getMany', 'slaHealthCheck').",
+			);
 
-        return rz.object(shape);
-    }
+		traceSchemaBuild({
+			phase: 'build-complete',
+			resource,
+			summary: {
+				topLevelSchemaKeys: safeKeys(shape),
+				dynamicWriteFieldCount: writeFields.filter(
+					(field) =>
+						field.id !== 'id' &&
+						!Object.prototype.hasOwnProperty.call({ operation: true }, field.id),
+				).length,
+				readEnumFilterFieldCount: readFields.filter((field) => !field.udf).length,
+				exposesFiltersJson: Boolean(shape.filtersJson),
+				exposesReturnAll: Boolean(shape.returnAll),
+				exposesOutputMode: Boolean(shape.outputMode),
+				exposesDryRun: Boolean(shape.dryRun),
+				exposesImpersonationResourceId: Boolean(shape.impersonationResourceId),
+			},
+		});
+		return rz.object(shape);
+	}
 
-    return { buildUnifiedSchema };
+	return { buildUnifiedSchema };
 }

--- a/nodes/Autotask/ai-tools/tool-executor.ts
+++ b/nodes/Autotask/ai-tools/tool-executor.ts
@@ -1,50 +1,94 @@
-import type { IExecuteFunctions, IGetNodeParameterOptions, ILoadOptionsFunctions, IDataObject } from 'n8n-workflow';
+import type {
+	IExecuteFunctions,
+	IGetNodeParameterOptions,
+	ILoadOptionsFunctions,
+	IDataObject,
+} from 'n8n-workflow';
 import moment from 'moment-timezone';
 import { executeToolOperation } from '../resources/tool/execute';
 import type { FieldMeta } from '../helpers/aiHelper';
-import { describeResource, listPicklistValues, type DescribeResourceResponse } from '../helpers/aiHelper';
+import {
+	describeResource,
+	listPicklistValues,
+	type DescribeResourceResponse,
+} from '../helpers/aiHelper';
 import { mapFilterOp } from './schema-generator';
 import { validateEntityId, validateReadFields, validateWriteFields } from './field-validator';
-import { formatApiError, formatFilterConstraintError, formatIdError, formatNotFoundError, formatNoResultsFound, wrapSuccess, wrapError, ERROR_TYPES, type ResultKind, type ResultPayload, type PaginationInfo } from './error-formatter';
-import { resolveLabelsToIds, resolveFilterLabelsToIds, type LabelResolution, type PendingLabelConfirmation } from '../helpers/label-resolution';
-import { applyChangeInfoAliases, buildAliasMap, shouldApplyAliases } from '../helpers/change-info-aliases';
+import {
+	formatApiError,
+	formatFilterConstraintError,
+	formatIdError,
+	formatNotFoundError,
+	formatNoResultsFound,
+	wrapSuccess,
+	wrapError,
+	ERROR_TYPES,
+	type ResultKind,
+	type ResultPayload,
+	type PaginationInfo,
+} from './error-formatter';
+import {
+	resolveLabelsToIds,
+	resolveFilterLabelsToIds,
+	type LabelResolution,
+	type PendingLabelConfirmation,
+} from '../helpers/label-resolution';
+import {
+	applyChangeInfoAliases,
+	buildAliasMap,
+	shouldApplyAliases,
+} from '../helpers/change-info-aliases';
 import { buildOperationDoc } from './description-builders';
 import { getIdentifierPairConfig } from '../constants/resource-operations';
 import { getConfiguredTimezone, convertDatesToUTC } from '../helpers/date-time/utils';
 import type { IAutotaskCredentials } from '../types/base/auth';
+import {
+	AI_TOOL_DEBUG_VERBOSE,
+	redactForVerbose,
+	safeKeys,
+	summariseFilters,
+	summariseResponseEnvelope,
+	traceError,
+	traceExecutor,
+	traceFilterBuild,
+	traceLabelResolution,
+	traceResponse,
+	traceToolCall,
+	traceWriteGuard,
+} from './debug-trace';
 
 export interface ToolExecutorParams {
-    resource: string;
-    operation: string;
-    id?: number;
-    ticketNumber?: string;
-    ticketFields?: string;
-    filter_field?: string;
-    filter_op?: string;
-    filter_value?: string | number | boolean | Array<string | number | boolean>;
-    filter_field_2?: string;
-    filter_op_2?: string;
-    filter_value_2?: string | number | boolean | Array<string | number | boolean>;
-    filter_logic?: 'and' | 'or';
-    limit?: number;
-    offset?: number;
-    fields?: string;
-    recency?: string;
-    since?: string;
-    until?: string;
-    domain?: string;
-    domainOperator?: string;
-    searchContactEmails?: boolean;
-    filtersJson?: string;
-    returnAll?: boolean;
-    targetOperation?: string;
-    [key: string]: string | number | boolean | Array<string | number | boolean> | undefined;
+	resource: string;
+	operation: string;
+	id?: number;
+	ticketNumber?: string;
+	ticketFields?: string;
+	filter_field?: string;
+	filter_op?: string;
+	filter_value?: string | number | boolean | Array<string | number | boolean>;
+	filter_field_2?: string;
+	filter_op_2?: string;
+	filter_value_2?: string | number | boolean | Array<string | number | boolean>;
+	filter_logic?: 'and' | 'or';
+	limit?: number;
+	offset?: number;
+	fields?: string;
+	recency?: string;
+	since?: string;
+	until?: string;
+	domain?: string;
+	domainOperator?: string;
+	searchContactEmails?: boolean;
+	filtersJson?: string;
+	returnAll?: boolean;
+	targetOperation?: string;
+	[key: string]: string | number | boolean | Array<string | number | boolean> | undefined;
 }
 
 export interface ToolExecutionMetadata {
-    readFields?: FieldMeta[];
-    writeFields?: FieldMeta[];
-    allAllowedOps?: string[];
+	readFields?: FieldMeta[];
+	writeFields?: FieldMeta[];
+	allAllowedOps?: string[];
 }
 
 /** Maximum records to include in a single tool response before truncation */
@@ -53,24 +97,24 @@ const DEFAULT_QUERY_LIMIT = 10;
 const MAX_QUERY_LIMIT = 500;
 const RECENCY_OVER_REQUEST_LIMIT = 500;
 const RECENCY_FIELD_PRIORITY = [
-    'createDateTime',
-    'createDate',
-    'lastModifiedDateTime',
-    'lastActivityDateTime',
-    'lastActivityDate',
-    'dateWorked',
+	'createDateTime',
+	'createDate',
+	'lastModifiedDateTime',
+	'lastActivityDateTime',
+	'lastActivityDate',
+	'dateWorked',
 ] as const;
 const RECENCY_WINDOWS_MS: Record<string, number> = {
-    last_15m: 15 * 60 * 1000,
-    last_1h: 60 * 60 * 1000,
-    last_4h: 4 * 60 * 60 * 1000,
-    last_12h: 12 * 60 * 60 * 1000,
-    last_24h: 24 * 60 * 60 * 1000,
-    last_3d: 3 * 24 * 60 * 60 * 1000,
-    last_7d: 7 * 24 * 60 * 60 * 1000,
-    last_14d: 14 * 24 * 60 * 60 * 1000,
-    last_30d: 30 * 24 * 60 * 60 * 1000,
-    last_90d: 90 * 24 * 60 * 60 * 1000,
+	last_15m: 15 * 60 * 1000,
+	last_1h: 60 * 60 * 1000,
+	last_4h: 4 * 60 * 60 * 1000,
+	last_12h: 12 * 60 * 60 * 1000,
+	last_24h: 24 * 60 * 60 * 1000,
+	last_3d: 3 * 24 * 60 * 60 * 1000,
+	last_7d: 7 * 24 * 60 * 60 * 1000,
+	last_14d: 14 * 24 * 60 * 60 * 1000,
+	last_30d: 30 * 24 * 60 * 60 * 1000,
+	last_90d: 90 * 24 * 60 * 60 * 1000,
 };
 
 const RECENCY_CUSTOM_DAYS_MIN = 1;
@@ -78,178 +122,197 @@ const RECENCY_CUSTOM_DAYS_MAX = 365;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 function parseRecencyWindowMs(recency: string): number {
-    const preset = RECENCY_WINDOWS_MS[recency];
-    if (preset !== undefined) {
-        return preset;
-    }
-    const match = /^last_(\d+)d$/.exec(recency);
-    if (match) {
-        const days = parseInt(match[1], 10);
-        if (Number.isFinite(days) && days >= RECENCY_CUSTOM_DAYS_MIN && days <= RECENCY_CUSTOM_DAYS_MAX) {
-            return days * MS_PER_DAY;
-        }
-    }
-    const presets = Object.keys(RECENCY_WINDOWS_MS).join(', ');
-    throw new Error(
-        `Unsupported recency value '${recency}'. Use a preset (${presets}) or custom last_Nd with N between ${RECENCY_CUSTOM_DAYS_MIN} and ${RECENCY_CUSTOM_DAYS_MAX} (e.g. last_5d, last_45d).`,
-    );
+	const preset = RECENCY_WINDOWS_MS[recency];
+	if (preset !== undefined) {
+		return preset;
+	}
+	const match = /^last_(\d+)d$/.exec(recency);
+	if (match) {
+		const days = parseInt(match[1], 10);
+		if (
+			Number.isFinite(days) &&
+			days >= RECENCY_CUSTOM_DAYS_MIN &&
+			days <= RECENCY_CUSTOM_DAYS_MAX
+		) {
+			return days * MS_PER_DAY;
+		}
+	}
+	const presets = Object.keys(RECENCY_WINDOWS_MS).join(', ');
+	throw new Error(
+		`Unsupported recency value '${recency}'. Use a preset (${presets}) or custom last_Nd with N between ${RECENCY_CUSTOM_DAYS_MIN} and ${RECENCY_CUSTOM_DAYS_MAX} (e.g. last_5d, last_45d).`,
+	);
 }
 
 interface ToolFilter {
-    field: string;
-    op: string;
-    value?: string | number | boolean | Array<string | number | boolean>;
-    udf?: boolean;
+	field: string;
+	op: string;
+	value?: string | number | boolean | Array<string | number | boolean>;
+	udf?: boolean;
 }
 
 interface RecencyBuildResult {
-    filters: ToolFilter[];
-    isActive: boolean;
-    note?: string;
+	filters: ToolFilter[];
+	isActive: boolean;
+	note?: string;
 }
 
 interface ToolResponseContext {
-    recencyActive?: boolean;
-    recencyWindowLimited?: boolean;
-    recencyNote?: string;
-    resolutions?: LabelResolution[];
-    resolutionWarnings?: string[];
-    pendingConfirmations?: PendingLabelConfirmation[];
-    effectiveOffset?: number;
+	recencyActive?: boolean;
+	recencyWindowLimited?: boolean;
+	recencyNote?: string;
+	resolutions?: LabelResolution[];
+	resolutionWarnings?: string[];
+	pendingConfirmations?: PendingLabelConfirmation[];
+	effectiveOffset?: number;
 }
 
 function getEffectiveLimit(limit: number | undefined): number {
-    if (typeof limit !== 'number' || Number.isNaN(limit)) {
-        return DEFAULT_QUERY_LIMIT;
-    }
-    return Math.min(Math.max(Math.trunc(limit), 1), MAX_QUERY_LIMIT);
+	if (typeof limit !== 'number' || Number.isNaN(limit)) {
+		return DEFAULT_QUERY_LIMIT;
+	}
+	return Math.min(Math.max(Math.trunc(limit), 1), MAX_QUERY_LIMIT);
 }
 
 function buildFieldLookup(fields: FieldMeta[]): Map<string, FieldMeta> {
-    return new Map(fields.map((field) => [field.id.toLowerCase(), field]));
+	return new Map(fields.map((field) => [field.id.toLowerCase(), field]));
 }
 
-function toUtcIsoSeconds(input: string, parameterName: 'since' | 'until', timezone: string): string {
-    const parsed = moment.tz(input, timezone);
-    if (!parsed.isValid()) {
-        throw new Error(
-            `Invalid ${parameterName} value '${input}'. Use a date/time string such as ` +
-            `2026-01-15T09:00:00 (interpreted as your configured timezone) or ` +
-            `2026-01-15T09:00:00Z / 2026-01-15T09:00:00+10:00 (explicit offset respected).`,
-        );
-    }
-    return parsed.utc().toISOString().replace(/\.\d{3}Z$/, 'Z');
+function toUtcIsoSeconds(
+	input: string,
+	parameterName: 'since' | 'until',
+	timezone: string,
+): string {
+	const parsed = moment.tz(input, timezone);
+	if (!parsed.isValid()) {
+		throw new Error(
+			`Invalid ${parameterName} value '${input}'. Use a date/time string such as ` +
+				`2026-01-15T09:00:00 (interpreted as your configured timezone) or ` +
+				`2026-01-15T09:00:00Z / 2026-01-15T09:00:00+10:00 (explicit offset respected).`,
+		);
+	}
+	return parsed
+		.utc()
+		.toISOString()
+		.replace(/\.\d{3}Z$/, 'Z');
 }
 
 function resolveRecencyField(readFields: FieldMeta[]): string | null {
-    if (readFields.length === 0) {
-        return null;
-    }
-    const lookup = buildFieldLookup(readFields);
-    for (const candidate of RECENCY_FIELD_PRIORITY) {
-        const field = lookup.get(candidate.toLowerCase());
-        if (field && !field.udf) {
-            return field.id;
-        }
-    }
-    const fallback = readFields.find((field) => !field.udf && field.type.toLowerCase().includes('date'));
-    return fallback?.id ?? null;
+	if (readFields.length === 0) {
+		return null;
+	}
+	const lookup = buildFieldLookup(readFields);
+	for (const candidate of RECENCY_FIELD_PRIORITY) {
+		const field = lookup.get(candidate.toLowerCase());
+		if (field && !field.udf) {
+			return field.id;
+		}
+	}
+	const fallback = readFields.find(
+		(field) => !field.udf && field.type.toLowerCase().includes('date'),
+	);
+	return fallback?.id ?? null;
 }
 
-function buildRecencyFilters(params: ToolExecutorParams, readFields: FieldMeta[], timezone: string): RecencyBuildResult {
-    const recency = typeof params.recency === 'string' ? params.recency.trim() : '';
-    const sinceRaw = typeof params.since === 'string' ? params.since.trim() : '';
-    const untilRaw = typeof params.until === 'string' ? params.until.trim() : '';
-    const hasRecencyInput = Boolean(recency || sinceRaw || untilRaw);
+function buildRecencyFilters(
+	params: ToolExecutorParams,
+	readFields: FieldMeta[],
+	timezone: string,
+): RecencyBuildResult {
+	const recency = typeof params.recency === 'string' ? params.recency.trim() : '';
+	const sinceRaw = typeof params.since === 'string' ? params.since.trim() : '';
+	const untilRaw = typeof params.until === 'string' ? params.until.trim() : '';
+	const hasRecencyInput = Boolean(recency || sinceRaw || untilRaw);
 
-    if (!hasRecencyInput) {
-        return { filters: [], isActive: false };
-    }
+	if (!hasRecencyInput) {
+		return { filters: [], isActive: false };
+	}
 
-    const recencyField = resolveRecencyField(readFields);
-    if (!recencyField) {
-        return {
-            filters: [],
-            isActive: false,
-            note: 'Recency filters were ignored because no datetime field was detected for this resource.',
-        };
-    }
+	const recencyField = resolveRecencyField(readFields);
+	if (!recencyField) {
+		return {
+			filters: [],
+			isActive: false,
+			note: 'Recency filters were ignored because no datetime field was detected for this resource.',
+		};
+	}
 
-    let startIso: string | undefined;
-    if (sinceRaw) {
-        startIso = toUtcIsoSeconds(sinceRaw, 'since', timezone);
-    } else if (recency) {
-        const windowMs = parseRecencyWindowMs(recency);
-        startIso = new Date(Date.now() - windowMs).toISOString().replace(/\.\d{3}Z$/, 'Z');
-    } else if (untilRaw) {
-        throw new Error("The 'until' parameter requires either 'since' or 'recency'.");
-    }
+	let startIso: string | undefined;
+	if (sinceRaw) {
+		startIso = toUtcIsoSeconds(sinceRaw, 'since', timezone);
+	} else if (recency) {
+		const windowMs = parseRecencyWindowMs(recency);
+		startIso = new Date(Date.now() - windowMs).toISOString().replace(/\.\d{3}Z$/, 'Z');
+	} else if (untilRaw) {
+		throw new Error("The 'until' parameter requires either 'since' or 'recency'.");
+	}
 
-    if (!startIso) {
-        return { filters: [], isActive: false };
-    }
+	if (!startIso) {
+		return { filters: [], isActive: false };
+	}
 
-    const filters: ToolFilter[] = [
-        {
-            field: recencyField,
-            op: 'gte',
-            value: startIso,
-        },
-    ];
+	const filters: ToolFilter[] = [
+		{
+			field: recencyField,
+			op: 'gte',
+			value: startIso,
+		},
+	];
 
-    if (untilRaw) {
-        const endIso = toUtcIsoSeconds(untilRaw, 'until', timezone);
-        if (new Date(endIso).getTime() < new Date(startIso).getTime()) {
-            throw new Error(`'until' (${endIso}) must be greater than or equal to 'since' (${startIso}).`);
-        }
-        filters.push({
-            field: recencyField,
-            op: 'lte',
-            value: endIso,
-        });
-    }
+	if (untilRaw) {
+		const endIso = toUtcIsoSeconds(untilRaw, 'until', timezone);
+		if (new Date(endIso).getTime() < new Date(startIso).getTime()) {
+			throw new Error(
+				`'until' (${endIso}) must be greater than or equal to 'since' (${startIso}).`,
+			);
+		}
+		filters.push({
+			field: recencyField,
+			op: 'lte',
+			value: endIso,
+		});
+	}
 
-    return { filters, isActive: true };
+	return { filters, isActive: true };
 }
 
 function coerceFilterValueByFieldType(
-    value: string | number | boolean | Array<string | number | boolean>,
-    fieldType: string | undefined,
-    operator: string,
+	value: string | number | boolean | Array<string | number | boolean>,
+	fieldType: string | undefined,
+	operator: string,
 ): string | number | boolean | Array<string | number | boolean> {
-    const normalisedType = (fieldType ?? '').toLowerCase();
-    const toTypedScalar = (input: string | number | boolean): string | number | boolean => {
-        if (typeof input === 'number' || typeof input === 'boolean') {
-            return input;
-        }
-        if (normalisedType === 'number') {
-            const parsed = Number(input);
-            return Number.isFinite(parsed) ? parsed : input;
-        }
-        if (normalisedType === 'boolean') {
-            if (input.toLowerCase() === 'true') return true;
-            if (input.toLowerCase() === 'false') return false;
-        }
-        return input;
-    };
+	const normalisedType = (fieldType ?? '').toLowerCase();
+	const toTypedScalar = (input: string | number | boolean): string | number | boolean => {
+		if (typeof input === 'number' || typeof input === 'boolean') {
+			return input;
+		}
+		if (normalisedType === 'number') {
+			const parsed = Number(input);
+			return Number.isFinite(parsed) ? parsed : input;
+		}
+		if (normalisedType === 'boolean') {
+			if (input.toLowerCase() === 'true') return true;
+			if (input.toLowerCase() === 'false') return false;
+		}
+		return input;
+	};
 
-    if (operator === 'in' || operator === 'notIn') {
-        if (Array.isArray(value)) {
-            return value.map((v) => toTypedScalar(v));
-        }
-        if (typeof value === 'string' && value.includes(',')) {
-            return value
-                .split(',')
-                .map((v) => v.trim())
-                .filter(Boolean)
-                .map((v) => toTypedScalar(v));
-        }
-        return [toTypedScalar(value)];
-    }
-    if (Array.isArray(value)) {
-        return value.length > 0 ? toTypedScalar(value[0]) : '';
-    }
-    return toTypedScalar(value);
+	if (operator === 'in' || operator === 'notIn') {
+		if (Array.isArray(value)) {
+			return value.map((v) => toTypedScalar(v));
+		}
+		if (typeof value === 'string' && value.includes(',')) {
+			return value
+				.split(',')
+				.map((v) => v.trim())
+				.filter(Boolean)
+				.map((v) => toTypedScalar(v));
+		}
+		return [toTypedScalar(value)];
+	}
+	if (Array.isArray(value)) {
+		return value.length > 0 ? toTypedScalar(value[0]) : '';
+	}
+	return toTypedScalar(value);
 }
 
 /**
@@ -257,72 +320,84 @@ function coerceFilterValueByFieldType(
  * Supports two filter triplets for compound queries.
  */
 function buildFilterFromParams(
-    params: ToolExecutorParams,
-    readFields: FieldMeta[],
-    timezone: string,
+	params: ToolExecutorParams,
+	readFields: FieldMeta[],
+	timezone: string,
 ): ToolFilter[] {
-    const filters: ToolFilter[] = [];
-    const readFieldLookup = buildFieldLookup(readFields);
+	const filters: ToolFilter[] = [];
+	const readFieldLookup = buildFieldLookup(readFields);
 
-    // First filter
-    const mappedOp1 = params.filter_op ? mapFilterOp(params.filter_op) : 'eq';
-    const isNullCheckOp1 = mappedOp1 === 'exist' || mappedOp1 === 'notExist';
-    if (params.filter_field && (isNullCheckOp1 || (params.filter_value !== undefined && params.filter_value !== ''))) {
-        const canonicalField = readFieldLookup.get(params.filter_field.toLowerCase());
-        let coercedValue1 = coerceFilterValueByFieldType(
-            params.filter_value as string | number | boolean | Array<string | number | boolean>,
-            canonicalField?.type,
-            mappedOp1,
-        );
-        if (
-            !isNullCheckOp1 &&
-            typeof coercedValue1 === 'string' &&
-            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(coercedValue1) &&
-            canonicalField?.type?.toLowerCase() === 'datetime'
-        ) {
-            const converted = moment.tz(coercedValue1, timezone);
-            if (converted.isValid()) {
-                coercedValue1 = converted.utc().toISOString().replace(/\.\d{3}Z$/, 'Z');
-            }
-        }
-        filters.push({
-            field: canonicalField?.id ?? params.filter_field,
-            op: mappedOp1,
-            ...(!isNullCheckOp1 ? { value: coercedValue1 } : {}),
-            ...(canonicalField?.udf ? { udf: true } : {}),
-        });
-    }
+	// First filter
+	const mappedOp1 = params.filter_op ? mapFilterOp(params.filter_op) : 'eq';
+	const isNullCheckOp1 = mappedOp1 === 'exist' || mappedOp1 === 'notExist';
+	if (
+		params.filter_field &&
+		(isNullCheckOp1 || (params.filter_value !== undefined && params.filter_value !== ''))
+	) {
+		const canonicalField = readFieldLookup.get(params.filter_field.toLowerCase());
+		let coercedValue1 = coerceFilterValueByFieldType(
+			params.filter_value as string | number | boolean | Array<string | number | boolean>,
+			canonicalField?.type,
+			mappedOp1,
+		);
+		if (
+			!isNullCheckOp1 &&
+			typeof coercedValue1 === 'string' &&
+			/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(coercedValue1) &&
+			canonicalField?.type?.toLowerCase() === 'datetime'
+		) {
+			const converted = moment.tz(coercedValue1, timezone);
+			if (converted.isValid()) {
+				coercedValue1 = converted
+					.utc()
+					.toISOString()
+					.replace(/\.\d{3}Z$/, 'Z');
+			}
+		}
+		filters.push({
+			field: canonicalField?.id ?? params.filter_field,
+			op: mappedOp1,
+			...(!isNullCheckOp1 ? { value: coercedValue1 } : {}),
+			...(canonicalField?.udf ? { udf: true } : {}),
+		});
+	}
 
-    // Second filter
-    const mappedOp2 = params.filter_op_2 ? mapFilterOp(params.filter_op_2) : 'eq';
-    const isNullCheckOp2 = mappedOp2 === 'exist' || mappedOp2 === 'notExist';
-    if (params.filter_field_2 && (isNullCheckOp2 || (params.filter_value_2 !== undefined && params.filter_value_2 !== ''))) {
-        const canonicalField = readFieldLookup.get(params.filter_field_2.toLowerCase());
-        let coercedValue2 = coerceFilterValueByFieldType(
-            params.filter_value_2 as string | number | boolean | Array<string | number | boolean>,
-            canonicalField?.type,
-            mappedOp2,
-        );
-        if (
-            !isNullCheckOp2 &&
-            typeof coercedValue2 === 'string' &&
-            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(coercedValue2) &&
-            canonicalField?.type?.toLowerCase() === 'datetime'
-        ) {
-            const converted = moment.tz(coercedValue2, timezone);
-            if (converted.isValid()) {
-                coercedValue2 = converted.utc().toISOString().replace(/\.\d{3}Z$/, 'Z');
-            }
-        }
-        filters.push({
-            field: canonicalField?.id ?? params.filter_field_2,
-            op: mappedOp2,
-            ...(!isNullCheckOp2 ? { value: coercedValue2 } : {}),
-            ...(canonicalField?.udf ? { udf: true } : {}),
-        });
-    }
+	// Second filter
+	const mappedOp2 = params.filter_op_2 ? mapFilterOp(params.filter_op_2) : 'eq';
+	const isNullCheckOp2 = mappedOp2 === 'exist' || mappedOp2 === 'notExist';
+	if (
+		params.filter_field_2 &&
+		(isNullCheckOp2 || (params.filter_value_2 !== undefined && params.filter_value_2 !== ''))
+	) {
+		const canonicalField = readFieldLookup.get(params.filter_field_2.toLowerCase());
+		let coercedValue2 = coerceFilterValueByFieldType(
+			params.filter_value_2 as string | number | boolean | Array<string | number | boolean>,
+			canonicalField?.type,
+			mappedOp2,
+		);
+		if (
+			!isNullCheckOp2 &&
+			typeof coercedValue2 === 'string' &&
+			/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(coercedValue2) &&
+			canonicalField?.type?.toLowerCase() === 'datetime'
+		) {
+			const converted = moment.tz(coercedValue2, timezone);
+			if (converted.isValid()) {
+				coercedValue2 = converted
+					.utc()
+					.toISOString()
+					.replace(/\.\d{3}Z$/, 'Z');
+			}
+		}
+		filters.push({
+			field: canonicalField?.id ?? params.filter_field_2,
+			op: mappedOp2,
+			...(!isNullCheckOp2 ? { value: coercedValue2 } : {}),
+			...(canonicalField?.udf ? { udf: true } : {}),
+		});
+	}
 
-    return filters;
+	return filters;
 }
 
 /**
@@ -330,106 +405,110 @@ function buildFilterFromParams(
  * Only includes actual entity field values, excluding control params.
  */
 function buildFieldValues(
-    params: ToolExecutorParams,
-    excludeKeys: string[],
-    writeFields: FieldMeta[],
+	params: ToolExecutorParams,
+	excludeKeys: string[],
+	writeFields: FieldMeta[],
 ): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
-    const writeFieldLookup = buildFieldLookup(writeFields);
-    const exclude = new Set([
-        ...excludeKeys,
-        'resource',
-        'operation',
-        'filter_field',
-        'filter_op',
-        'filter_value',
-        'filter_field_2',
-        'filter_op_2',
-        'filter_value_2',
-        'filter_logic',
-        'limit',
-        'offset',
-        'fields',
-        'recency',
-        'since',
-        'until',
-        'domain',
-        'domainOperator',
-        'searchContactEmails',
-				'impersonationResourceId',
-				'proceedWithoutImpersonationIfDenied',
-				'dedupFields',
-				'errorOnDuplicate',
-				'updateFields',
-				'outputMode',
-				'targetOperation',
-				'filtersJson',
-				'returnAll',
-    ]);
-    for (const [key, value] of Object.entries(params)) {
-        if (value !== undefined && value !== '' && !exclude.has(key)) {
-            const canonicalField = writeFieldLookup.get(key.toLowerCase());
-            result[canonicalField?.id ?? key] = value;
-        }
-    }
-    return result;
+	const result: Record<string, unknown> = {};
+	const writeFieldLookup = buildFieldLookup(writeFields);
+	const exclude = new Set([
+		...excludeKeys,
+		'resource',
+		'operation',
+		'filter_field',
+		'filter_op',
+		'filter_value',
+		'filter_field_2',
+		'filter_op_2',
+		'filter_value_2',
+		'filter_logic',
+		'limit',
+		'offset',
+		'fields',
+		'recency',
+		'since',
+		'until',
+		'domain',
+		'domainOperator',
+		'searchContactEmails',
+		'impersonationResourceId',
+		'proceedWithoutImpersonationIfDenied',
+		'dedupFields',
+		'errorOnDuplicate',
+		'updateFields',
+		'outputMode',
+		'targetOperation',
+		'filtersJson',
+		'returnAll',
+	]);
+	for (const [key, value] of Object.entries(params)) {
+		if (value !== undefined && value !== '' && !exclude.has(key)) {
+			const canonicalField = writeFieldLookup.get(key.toLowerCase());
+			result[canonicalField?.id ?? key] = value;
+		}
+	}
+	return result;
 }
 
 /**
  * Parse the 'fields' param into a selectColumns-compatible array.
  */
 function parseFieldsParam(fields: string | undefined): string[] {
-    if (!fields || typeof fields !== 'string') return [];
-    return fields
-        .split(',')
-        .map((f) => f.trim())
-        .filter(Boolean);
+	if (!fields || typeof fields !== 'string') return [];
+	return fields
+		.split(',')
+		.map((f) => f.trim())
+		.filter(Boolean);
 }
 
 /**
  * Normalise operation names to canonical forms used by the executor.
  */
 function normaliseOperation(operation: string): string {
-    const key = operation.trim().toLowerCase();
-    switch (key) {
-        case 'getmany':
-            return 'getMany';
-        case 'whoami':
-            return 'whoAmI';
-        case 'getposted':
-            return 'getPosted';
-        case 'getunposted':
-            return 'getUnposted';
-        case 'searchbydomain':
-            return 'searchByDomain';
-        case 'slahealthcheck':
-            return 'slaHealthCheck';
-        case 'moveconfigurationitem':
-            return 'moveConfigurationItem';
-        case 'movetocompany':
-            return 'moveToCompany';
-        case 'transferownership':
-            return 'transferOwnership';
-        case 'createifnotexists':
-            return 'createIfNotExists';
-        case 'getbyresource':
-            return 'getByResource';
-        case 'getbyyear':
-            return 'getByYear';
-        case 'describeoperation':
-            return 'describeOperation';
-        default:
-            return key;
-    }
+	const key = operation.trim().toLowerCase();
+	switch (key) {
+		case 'getmany':
+			return 'getMany';
+		case 'whoami':
+			return 'whoAmI';
+		case 'getposted':
+			return 'getPosted';
+		case 'getunposted':
+			return 'getUnposted';
+		case 'searchbydomain':
+			return 'searchByDomain';
+		case 'slahealthcheck':
+			return 'slaHealthCheck';
+		case 'moveconfigurationitem':
+			return 'moveConfigurationItem';
+		case 'movetocompany':
+			return 'moveToCompany';
+		case 'transferownership':
+			return 'transferOwnership';
+		case 'createifnotexists':
+			return 'createIfNotExists';
+		case 'getbyresource':
+			return 'getByResource';
+		case 'getbyyear':
+			return 'getByYear';
+		case 'describeoperation':
+			return 'describeOperation';
+		default:
+			return key;
+	}
 }
 
 /** n8n framework fields injected into every tool call — must not reach API request bodies */
 const N8N_METADATA_FIELDS = new Set([
-    'sessionId', 'action', 'chatInput',
-    'root',
-    'tool', 'toolName', 'toolCallId',
-    'operation',
-    'dryRun',
+	'sessionId',
+	'action',
+	'chatInput',
+	'root',
+	'tool',
+	'toolName',
+	'toolCallId',
+	'operation',
+	'dryRun',
 ]);
 
 /** Key prefixes injected by n8n that must be stripped regardless of suffix */
@@ -437,33 +516,62 @@ const N8N_METADATA_PREFIXES = ['Prompt__'];
 
 /** Inject correlationId into a serialised envelope JSON string if defined. */
 function attachCorrelation(json: string, id: string | undefined): string {
-    if (!id) return json;
-    try {
-        const parsed = JSON.parse(json) as Record<string, unknown>;
-        return JSON.stringify({ correlationId: id, ...parsed });
-    } catch {
-        return json;
-    }
+	if (!id) return json;
+	try {
+		const parsed = JSON.parse(json) as Record<string, unknown>;
+		return JSON.stringify({ correlationId: id, ...parsed });
+	} catch {
+		return json;
+	}
 }
 
 /** Compound operation outcomes that indicate a parent entity was not found — become ErrorEnvelope */
 const PARENT_NOT_FOUND_OUTCOMES = new Set([
-	'parent_not_found',      // defensive — remapped by thin wrappers but kept for safety
-	'company_not_found',     // contract, configurationItems, opportunity
-	'contract_not_found',    // contractCharge, contractService
-	'ticket_not_found',      // ticketCharge, ticketAdditionalConfigurationItem, ticketAdditionalContact
-	'project_not_found',     // projectCharge
+	'parent_not_found', // defensive — remapped by thin wrappers but kept for safety
+	'company_not_found', // contract, configurationItems, opportunity
+	'contract_not_found', // contractCharge, contractService
+	'ticket_not_found', // ticketCharge, ticketAdditionalConfigurationItem, ticketAdditionalContact
+	'project_not_found', // projectCharge
 	'holiday_set_not_found', // holiday
 ]);
 
 /** Returns true for warnings that indicate a resolution failure affecting written data. */
 function isResolutionFailureWarning(w: string): boolean {
-	return w.startsWith('[INFRASTRUCTURE]')
-		|| w.includes('resolution failed')
-		|| w.includes('resolution error')
-		|| w.includes('Proceeding with raw values')
-		|| w.includes('Could not resolve')
-		|| w.includes('has no known entity type');
+	return (
+		w.startsWith('[INFRASTRUCTURE]') ||
+		w.includes('resolution failed') ||
+		w.includes('resolution error') ||
+		w.includes('Proceeding with raw values') ||
+		w.includes('Could not resolve') ||
+		w.includes('has no known entity type')
+	);
+}
+
+function summariseResolutionState(
+	resolutions: LabelResolution[],
+	warnings: string[],
+	pendingConfirmations: PendingLabelConfirmation[],
+): Record<string, unknown> {
+	const warningKinds = warnings.map((warning) =>
+		warning.startsWith('[INFRASTRUCTURE]') ? 'infrastructure' : 'resolution',
+	);
+	return {
+		resolvedFields: Array.from(new Set(resolutions.map((r) => r.field))),
+		failedFields: Array.from(
+			new Set(
+				warnings
+					.filter((w) => isResolutionFailureWarning(w))
+					.map((w) => {
+						const fieldMatch = w.match(/for (?:field )?'([^']+)'/);
+						return fieldMatch ? fieldMatch[1] : '[unknown]';
+					}),
+			),
+		),
+		pendingConfirmationFields: Array.from(new Set(pendingConfirmations.map((p) => p.field))),
+		warningKinds: Array.from(new Set(warningKinds)),
+		warningCount: warnings.length,
+		pendingConfirmationCount: pendingConfirmations.length,
+	};
 }
 
 /**
@@ -477,56 +585,81 @@ function isResolutionFailureWarning(w: string): boolean {
  *  - impersonationFailed === true          (unresolvable impersonationResourceId string)
  */
 function buildWriteResolutionBlocker(
-    resource: string,
-    operation: string,
-    pendingConfirmations: import('../helpers/label-resolution').PendingLabelConfirmation[],
-    warnings: string[],
-    impersonationFailed: boolean,
+	resource: string,
+	operation: string,
+	pendingConfirmations: import('../helpers/label-resolution').PendingLabelConfirmation[],
+	warnings: string[],
+	impersonationFailed: boolean,
 ): string | null {
-    const unresolvedFields = warnings
-        .filter(w => isResolutionFailureWarning(w) && !w.startsWith('[INFRASTRUCTURE]') && !w.includes('impersonation'))
-        .map(w => {
-            const fieldMatch = w.match(/for (?:field )?'([^']+)'/);
-            return fieldMatch ? fieldMatch[1] : '[general-resolution-failure]';
-        });
-    const infraErrors = warnings.filter(w => w.startsWith('[INFRASTRUCTURE]'));
+	const unresolvedFields = warnings
+		.filter(
+			(w) =>
+				isResolutionFailureWarning(w) &&
+				!w.startsWith('[INFRASTRUCTURE]') &&
+				!w.includes('impersonation'),
+		)
+		.map((w) => {
+			const fieldMatch = w.match(/for (?:field )?'([^']+)'/);
+			return fieldMatch ? fieldMatch[1] : '[general-resolution-failure]';
+		});
+	const infraErrors = warnings.filter((w) => w.startsWith('[INFRASTRUCTURE]'));
 
-    const hasBlock = pendingConfirmations.length > 0
-        || unresolvedFields.length > 0
-        || infraErrors.length > 0
-        || impersonationFailed;
+	const hasBlock =
+		pendingConfirmations.length > 0 ||
+		unresolvedFields.length > 0 ||
+		infraErrors.length > 0 ||
+		impersonationFailed;
 
-    if (!hasBlock) return null;
+	if (!hasBlock) return null;
+	traceWriteGuard({
+		phase: 'blocked',
+		resource,
+		operation,
+		summary: {
+			blockerTypes: [
+				...(pendingConfirmations.length > 0 ? ['ambiguous'] : []),
+				...(unresolvedFields.length > 0 ? ['unresolved'] : []),
+				...(infraErrors.length > 0 ? ['infra'] : []),
+				...(impersonationFailed ? ['impersonation'] : []),
+			],
+			unresolvedFields,
+			infraErrorsCount: infraErrors.length,
+			ambiguousFieldsCount: pendingConfirmations.length,
+			impersonationFailure: impersonationFailed,
+		},
+	});
 
-    const parts: string[] = [];
-    if (pendingConfirmations.length > 0) {
-        const fields = pendingConfirmations.map(p => `'${p.field}'`).join(', ');
-        parts.push(`Ambiguous matches for field(s) ${fields} — multiple candidates found.`);
-    }
-    if (unresolvedFields.length > 0) {
-        parts.push(`No match found for field(s): ${unresolvedFields.map(f => `'${f}'`).join(', ')}.`);
-    }
-    if (infraErrors.length > 0) {
-        parts.push(`Resolution infrastructure error(s) prevented field lookup.`);
-    }
-    if (impersonationFailed) {
-        parts.push(`'impersonationResourceId' could not be resolved to a numeric resource ID.`);
-    }
+	const parts: string[] = [];
+	if (pendingConfirmations.length > 0) {
+		const fields = pendingConfirmations.map((p) => `'${p.field}'`).join(', ');
+		parts.push(`Ambiguous matches for field(s) ${fields} — multiple candidates found.`);
+	}
+	if (unresolvedFields.length > 0) {
+		parts.push(`No match found for field(s): ${unresolvedFields.map((f) => `'${f}'`).join(', ')}.`);
+	}
+	if (infraErrors.length > 0) {
+		parts.push(`Resolution infrastructure error(s) prevented field lookup.`);
+	}
+	if (impersonationFailed) {
+		parts.push(`'impersonationResourceId' could not be resolved to a numeric resource ID.`);
+	}
 
-    const ctx: Record<string, unknown> = {};
-    if (pendingConfirmations.length > 0) ctx.pendingConfirmations = pendingConfirmations;
-    if (unresolvedFields.length > 0) ctx.unresolvedFields = unresolvedFields;
-    if (infraErrors.length > 0) ctx.infraErrors = infraErrors;
-    if (impersonationFailed) ctx.impersonationFailed = true;
+	const ctx: Record<string, unknown> = {};
+	if (pendingConfirmations.length > 0) ctx.pendingConfirmations = pendingConfirmations;
+	if (unresolvedFields.length > 0) ctx.unresolvedFields = unresolvedFields;
+	if (infraErrors.length > 0) ctx.infraErrors = infraErrors;
+	if (impersonationFailed) ctx.impersonationFailed = true;
 
-    return JSON.stringify(wrapError(
-        resource,
-        operation,
-        ERROR_TYPES.WRITE_RESOLUTION_INCOMPLETE,
-        `Write blocked: ${parts.join(' ')} Resolve all field references before retrying.`,
-        `Call autotask_${resource} with operation 'describeFields' to inspect field metadata, then retry with exact IDs or unambiguous labels.`,
-        ctx,
-    ));
+	return JSON.stringify(
+		wrapError(
+			resource,
+			operation,
+			ERROR_TYPES.WRITE_RESOLUTION_INCOMPLETE,
+			`Write blocked: ${parts.join(' ')} Resolve all field references before retrying.`,
+			`Call autotask_${resource} with operation 'describeFields' to inspect field metadata, then retry with exact IDs or unambiguous labels.`,
+			ctx,
+		),
+	);
 }
 
 /**
@@ -536,7 +669,9 @@ function buildWriteResolutionBlocker(
 function buildResultPayload(
 	kind: ResultKind,
 	data: unknown,
-	flags: Partial<Omit<import('./error-formatter').ResultFlags, 'needsUserConfirmation' | 'safeToContinue'>>,
+	flags: Partial<
+		Omit<import('./error-formatter').ResultFlags, 'needsUserConfirmation' | 'safeToContinue'>
+	>,
 	extras: {
 		warnings?: string[];
 		pendingConfirmations?: import('../helpers/label-resolution').PendingLabelConfirmation[];
@@ -671,8 +806,10 @@ function buildCompoundContext(resource: string, result: any): Record<string, unk
 			return result.ticketID !== undefined ? { ticketID: result.ticketID } : undefined;
 		case 'changeRequestLink': {
 			const ctx: Record<string, unknown> = {};
-			if (result.changeRequestTicketID !== undefined) ctx.changeRequestTicketID = result.changeRequestTicketID;
-			if (result.problemOrIncidentTicketID !== undefined) ctx.problemOrIncidentTicketID = result.problemOrIncidentTicketID;
+			if (result.changeRequestTicketID !== undefined)
+				ctx.changeRequestTicketID = result.changeRequestTicketID;
+			if (result.problemOrIncidentTicketID !== undefined)
+				ctx.problemOrIncidentTicketID = result.problemOrIncidentTicketID;
 			return Object.keys(ctx).length > 0 ? ctx : undefined;
 		}
 		case 'holidaySet':
@@ -685,19 +822,19 @@ function buildCompoundContext(resource: string, result: any): Record<string, unk
 }
 
 function compactDescribeResponse(response: DescribeResourceResponse): Record<string, unknown> {
-    return {
-        resource: response.resource,
-        mode: response.mode,
-        timezone: response.timezone,
-        fields: response.fields.map((field) => ({
-            id: field.id,
-            type: field.type,
-            required: field.required,
-            isPickList: field.isPickList,
-            isReference: field.isReference,
-        })),
-        notes: response.notes ?? [],
-    };
+	return {
+		resource: response.resource,
+		mode: response.mode,
+		timezone: response.timezone,
+		fields: response.fields.map((field) => ({
+			id: field.id,
+			type: field.type,
+			required: field.required,
+			isPickList: field.isPickList,
+			isReference: field.isReference,
+		})),
+		notes: response.notes ?? [],
+	};
 }
 
 /**
@@ -705,1146 +842,1675 @@ function compactDescribeResponse(response: DescribeResourceResponse): Record<str
  * with getNodeParameter overridden to map flat AI tool params.
  */
 export async function executeAiTool(
-    context: IExecuteFunctions,
-    resource: string,
-    operation: string,
-    rawParams: ToolExecutorParams,
-    metadata: ToolExecutionMetadata = {},
+	context: IExecuteFunctions,
+	resource: string,
+	operation: string,
+	rawParams: ToolExecutorParams,
+	metadata: ToolExecutionMetadata = {},
 ): Promise<string> {
-    const rawCorrelation = rawParams.toolCallId ?? rawParams.sessionId;
-    const correlationId: string | undefined = typeof rawCorrelation === 'string' && rawCorrelation.trim()
-        ? rawCorrelation.trim()
-        : typeof rawCorrelation === 'number' ? String(rawCorrelation) : undefined;
+	const startedAt = Date.now();
+	const rawCorrelation = rawParams.toolCallId ?? rawParams.sessionId;
+	const correlationId: string | undefined =
+		typeof rawCorrelation === 'string' && rawCorrelation.trim()
+			? rawCorrelation.trim()
+			: typeof rawCorrelation === 'number'
+				? String(rawCorrelation)
+				: undefined;
 
-    // Strip n8n framework metadata injected into every tool call
-    const params = {} as ToolExecutorParams;
-    for (const [key, value] of Object.entries(rawParams)) {
-        if (N8N_METADATA_FIELDS.has(key)) continue;
-        if (N8N_METADATA_PREFIXES.some((p) => key.startsWith(p))) continue;
-        (params as Record<string, unknown>)[key] = value;
-    }
+	// Strip n8n framework metadata injected into every tool call
+	const params = {} as ToolExecutorParams;
+	const strippedMetadataKeys: string[] = [];
+	for (const [key, value] of Object.entries(rawParams)) {
+		if (N8N_METADATA_FIELDS.has(key) || N8N_METADATA_PREFIXES.some((p) => key.startsWith(p))) {
+			strippedMetadataKeys.push(key);
+			continue;
+		}
+		(params as Record<string, unknown>)[key] = value;
+	}
+	const normalisedOperation = normaliseOperation(operation);
+	traceToolCall({
+		phase: 'execute-start',
+		resource,
+		operation: normalisedOperation,
+		correlationId,
+		summary: {
+			rawOperation: operation,
+			normalisedOperation,
+			rawParamKeys: safeKeys(rawParams),
+			sanitisedParamKeys: safeKeys(params),
+			strippedMetadataKeys,
+		},
+	});
 
-    const timezone = await getConfiguredTimezone.call(context);
+	const timezone = await getConfiguredTimezone.call(context);
 
-    const originalGetNodeParameter = context.getNodeParameter.bind(context);
-    const readFields = metadata.readFields ?? [];
-    const writeFields = metadata.writeFields ?? [];
-    const fieldValues = buildFieldValues(params, ['id'], writeFields);
-    const filters = buildFilterFromParams(params, readFields, timezone);
-    const entityId = params.id !== undefined ? String(params.id) : '';
+	const originalGetNodeParameter = context.getNodeParameter.bind(context);
+	const readFields = metadata.readFields ?? [];
+	const writeFields = metadata.writeFields ?? [];
+	const fieldValues = buildFieldValues(params, ['id'], writeFields);
+	const filters = buildFilterFromParams(params, readFields, timezone);
+	const entityId = params.id !== undefined ? String(params.id) : '';
 
-    // Resolve human-readable labels to IDs for filter values on reference/picklist fields.
-    // This allows the LLM to pass e.g. filter_field="companyID", filter_value="Contoso"
-    // instead of requiring a prerequisite lookup to get the numeric ID.
-    const filterResolutions: LabelResolution[] = [];
-    const filterWarnings: string[] = [];
-    const filterPendingConfirmations: PendingLabelConfirmation[] = [];
-    for (const filter of filters) {
-        if (filter.value !== undefined && typeof filter.value === 'string') {
-            try {
-                const resolution = await resolveFilterLabelsToIds(
-                    context, resource, filter.field, filter.value, readFields,
-                );
-                if (resolution.resolutions.length > 0) {
-                    filter.value = resolution.values[filter.field] as string | number | boolean;
-                    filterResolutions.push(...resolution.resolutions);
-                }
-                if (resolution.warnings.length > 0) {
-                    filterWarnings.push(...resolution.warnings);
-                }
-                if (resolution.pendingConfirmations.length > 0) {
-                    filterPendingConfirmations.push(...resolution.pendingConfirmations);
-                }
-            } catch (err) {
-                const msg = err instanceof Error ? err.message : String(err);
-                filterWarnings.push(`Filter label resolution failed for '${filter.field}': ${msg}`);
-            }
-        } else if (Array.isArray(filter.value)) {
-            // Attempt label resolution for in/notIn array filter values on reference/picklist fields.
-            // Each string element is resolved individually; numeric elements are kept as-is.
-            try {
-                const resolution = await resolveFilterLabelsToIds(
-                    context, resource, filter.field, filter.value, readFields,
-                );
-                if (resolution.resolutions.length > 0) {
-                    filter.value = resolution.values[filter.field] as Array<string | number | boolean>;
-                    filterResolutions.push(...resolution.resolutions);
-                }
-                filterWarnings.push(...resolution.warnings);
-                filterPendingConfirmations.push(...resolution.pendingConfirmations);
-            } catch (err) {
-                const msg = err instanceof Error ? err.message : String(err);
-                filterWarnings.push(`Array filter label resolution failed for '${filter.field}': ${msg}`);
-            }
-        }
-    }
-    const selectedColumns = parseFieldsParam(params.fields);
-    const selectedSlaTicketColumns = parseFieldsParam(params.ticketFields);
-    const effectiveLimit = getEffectiveLimit(params.limit);
-    const effectiveOffset = typeof params.offset === 'number' && Number.isFinite(params.offset) && params.offset >= 0
-        ? Math.trunc(params.offset) : 0;
-    const normalisedOperation = normaliseOperation(operation);
+	// Resolve human-readable labels to IDs for filter values on reference/picklist fields.
+	// This allows the LLM to pass e.g. filter_field="companyID", filter_value="Contoso"
+	// instead of requiring a prerequisite lookup to get the numeric ID.
+	const filterResolutions: LabelResolution[] = [];
+	const filterWarnings: string[] = [];
+	const filterPendingConfirmations: PendingLabelConfirmation[] = [];
+	for (const filter of filters) {
+		if (filter.value !== undefined && typeof filter.value === 'string') {
+			try {
+				const resolution = await resolveFilterLabelsToIds(
+					context,
+					resource,
+					filter.field,
+					filter.value,
+					readFields,
+				);
+				if (resolution.resolutions.length > 0) {
+					filter.value = resolution.values[filter.field] as string | number | boolean;
+					filterResolutions.push(...resolution.resolutions);
+				}
+				if (resolution.warnings.length > 0) {
+					filterWarnings.push(...resolution.warnings);
+				}
+				if (resolution.pendingConfirmations.length > 0) {
+					filterPendingConfirmations.push(...resolution.pendingConfirmations);
+				}
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				filterWarnings.push(`Filter label resolution failed for '${filter.field}': ${msg}`);
+			}
+		} else if (Array.isArray(filter.value)) {
+			// Attempt label resolution for in/notIn array filter values on reference/picklist fields.
+			// Each string element is resolved individually; numeric elements are kept as-is.
+			try {
+				const resolution = await resolveFilterLabelsToIds(
+					context,
+					resource,
+					filter.field,
+					filter.value,
+					readFields,
+				);
+				if (resolution.resolutions.length > 0) {
+					filter.value = resolution.values[filter.field] as Array<string | number | boolean>;
+					filterResolutions.push(...resolution.resolutions);
+				}
+				filterWarnings.push(...resolution.warnings);
+				filterPendingConfirmations.push(...resolution.pendingConfirmations);
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				filterWarnings.push(`Array filter label resolution failed for '${filter.field}': ${msg}`);
+			}
+		}
+	}
+	traceLabelResolution({
+		phase: 'filter-resolution',
+		resource,
+		operation: normalisedOperation,
+		correlationId,
+		summary: {
+			attempted: filters.length > 0,
+			...summariseResolutionState(filterResolutions, filterWarnings, filterPendingConfirmations),
+			...(AI_TOOL_DEBUG_VERBOSE ? { filterSnapshot: redactForVerbose(filters) } : {}),
+		},
+	});
+	const selectedColumns = parseFieldsParam(params.fields);
+	const selectedSlaTicketColumns = parseFieldsParam(params.ticketFields);
+	const effectiveLimit = getEffectiveLimit(params.limit);
+	const effectiveOffset =
+		typeof params.offset === 'number' && Number.isFinite(params.offset) && params.offset >= 0
+			? Math.trunc(params.offset)
+			: 0;
 
-    // Handle helper operations that bypass the standard executor
-    if (normalisedOperation === 'describeFields') {
-        try {
-            const mode = (params.mode as 'read' | 'write') ?? 'read';
-            const result = await describeResource(context as unknown as ILoadOptionsFunctions, resource, mode);
-            return attachCorrelation(JSON.stringify(wrapSuccess(resource, 'describeFields',
-                buildResultPayload('metadata', compactDescribeResponse(result), { mutated: false, retryable: true }),
-            )), correlationId);
-        } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            return attachCorrelation(JSON.stringify(formatApiError(message, resource, 'describeFields')), correlationId);
-        }
-    }
-    if (normalisedOperation === 'listPicklistValues') {
-        try {
-            const result = await listPicklistValues(
-                context as unknown as ILoadOptionsFunctions,
-                resource,
-                params.fieldId as string,
-                params.query as string | undefined,
-                (params.limit as number) ?? 50,
-                (params.page as number) ?? 1,
-            );
-            return attachCorrelation(JSON.stringify(wrapSuccess(resource, 'listPicklistValues',
-                buildResultPayload('metadata', result, { mutated: false, retryable: true }),
-            )), correlationId);
-        } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            return attachCorrelation(JSON.stringify(formatApiError(message, resource, 'listPicklistValues')), correlationId);
-        }
-    }
-    if (normalisedOperation === 'describeOperation') {
-        try {
-            const target = params.targetOperation as string | undefined;
-            const allAllowedOps = metadata.allAllowedOps ?? [];
-            if (!target || !allAllowedOps.includes(target)) {
-                return attachCorrelation(JSON.stringify(wrapError(
-                    resource, 'describeOperation', ERROR_TYPES.INVALID_OPERATION,
-                    `'targetOperation' must be one of: ${allAllowedOps.join(', ')}`,
-                    `Call autotask_${resource} with operation='describeOperation' and a valid targetOperation value.`,
-                )), correlationId);
-            }
-            const doc = buildOperationDoc(resource, target, readFields, writeFields);
-            return attachCorrelation(JSON.stringify(wrapSuccess(resource, 'describeOperation',
-                buildResultPayload('metadata', doc, { mutated: false, retryable: true }),
-            )), correlationId);
-        } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            return attachCorrelation(JSON.stringify(formatApiError(message, resource, 'describeOperation')), correlationId);
-        }
-    }
+	// Handle helper operations that bypass the standard executor
+	if (normalisedOperation === 'describeFields') {
+		try {
+			const mode = (params.mode as 'read' | 'write') ?? 'read';
+			const result = await describeResource(
+				context as unknown as ILoadOptionsFunctions,
+				resource,
+				mode,
+			);
+			const responseJson = JSON.stringify(
+				wrapSuccess(
+					resource,
+					'describeFields',
+					buildResultPayload('metadata', compactDescribeResponse(result), {
+						mutated: false,
+						retryable: true,
+					}),
+				),
+			);
+			traceResponse({
+				phase: 'helper-describeFields',
+				resource,
+				operation: 'describeFields',
+				correlationId,
+				durationMs: Date.now() - startedAt,
+				summary: summariseResponseEnvelope(responseJson),
+			});
+			return attachCorrelation(responseJson, correlationId);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			traceError({
+				phase: 'helper-describeFields',
+				resource,
+				operation: 'describeFields',
+				correlationId,
+				summary: { errorMessage: message, beforeApiCall: false },
+			});
+			return attachCorrelation(
+				JSON.stringify(formatApiError(message, resource, 'describeFields')),
+				correlationId,
+			);
+		}
+	}
+	if (normalisedOperation === 'listPicklistValues') {
+		try {
+			const result = await listPicklistValues(
+				context as unknown as ILoadOptionsFunctions,
+				resource,
+				params.fieldId as string,
+				params.query as string | undefined,
+				(params.limit as number) ?? 50,
+				(params.page as number) ?? 1,
+			);
+			return attachCorrelation(
+				JSON.stringify(
+					wrapSuccess(
+						resource,
+						'listPicklistValues',
+						buildResultPayload('metadata', result, { mutated: false, retryable: true }),
+					),
+				),
+				correlationId,
+			);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return attachCorrelation(
+				JSON.stringify(formatApiError(message, resource, 'listPicklistValues')),
+				correlationId,
+			);
+		}
+	}
+	if (normalisedOperation === 'describeOperation') {
+		try {
+			const target = params.targetOperation as string | undefined;
+			const allAllowedOps = metadata.allAllowedOps ?? [];
+			if (!target || !allAllowedOps.includes(target)) {
+				return attachCorrelation(
+					JSON.stringify(
+						wrapError(
+							resource,
+							'describeOperation',
+							ERROR_TYPES.INVALID_OPERATION,
+							`'targetOperation' must be one of: ${allAllowedOps.join(', ')}`,
+							`Call autotask_${resource} with operation='describeOperation' and a valid targetOperation value.`,
+						),
+					),
+					correlationId,
+				);
+			}
+			const doc = buildOperationDoc(resource, target, readFields, writeFields);
+			return attachCorrelation(
+				JSON.stringify(
+					wrapSuccess(
+						resource,
+						'describeOperation',
+						buildResultPayload('metadata', doc, { mutated: false, retryable: true }),
+					),
+				),
+				correlationId,
+			);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return attachCorrelation(
+				JSON.stringify(formatApiError(message, resource, 'describeOperation')),
+				correlationId,
+			);
+		}
+	}
 
-    let recencyResult: RecencyBuildResult;
-    try {
-        recencyResult = buildRecencyFilters(params, readFields, timezone);
-    } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        return attachCorrelation(JSON.stringify(
-            formatFilterConstraintError(
-                resource,
-                normalisedOperation,
-                detail,
-                "Use recency windows (for example 'last_7d') or date/time strings for since/until (e.g. 2026-01-15T09:00:00 in your configured timezone, or 2026-01-15T09:00:00Z with explicit UTC offset).",
-            ),
-        ), correlationId);
-    }
-    if (recencyResult.note && !recencyResult.isActive) {
-        return attachCorrelation(JSON.stringify(formatFilterConstraintError(
-            resource,
-            normalisedOperation,
-            recencyResult.note,
-            `No datetime field was detected for ${resource}. Use explicit filter_field/filter_value pairs with a known date field, or call autotask_${resource} with operation 'describeFields' with mode 'read' to discover available date fields.`,
-        )), correlationId);
-    }
+	let recencyResult: RecencyBuildResult;
+	try {
+		recencyResult = buildRecencyFilters(params, readFields, timezone);
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		return attachCorrelation(
+			JSON.stringify(
+				formatFilterConstraintError(
+					resource,
+					normalisedOperation,
+					detail,
+					"Use recency windows (for example 'last_7d') or date/time strings for since/until (e.g. 2026-01-15T09:00:00 in your configured timezone, or 2026-01-15T09:00:00Z with explicit UTC offset).",
+				),
+			),
+			correlationId,
+		);
+	}
+	if (recencyResult.note && !recencyResult.isActive) {
+		return attachCorrelation(
+			JSON.stringify(
+				formatFilterConstraintError(
+					resource,
+					normalisedOperation,
+					recencyResult.note,
+					`No datetime field was detected for ${resource}. Use explicit filter_field/filter_value pairs with a known date field, or call autotask_${resource} with operation 'describeFields' with mode 'read' to discover available date fields.`,
+				),
+			),
+			correlationId,
+		);
+	}
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let combinedFilters: any[];
-    if (params.filtersJson) {
-        // filtersJson path — mutually exclusive with flat filter triplets
-        if (params.filter_field || params.filter_field_2) {
-            return attachCorrelation(JSON.stringify(formatFilterConstraintError(
-                resource, normalisedOperation,
-                'filtersJson is mutually exclusive with filter_field/filter_field_2. Provide one or the other, not both.',
-                'Remove filter_field and filter_field_2 when using filtersJson, or remove filtersJson when using flat triplets.',
-            )), correlationId);
-        }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let parsedFiltersJson: any[] = [];
-        try {
-            const parsed: unknown = JSON.parse(params.filtersJson as string);
-            if (!Array.isArray(parsed)) throw new Error('filtersJson must be a JSON array.');
-            parsedFiltersJson = parsed;
-        } catch (e) {
-            return attachCorrelation(JSON.stringify(formatFilterConstraintError(
-                resource, normalisedOperation,
-                `filtersJson parse error: ${e instanceof Error ? e.message : String(e)}`,
-                "Provide a valid JSON array of Autotask IFilterCondition objects. Example: '[{\"field\":\"status\",\"op\":\"eq\",\"value\":1}]'",
-            )), correlationId);
-        }
-        if (parsedFiltersJson.some((f) => typeof f !== 'object' || f === null || !('op' in (f as object)))) {
-            return attachCorrelation(JSON.stringify(formatFilterConstraintError(
-                resource, normalisedOperation,
-                'filtersJson validation error: each element must have at minimum an "op" property.',
-                "Each filter object requires at minimum an 'op' property (e.g. 'eq', 'or', 'and'). Field-level filters also need 'field' and 'value'.",
-            )), correlationId);
-        }
-        // Recency always AND-appended on top (time window constraint)
-        combinedFilters = [...parsedFiltersJson, ...recencyResult.filters];
-    } else {
-        // Standard flat-triplet filter path
-        const filterLogic = params.filter_logic === 'or' ? 'or' : 'and';
-        if (filterLogic === 'or' && filters.length >= 2 && recencyResult.filters.length > 0) {
-            // OR between user filters, AND with recency
-            combinedFilters = [{ op: 'or', items: [...filters] }, ...recencyResult.filters];
-        } else if (filterLogic === 'or' && filters.length >= 2) {
-            combinedFilters = [{ op: 'or', items: [...filters] }];
-        } else {
-            combinedFilters = [...filters, ...recencyResult.filters];
-        }
-    }
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let combinedFilters: any[];
+	if (params.filtersJson) {
+		// filtersJson path — mutually exclusive with flat filter triplets
+		if (params.filter_field || params.filter_field_2) {
+			return attachCorrelation(
+				JSON.stringify(
+					formatFilterConstraintError(
+						resource,
+						normalisedOperation,
+						'filtersJson is mutually exclusive with filter_field/filter_field_2. Provide one or the other, not both.',
+						'Remove filter_field and filter_field_2 when using filtersJson, or remove filtersJson when using flat triplets.',
+					),
+				),
+				correlationId,
+			);
+		}
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		let parsedFiltersJson: any[] = [];
+		try {
+			const parsed: unknown = JSON.parse(params.filtersJson as string);
+			if (!Array.isArray(parsed)) throw new Error('filtersJson must be a JSON array.');
+			parsedFiltersJson = parsed;
+		} catch (e) {
+			return attachCorrelation(
+				JSON.stringify(
+					formatFilterConstraintError(
+						resource,
+						normalisedOperation,
+						`filtersJson parse error: ${e instanceof Error ? e.message : String(e)}`,
+						'Provide a valid JSON array of Autotask IFilterCondition objects. Example: \'[{"field":"status","op":"eq","value":1}]\'',
+					),
+				),
+				correlationId,
+			);
+		}
+		if (
+			parsedFiltersJson.some((f) => typeof f !== 'object' || f === null || !('op' in (f as object)))
+		) {
+			return attachCorrelation(
+				JSON.stringify(
+					formatFilterConstraintError(
+						resource,
+						normalisedOperation,
+						'filtersJson validation error: each element must have at minimum an "op" property.',
+						"Each filter object requires at minimum an 'op' property (e.g. 'eq', 'or', 'and'). Field-level filters also need 'field' and 'value'.",
+					),
+				),
+				correlationId,
+			);
+		}
+		// Recency always AND-appended on top (time window constraint)
+		combinedFilters = [...parsedFiltersJson, ...recencyResult.filters];
+	} else {
+		// Standard flat-triplet filter path
+		const filterLogic = params.filter_logic === 'or' ? 'or' : 'and';
+		if (filterLogic === 'or' && filters.length >= 2 && recencyResult.filters.length > 0) {
+			// OR between user filters, AND with recency
+			combinedFilters = [{ op: 'or', items: [...filters] }, ...recencyResult.filters];
+		} else if (filterLogic === 'or' && filters.length >= 2) {
+			combinedFilters = [{ op: 'or', items: [...filters] }];
+		} else {
+			combinedFilters = [...filters, ...recencyResult.filters];
+		}
+	}
+	traceFilterBuild({
+		phase: 'combined-filters',
+		resource,
+		operation: normalisedOperation,
+		correlationId,
+		summary: {
+			flatFilters: summariseFilters(filters),
+			recencyFilters: summariseFilters(recencyResult.filters),
+			filtersJsonUsed: Boolean(params.filtersJson),
+			combinedStrategy: params.filtersJson
+				? 'filtersJson+recency'
+				: params.filter_logic === 'or' && filters.length >= 2
+					? recencyResult.filters.length > 0
+						? 'or-group+recency'
+						: 'or-group'
+					: 'flat-and-recency',
+			recencyActive: recencyResult.isActive,
+			recencyNote: recencyResult.note,
+		},
+	});
 
-    const allFilterCount = filters.length + recencyResult.filters.length + (params.filtersJson ? 1 : 0);
-    if (normalisedOperation === 'get' && entityId === '') {
-        return attachCorrelation(JSON.stringify(
-            allFilterCount > 0
-                ? wrapError(resource, 'get', ERROR_TYPES.INVALID_OPERATION,
-                    'operation "get" requires a numeric entity ID. Filters and recency parameters are not valid for "get".',
-                    `Use operation 'getMany' with the same filters to retrieve matching ${resource} records.`)
-                : formatIdError(resource, 'get'),
-        ), correlationId);
-    }
-    const effectiveOperation = normalisedOperation;
-    // When offset is used, we need offset+limit records from the API then slice client-side.
-    // Cap at MAX_QUERY_LIMIT to stay within API bounds; warn if offset exceeds this.
-    const offsetExceedsApiCap = effectiveOffset > 0 && effectiveOffset >= MAX_QUERY_LIMIT;
-    const supportsOffsetPagination = ['getMany', 'getPosted', 'getUnposted'].includes(effectiveOperation);
-    const queryLimit = recencyResult.isActive
-        ? RECENCY_OVER_REQUEST_LIMIT
-        : (effectiveOffset > 0 && supportsOffsetPagination)
-            ? Math.min(effectiveOffset + effectiveLimit, MAX_QUERY_LIMIT)
-            : effectiveLimit;
+	const allFilterCount =
+		filters.length + recencyResult.filters.length + (params.filtersJson ? 1 : 0);
+	if (normalisedOperation === 'get' && entityId === '') {
+		return attachCorrelation(
+			JSON.stringify(
+				allFilterCount > 0
+					? wrapError(
+							resource,
+							'get',
+							ERROR_TYPES.INVALID_OPERATION,
+							'operation "get" requires a numeric entity ID. Filters and recency parameters are not valid for "get".',
+							`Use operation 'getMany' with the same filters to retrieve matching ${resource} records.`,
+						)
+					: formatIdError(resource, 'get'),
+			),
+			correlationId,
+		);
+	}
+	const effectiveOperation = normalisedOperation;
+	// When offset is used, we need offset+limit records from the API then slice client-side.
+	// Cap at MAX_QUERY_LIMIT to stay within API bounds; warn if offset exceeds this.
+	const offsetExceedsApiCap = effectiveOffset > 0 && effectiveOffset >= MAX_QUERY_LIMIT;
+	const supportsOffsetPagination = ['getMany', 'getPosted', 'getUnposted'].includes(
+		effectiveOperation,
+	);
+	const queryLimit = recencyResult.isActive
+		? RECENCY_OVER_REQUEST_LIMIT
+		: effectiveOffset > 0 && supportsOffsetPagination
+			? Math.min(effectiveOffset + effectiveLimit, MAX_QUERY_LIMIT)
+			: effectiveLimit;
+	traceFilterBuild({
+		phase: 'pagination-plan',
+		resource,
+		operation: effectiveOperation,
+		correlationId,
+		summary: {
+			effectiveLimit,
+			effectiveOffset,
+			queryLimit,
+			recencyActive: recencyResult.isActive,
+			offsetIgnoredDueToRecency: recencyResult.isActive && effectiveOffset > 0,
+			offsetExceedsApiCap,
+			outputMode: params.outputMode ?? 'idsAndLabels',
+		},
+	});
 
-    if (supportsOffsetPagination && offsetExceedsApiCap && !params.returnAll) {
-        return attachCorrelation(JSON.stringify(wrapError(
-            resource, effectiveOperation, ERROR_TYPES.INVALID_FILTER_CONSTRAINT,
-            `Offset ${effectiveOffset} exceeds the maximum queryable range of ${MAX_QUERY_LIMIT} records. Pagination via offset is limited to the first ${MAX_QUERY_LIMIT} records.`,
-            `Use narrower filters (e.g. date ranges via since/until, or more specific filter_field/filter_value) to reduce the result set, then paginate within the narrowed results.`,
-        )), correlationId);
-    }
+	if (supportsOffsetPagination && offsetExceedsApiCap && !params.returnAll) {
+		return attachCorrelation(
+			JSON.stringify(
+				wrapError(
+					resource,
+					effectiveOperation,
+					ERROR_TYPES.INVALID_FILTER_CONSTRAINT,
+					`Offset ${effectiveOffset} exceeds the maximum queryable range of ${MAX_QUERY_LIMIT} records. Pagination via offset is limited to the first ${MAX_QUERY_LIMIT} records.`,
+					`Use narrower filters (e.g. date ranges via since/until, or more specific filter_field/filter_value) to reduce the result set, then paginate within the narrowed results.`,
+				),
+			),
+			correlationId,
+		);
+	}
 
-    const idValidation = validateEntityId(entityId, resource, effectiveOperation);
-    if (!idValidation.valid) {
-        return attachCorrelation(JSON.stringify(idValidation.error), correlationId);
-    }
+	const idValidation = validateEntityId(entityId, resource, effectiveOperation);
+	if (!idValidation.valid) {
+		return attachCorrelation(JSON.stringify(idValidation.error), correlationId);
+	}
 
-    // Pre-flight: operations using the identifier-pair pattern (id OR altIdField) require at least one.
-    // This returns a structured error before the runtime handler throws an unhandled exception.
-    const idPairConfig = getIdentifierPairConfig(resource, effectiveOperation);
-    if (idPairConfig) {
-        const hasId = typeof params.id === 'number' && params.id > 0;
-        const hasAltId = typeof params[idPairConfig.altIdField as keyof typeof params] === 'string'
-            && (params[idPairConfig.altIdField as keyof typeof params] as string).trim() !== '';
-        if (!hasId && !hasAltId) {
-            return attachCorrelation(JSON.stringify(wrapError(
-                resource,
-                operation,
-                ERROR_TYPES.INVALID_FILTER_CONSTRAINT,
-                `${effectiveOperation} requires a ticket identifier: provide 'id' (numeric Ticket ID) or '${idPairConfig.altIdField}' (format ${idPairConfig.altIdFormat}, e.g. ${idPairConfig.altIdExample}).`,
-                `Call autotask_${resource} with operation '${effectiveOperation}' and include either 'id' (numeric Ticket ID) or '${idPairConfig.altIdField}' (format ${idPairConfig.altIdFormat}, e.g. ${idPairConfig.altIdExample}).`,
-            )), correlationId);
-        }
-    }
+	// Pre-flight: operations using the identifier-pair pattern (id OR altIdField) require at least one.
+	// This returns a structured error before the runtime handler throws an unhandled exception.
+	const idPairConfig = getIdentifierPairConfig(resource, effectiveOperation);
+	if (idPairConfig) {
+		const hasId = typeof params.id === 'number' && params.id > 0;
+		const hasAltId =
+			typeof params[idPairConfig.altIdField as keyof typeof params] === 'string' &&
+			(params[idPairConfig.altIdField as keyof typeof params] as string).trim() !== '';
+		if (!hasId && !hasAltId) {
+			return attachCorrelation(
+				JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.INVALID_FILTER_CONSTRAINT,
+						`${effectiveOperation} requires a ticket identifier: provide 'id' (numeric Ticket ID) or '${idPairConfig.altIdField}' (format ${idPairConfig.altIdFormat}, e.g. ${idPairConfig.altIdExample}).`,
+						`Call autotask_${resource} with operation '${effectiveOperation}' and include either 'id' (numeric Ticket ID) or '${idPairConfig.altIdField}' (format ${idPairConfig.altIdFormat}, e.g. ${idPairConfig.altIdExample}).`,
+					),
+				),
+				correlationId,
+			);
+		}
+	}
 
-    if (['get', 'getMany', 'getPosted', 'getUnposted', 'count', 'whoAmI', 'searchByDomain'].includes(effectiveOperation)) {
-        const udfFilters = filters.filter((filter) => filter.udf);
-        if (udfFilters.length > 1) {
-            return attachCorrelation(JSON.stringify(
-                formatFilterConstraintError(
-                    resource,
-                    effectiveOperation,
-                    `Only one UDF filter is supported per query for ${resource}.${effectiveOperation}.`,
-                    `Retry with a single UDF filter, or use autotask_${resource} with operation 'describeFields' to use standard fields where possible.`,
-                ),
-            ), correlationId);
-        }
-        const readValidation = validateReadFields(selectedColumns, readFields, resource, effectiveOperation);
-        if (!readValidation.valid) {
-            return attachCorrelation(JSON.stringify(readValidation.error), correlationId);
-        }
-    }
+	if (
+		['get', 'getMany', 'getPosted', 'getUnposted', 'count', 'whoAmI', 'searchByDomain'].includes(
+			effectiveOperation,
+		)
+	) {
+		const udfFilters = filters.filter((filter) => filter.udf);
+		if (udfFilters.length > 1) {
+			return attachCorrelation(
+				JSON.stringify(
+					formatFilterConstraintError(
+						resource,
+						effectiveOperation,
+						`Only one UDF filter is supported per query for ${resource}.${effectiveOperation}.`,
+						`Retry with a single UDF filter, or use autotask_${resource} with operation 'describeFields' to use standard fields where possible.`,
+					),
+				),
+				correlationId,
+			);
+		}
+		const readValidation = validateReadFields(
+			selectedColumns,
+			readFields,
+			resource,
+			effectiveOperation,
+		);
+		if (!readValidation.valid) {
+			return attachCorrelation(JSON.stringify(readValidation.error), correlationId);
+		}
+	}
 
-    if (['create', 'update', 'createIfNotExists'].includes(effectiveOperation)) {
-        const writeValidation = validateWriteFields(fieldValues, writeFields, resource, effectiveOperation);
-        if (!writeValidation.valid) {
-            return attachCorrelation(JSON.stringify(writeValidation.error), correlationId);
-        }
-    }
+	if (['create', 'update', 'createIfNotExists'].includes(effectiveOperation)) {
+		const writeValidation = validateWriteFields(
+			fieldValues,
+			writeFields,
+			resource,
+			effectiveOperation,
+		);
+		if (!writeValidation.valid) {
+			return attachCorrelation(JSON.stringify(writeValidation.error), correlationId);
+		}
+	}
 
-    // Resolve human-readable labels to IDs for picklist and reference fields on write ops.
-    // This allows the LLM to pass names (e.g. "Will Spence") instead of numeric IDs.
-    let labelResolutions: LabelResolution[] = [];
-    let labelWarnings: string[] = [];
-    let labelPendingConfirmations: PendingLabelConfirmation[] = [];
-    if (['create', 'update', 'createIfNotExists'].includes(effectiveOperation) && Object.keys(fieldValues).length > 0) {
-        try {
-            const resolution = await resolveLabelsToIds(context, resource, fieldValues as IDataObject);
-            // Replace fieldValues entries with resolved IDs in-place
-            for (const [key, value] of Object.entries(resolution.values)) {
-                fieldValues[key] = value;
-            }
-            labelResolutions = resolution.resolutions;
-            labelWarnings = resolution.warnings;
-            labelPendingConfirmations = resolution.pendingConfirmations;
-        } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            labelWarnings.push(`Label resolution failed: ${msg}.`);
-        }
-    }
+	// Resolve human-readable labels to IDs for picklist and reference fields on write ops.
+	// This allows the LLM to pass names (e.g. "Will Spence") instead of numeric IDs.
+	let labelResolutions: LabelResolution[] = [];
+	let labelWarnings: string[] = [];
+	let labelPendingConfirmations: PendingLabelConfirmation[] = [];
+	if (
+		['create', 'update', 'createIfNotExists'].includes(effectiveOperation) &&
+		Object.keys(fieldValues).length > 0
+	) {
+		try {
+			const resolution = await resolveLabelsToIds(context, resource, fieldValues as IDataObject);
+			// Replace fieldValues entries with resolved IDs in-place
+			for (const [key, value] of Object.entries(resolution.values)) {
+				fieldValues[key] = value;
+			}
+			labelResolutions = resolution.resolutions;
+			labelWarnings = resolution.warnings;
+			labelPendingConfirmations = resolution.pendingConfirmations;
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			labelWarnings.push(`Label resolution failed: ${msg}.`);
+		}
+	}
 
-    // Resolve impersonationResourceId name/email → numeric ID for write operations only.
-    // Gated to write ops to avoid unnecessary Resource entity list fetch on reads.
-    const isWriteOperation = ['create', 'createIfNotExists', 'update', 'moveConfigurationItem', 'moveToCompany', 'transferOwnership', 'approve', 'reject', 'delete'].includes(effectiveOperation);
-    let resolvedImpersonationId: number | undefined;
-    let labelImpersonationFailed = false;
-    const rawImpersonation = params.impersonationResourceId;
-    if (isWriteOperation && rawImpersonation !== undefined && rawImpersonation !== null && rawImpersonation !== '') {
-        const impersonationValue = typeof rawImpersonation === 'string' ? rawImpersonation.trim() : rawImpersonation;
-        const isNumericId = typeof impersonationValue === 'number' ||
-            (typeof impersonationValue === 'string' && /^\d+$/.test(impersonationValue) && String(parseInt(impersonationValue, 10)) === impersonationValue);
+	// Resolve impersonationResourceId name/email → numeric ID for write operations only.
+	// Gated to write ops to avoid unnecessary Resource entity list fetch on reads.
+	const isWriteOperation = [
+		'create',
+		'createIfNotExists',
+		'update',
+		'moveConfigurationItem',
+		'moveToCompany',
+		'transferOwnership',
+		'approve',
+		'reject',
+		'delete',
+	].includes(effectiveOperation);
+	let resolvedImpersonationId: number | undefined;
+	let labelImpersonationFailed = false;
+	const rawImpersonation = params.impersonationResourceId;
+	if (
+		isWriteOperation &&
+		rawImpersonation !== undefined &&
+		rawImpersonation !== null &&
+		rawImpersonation !== ''
+	) {
+		const impersonationValue =
+			typeof rawImpersonation === 'string' ? rawImpersonation.trim() : rawImpersonation;
+		const isNumericId =
+			typeof impersonationValue === 'number' ||
+			(typeof impersonationValue === 'string' &&
+				/^\d+$/.test(impersonationValue) &&
+				String(parseInt(impersonationValue, 10)) === impersonationValue);
 
-        if (isNumericId) {
-            resolvedImpersonationId = typeof impersonationValue === 'number' ? impersonationValue : parseInt(impersonationValue, 10);
-        } else if (typeof impersonationValue === 'string') {
-            // Resolve name or email to resource ID
-            try {
-                const { EntityValueHelper } = await import('../helpers/entity-values/value-helper');
-                const helper = new EntityValueHelper(context as unknown as import('n8n-workflow').ILoadOptionsFunctions, 'Resource');
-                const candidates = await helper.getValues(true);
-                const label = impersonationValue.toLowerCase();
+		if (isNumericId) {
+			resolvedImpersonationId =
+				typeof impersonationValue === 'number'
+					? impersonationValue
+					: parseInt(impersonationValue, 10);
+		} else if (typeof impersonationValue === 'string') {
+			// Resolve name or email to resource ID
+			try {
+				const { EntityValueHelper } = await import('../helpers/entity-values/value-helper');
+				const helper = new EntityValueHelper(
+					context as unknown as import('n8n-workflow').ILoadOptionsFunctions,
+					'Resource',
+				);
+				const candidates = await helper.getValues(true);
+				const label = impersonationValue.toLowerCase();
 
-                // Try exact name match first
-                let matchedId: number | undefined;
-                for (const entity of candidates) {
-                    const entityObj = entity as unknown as IDataObject;
-                    const display = helper.getEntityDisplayName(entityObj);
-                    if (display && display.toLowerCase() === label) {
-                        matchedId = entityObj.id as number;
-                        break;
-                    }
-                    // Also check email fields (must check each independently — ?? stops at first non-null)
-                    const emailFields = [entityObj.email, entityObj.email2, entityObj.email3] as (string | undefined)[];
-                    if (emailFields.some(e => e && e.toLowerCase() === label)) {
-                        matchedId = entityObj.id as number;
-                        break;
-                    }
-                }
+				// Try exact name match first
+				let matchedId: number | undefined;
+				for (const entity of candidates) {
+					const entityObj = entity as unknown as IDataObject;
+					const display = helper.getEntityDisplayName(entityObj);
+					if (display && display.toLowerCase() === label) {
+						matchedId = entityObj.id as number;
+						break;
+					}
+					// Also check email fields (must check each independently — ?? stops at first non-null)
+					const emailFields = [entityObj.email, entityObj.email2, entityObj.email3] as (
+						| string
+						| undefined
+					)[];
+					if (emailFields.some((e) => e && e.toLowerCase() === label)) {
+						matchedId = entityObj.id as number;
+						break;
+					}
+				}
 
-                if (matchedId !== undefined) {
-                    resolvedImpersonationId = matchedId;
-                    labelResolutions.push({ field: 'impersonationResourceId', from: impersonationValue, to: matchedId, method: 'reference' });
-                } else {
-                    labelImpersonationFailed = true;
-                    labelWarnings.push(`Could not resolve impersonation resource '${impersonationValue}' to a resource ID. Provide a numeric ID instead.`);
-                }
-            } catch (err) {
-                const msg = err instanceof Error ? err.message : String(err);
-                labelImpersonationFailed = true;
-                labelWarnings.push(`[INFRASTRUCTURE] Impersonation resource resolution failed: ${msg}. Provide a numeric ID instead.`);
-            }
-        }
-    }
+				if (matchedId !== undefined) {
+					resolvedImpersonationId = matchedId;
+					labelResolutions.push({
+						field: 'impersonationResourceId',
+						from: impersonationValue,
+						to: matchedId,
+						method: 'reference',
+					});
+				} else {
+					labelImpersonationFailed = true;
+					labelWarnings.push(
+						`Could not resolve impersonation resource '${impersonationValue}' to a resource ID. Provide a numeric ID instead.`,
+					);
+				}
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				labelImpersonationFailed = true;
+				labelWarnings.push(
+					`[INFRASTRUCTURE] Impersonation resource resolution failed: ${msg}. Provide a numeric ID instead.`,
+				);
+			}
+		}
+	}
+	traceLabelResolution({
+		phase: 'write-resolution',
+		resource,
+		operation: effectiveOperation,
+		correlationId,
+		summary: {
+			attempted: isWriteOperation && Object.keys(fieldValues).length > 0,
+			...summariseResolutionState(labelResolutions, labelWarnings, labelPendingConfirmations),
+			impersonationResolved: resolvedImpersonationId !== undefined,
+			impersonationFailed: labelImpersonationFailed,
+			...(AI_TOOL_DEBUG_VERBOSE ? { fieldValuesPreview: redactForVerbose(fieldValues) } : {}),
+		},
+	});
 
-    // Pre-execution write guard: block if any resolution failure condition exists.
-    if (isWriteOperation) {
-        const blocker = buildWriteResolutionBlocker(
-            resource,
-            effectiveOperation,
-            labelPendingConfirmations,
-            labelWarnings,
-            labelImpersonationFailed,
-        );
-        if (blocker !== null) return attachCorrelation(blocker, correlationId);
-    }
+	// Pre-execution write guard: block if any resolution failure condition exists.
+	if (isWriteOperation) {
+		const blocker = buildWriteResolutionBlocker(
+			resource,
+			effectiveOperation,
+			labelPendingConfirmations,
+			labelWarnings,
+			labelImpersonationFailed,
+		);
+		if (blocker !== null) return attachCorrelation(blocker, correlationId);
+	}
 
-    if (rawParams.dryRun === true) {
-        return attachCorrelation(JSON.stringify(wrapSuccess(resource, effectiveOperation,
-            buildResultPayload('summary', {
-                resolvedFieldValues: fieldValues,
-                note: 'Dry run only — no API call was made. The resolved field values above show exactly what would have been sent to the Autotask API.',
-            }, { mutated: false, retryable: true, dryRunOnly: true }, {
-                warnings: labelWarnings,
-                appliedResolutions: labelResolutions,
-            }),
-        )), correlationId);
-    }
+	if (rawParams.dryRun === true) {
+		const dryRunResponse = JSON.stringify(
+			wrapSuccess(
+				resource,
+				effectiveOperation,
+				buildResultPayload(
+					'summary',
+					{
+						resolvedFieldValues: fieldValues,
+						note: 'Dry run only — no API call was made. The resolved field values above show exactly what would have been sent to the Autotask API.',
+					},
+					{ mutated: false, retryable: true, dryRunOnly: true },
+					{
+						warnings: labelWarnings,
+						appliedResolutions: labelResolutions,
+					},
+				),
+			),
+		);
+		traceResponse({
+			phase: 'dry-run',
+			resource,
+			operation: effectiveOperation,
+			correlationId,
+			durationMs: Date.now() - startedAt,
+			summary: summariseResponseEnvelope(dryRunResponse),
+		});
+		return attachCorrelation(dryRunResponse, correlationId);
+	}
 
-    context.getNodeParameter = ((
-        name: string,
-        index: number,
-        fallbackValue?: unknown,
-        options?: IGetNodeParameterOptions,
-    ): unknown => {
-        switch (name) {
-            case 'resource':
-                return resource;
-            case 'operation':
-                return effectiveOperation;
-            case 'id':
-                return entityId;
-            case 'targetOperation':
-                return `${resource}.${effectiveOperation}`;
-            case 'entityId':
-                return entityId;
-            case 'requestData': {
-                const data: Record<string, unknown> =
-                    ['getMany', 'getPosted', 'getUnposted', 'count'].includes(effectiveOperation) && combinedFilters.length > 0
-                        ? { filter: combinedFilters }
-                        : Object.keys(fieldValues).length > 0
-                            ? fieldValues
-                            : {};
-                if (effectiveOperation === 'slaHealthCheck') {
-                    if (params.id !== undefined) {
-                        data.id = params.id;
-                    }
-                    if (typeof params.ticketNumber === 'string' && params.ticketNumber.trim() !== '') {
-                        data.ticketNumber = params.ticketNumber.trim();
-                    }
-                    if (selectedSlaTicketColumns.length > 0) {
-                        data.slaTicketFields = selectedSlaTicketColumns;
-                    }
-                }
-                // Always apply bounded query limits for list/count style operations.
-                // Note: offset is applied client-side only (slice after fetch), not sent to API.
-                if (['getMany', 'getPosted', 'getUnposted', 'count'].includes(effectiveOperation)) {
-                    data.limit = queryLimit;
-                }
-                if (effectiveOperation === 'searchByDomain') {
-                    data.limit = effectiveLimit;
-                }
-                return JSON.stringify(data);
-            }
-            case 'fieldsToMap':
-                if (['create', 'update'].includes(effectiveOperation) && Object.keys(fieldValues).length > 0) {
-                    return { mappingMode: 'defineBelow', value: fieldValues };
-                }
-                if (['getMany', 'getPosted', 'getUnposted', 'count'].includes(effectiveOperation) && combinedFilters.length > 0) {
-                    const value: Record<string, unknown> = {};
-                    // Only extract field/value from flat filter objects (skip nested OR/AND groups)
-                    for (const f of combinedFilters) {
-                        if (f.field !== undefined) {
-                            value[f.field] = f.value;
-                        }
-                    }
-                    return { value };
-                }
-                return fallbackValue ?? { value: {} };
-            case 'filtersFromTool':
-                return ['getMany', 'getPosted', 'getUnposted', 'count'].includes(effectiveOperation) && combinedFilters.length > 0
-                    ? combinedFilters
-                    : undefined;
-            case 'returnAll':
-                return params.returnAll === true;
-            case 'maxRecords':
-                return params.returnAll === true
-                    ? undefined  // executeScopedQuery handles full pagination internally; MaxRecords is ignored
-                    : queryLimit;
-            case 'bodyJson':
-                if (['create', 'update'].includes(effectiveOperation) && Object.keys(fieldValues).length > 0) {
-                    return JSON.stringify(fieldValues);
-                }
-                return fallbackValue ?? '{}';
-            // Label enrichment and UDF flattening -- default to idsAndLabels; caller may override to rawIds.
-            // addPicklistLabels and addReferenceLabels remain hardcoded true even when outputMode='rawIds':
-            // processOutputMode() reads outputMode first and short-circuits label enrichment before these
-            // flags are consulted, so they have no effect in rawIds mode. Keeping them true avoids
-            // sending a narrower IncludeFields request that would omit label columns needed if the
-            // caller later switches back to idsAndLabels without a new API call.
-            case 'outputMode':
-                return (params.outputMode as string | undefined) ?? 'idsAndLabels';
-            case 'addPicklistLabels':
-                return true;
-            case 'addReferenceLabels':
-                return true;
-            case 'flattenUdfs':
-                return true;
-            case 'ticketIdentifierType': {
-                const ipc = getIdentifierPairConfig(resource, effectiveOperation);
-                if (ipc) {
-                    const altVal = params[ipc.altIdField as keyof typeof params];
-                    return (typeof altVal === 'string' && altVal.trim() !== '') ? ipc.altIdField : 'id';
-                }
-                return fallbackValue;
-            }
-            case 'ticketNumber': {
-                const ipc = getIdentifierPairConfig(resource, effectiveOperation);
-                if (ipc && ipc.altIdField === 'ticketNumber') {
-                    return typeof params.ticketNumber === 'string' ? params.ticketNumber.trim() : fallbackValue;
-                }
-                return fallbackValue;
-            }
-            case 'includeRaw':
-                if (effectiveOperation === 'summary') {
-                    return typeof params.includeRaw === 'boolean' ? params.includeRaw : false;
-                }
-                return fallbackValue;
-            case 'summaryTextLimit':
-                if (effectiveOperation === 'summary') {
-                    return typeof params.summaryTextLimit === 'number' ? params.summaryTextLimit : 500;
-                }
-                return fallbackValue;
-            case 'includeChildCounts':
-                if (effectiveOperation === 'summary') {
-                    return typeof params.includeChildCounts === 'boolean' ? params.includeChildCounts : false;
-                }
-                return fallbackValue;
-            case 'slaTicketFields':
-                if (effectiveOperation === 'slaHealthCheck') {
-                    return selectedSlaTicketColumns.length > 0 ? selectedSlaTicketColumns : [];
-                }
-                return fallbackValue;
-            // Column selection
-            case 'selectColumns':
-                return selectedColumns.length > 0 ? selectedColumns : [];
-            case 'selectColumnsJson':
-                return selectedColumns.length > 0 ? JSON.stringify(selectedColumns) : '[]';
-            case 'allowWriteOperations':
-                return originalGetNodeParameter('allowWriteOperations', index, false);
-            case 'impersonationResourceId':
-                if (resolvedImpersonationId !== undefined) {
-                    return resolvedImpersonationId;
-                }
-                // If rawImpersonation was a non-numeric string that failed resolution,
-                // return fallbackValue so getOptionalImpersonationResourceId treats it as absent.
-                // The warning is already in labelWarnings.
-                if (typeof rawImpersonation === 'string' && rawImpersonation.trim() !== '' && !/^\d+$/.test(rawImpersonation.trim())) {
-                    return fallbackValue;
-                }
-                return rawImpersonation ?? fallbackValue;
-            case 'allowedResources':
-                // The AI tools path validates resource+operations in supplyData() at tool
-                // construction time. The downstream executor's allowedResources check is
-                // redundant — the AI tool already ensures only the configured resource's
-                // operations reach executeAiTool(). Empty array disables the allowlist check.
-                return '[]';
-            case 'allowDryRunForWrites':
-                // The AI path manages its own dry-run response contract: params.dryRun is
-                // stripped from API bodies via N8N_METADATA_FIELDS. This must remain true
-                // to allow the downstream executor to process dryRun calls that originate
-                // from the AI schema (currently exposed on moveToCompany / moveConfigurationItem
-                // / transferOwnership; extending to all write ops is a follow-on task).
-                return true;
-            default:
-                if (Object.prototype.hasOwnProperty.call(params, name)) {
-                    return params[name as keyof ToolExecutorParams];
-                }
-                return originalGetNodeParameter(name, index, fallbackValue, options);
-        }
-    }) as typeof context.getNodeParameter;
+	context.getNodeParameter = ((
+		name: string,
+		index: number,
+		fallbackValue?: unknown,
+		options?: IGetNodeParameterOptions,
+	): unknown => {
+		switch (name) {
+			case 'resource':
+				return resource;
+			case 'operation':
+				return effectiveOperation;
+			case 'id':
+				return entityId;
+			case 'targetOperation':
+				return `${resource}.${effectiveOperation}`;
+			case 'entityId':
+				return entityId;
+			case 'requestData': {
+				const data: Record<string, unknown> =
+					['getMany', 'getPosted', 'getUnposted', 'count'].includes(effectiveOperation) &&
+					combinedFilters.length > 0
+						? { filter: combinedFilters }
+						: Object.keys(fieldValues).length > 0
+							? fieldValues
+							: {};
+				if (effectiveOperation === 'slaHealthCheck') {
+					if (params.id !== undefined) {
+						data.id = params.id;
+					}
+					if (typeof params.ticketNumber === 'string' && params.ticketNumber.trim() !== '') {
+						data.ticketNumber = params.ticketNumber.trim();
+					}
+					if (selectedSlaTicketColumns.length > 0) {
+						data.slaTicketFields = selectedSlaTicketColumns;
+					}
+				}
+				// Always apply bounded query limits for list/count style operations.
+				// Note: offset is applied client-side only (slice after fetch), not sent to API.
+				if (['getMany', 'getPosted', 'getUnposted', 'count'].includes(effectiveOperation)) {
+					data.limit = queryLimit;
+				}
+				if (effectiveOperation === 'searchByDomain') {
+					data.limit = effectiveLimit;
+				}
+				return JSON.stringify(data);
+			}
+			case 'fieldsToMap':
+				if (
+					['create', 'update'].includes(effectiveOperation) &&
+					Object.keys(fieldValues).length > 0
+				) {
+					return { mappingMode: 'defineBelow', value: fieldValues };
+				}
+				if (
+					['getMany', 'getPosted', 'getUnposted', 'count'].includes(effectiveOperation) &&
+					combinedFilters.length > 0
+				) {
+					const value: Record<string, unknown> = {};
+					// Only extract field/value from flat filter objects (skip nested OR/AND groups)
+					for (const f of combinedFilters) {
+						if (f.field !== undefined) {
+							value[f.field] = f.value;
+						}
+					}
+					return { value };
+				}
+				return fallbackValue ?? { value: {} };
+			case 'filtersFromTool':
+				return ['getMany', 'getPosted', 'getUnposted', 'count'].includes(effectiveOperation) &&
+					combinedFilters.length > 0
+					? combinedFilters
+					: undefined;
+			case 'returnAll':
+				return params.returnAll === true;
+			case 'maxRecords':
+				return params.returnAll === true
+					? undefined // executeScopedQuery handles full pagination internally; MaxRecords is ignored
+					: queryLimit;
+			case 'bodyJson':
+				if (
+					['create', 'update'].includes(effectiveOperation) &&
+					Object.keys(fieldValues).length > 0
+				) {
+					return JSON.stringify(fieldValues);
+				}
+				return fallbackValue ?? '{}';
+			// Label enrichment and UDF flattening -- default to idsAndLabels; caller may override to rawIds.
+			// addPicklistLabels and addReferenceLabels remain hardcoded true even when outputMode='rawIds':
+			// processOutputMode() reads outputMode first and short-circuits label enrichment before these
+			// flags are consulted, so they have no effect in rawIds mode. Keeping them true avoids
+			// sending a narrower IncludeFields request that would omit label columns needed if the
+			// caller later switches back to idsAndLabels without a new API call.
+			case 'outputMode':
+				return (params.outputMode as string | undefined) ?? 'idsAndLabels';
+			case 'addPicklistLabels':
+				return true;
+			case 'addReferenceLabels':
+				return true;
+			case 'flattenUdfs':
+				return true;
+			case 'ticketIdentifierType': {
+				const ipc = getIdentifierPairConfig(resource, effectiveOperation);
+				if (ipc) {
+					const altVal = params[ipc.altIdField as keyof typeof params];
+					return typeof altVal === 'string' && altVal.trim() !== '' ? ipc.altIdField : 'id';
+				}
+				return fallbackValue;
+			}
+			case 'ticketNumber': {
+				const ipc = getIdentifierPairConfig(resource, effectiveOperation);
+				if (ipc && ipc.altIdField === 'ticketNumber') {
+					return typeof params.ticketNumber === 'string'
+						? params.ticketNumber.trim()
+						: fallbackValue;
+				}
+				return fallbackValue;
+			}
+			case 'includeRaw':
+				if (effectiveOperation === 'summary') {
+					return typeof params.includeRaw === 'boolean' ? params.includeRaw : false;
+				}
+				return fallbackValue;
+			case 'summaryTextLimit':
+				if (effectiveOperation === 'summary') {
+					return typeof params.summaryTextLimit === 'number' ? params.summaryTextLimit : 500;
+				}
+				return fallbackValue;
+			case 'includeChildCounts':
+				if (effectiveOperation === 'summary') {
+					return typeof params.includeChildCounts === 'boolean' ? params.includeChildCounts : false;
+				}
+				return fallbackValue;
+			case 'slaTicketFields':
+				if (effectiveOperation === 'slaHealthCheck') {
+					return selectedSlaTicketColumns.length > 0 ? selectedSlaTicketColumns : [];
+				}
+				return fallbackValue;
+			// Column selection
+			case 'selectColumns':
+				return selectedColumns.length > 0 ? selectedColumns : [];
+			case 'selectColumnsJson':
+				return selectedColumns.length > 0 ? JSON.stringify(selectedColumns) : '[]';
+			case 'allowWriteOperations':
+				return originalGetNodeParameter('allowWriteOperations', index, false);
+			case 'impersonationResourceId':
+				if (resolvedImpersonationId !== undefined) {
+					return resolvedImpersonationId;
+				}
+				// If rawImpersonation was a non-numeric string that failed resolution,
+				// return fallbackValue so getOptionalImpersonationResourceId treats it as absent.
+				// The warning is already in labelWarnings.
+				if (
+					typeof rawImpersonation === 'string' &&
+					rawImpersonation.trim() !== '' &&
+					!/^\d+$/.test(rawImpersonation.trim())
+				) {
+					return fallbackValue;
+				}
+				return rawImpersonation ?? fallbackValue;
+			case 'allowedResources':
+				// The AI tools path validates resource+operations in supplyData() at tool
+				// construction time. The downstream executor's allowedResources check is
+				// redundant — the AI tool already ensures only the configured resource's
+				// operations reach executeAiTool(). Empty array disables the allowlist check.
+				return '[]';
+			case 'allowDryRunForWrites':
+				// The AI path manages its own dry-run response contract: params.dryRun is
+				// stripped from API bodies via N8N_METADATA_FIELDS. This must remain true
+				// to allow the downstream executor to process dryRun calls that originate
+				// from the AI schema (currently exposed on moveToCompany / moveConfigurationItem
+				// / transferOwnership; extending to all write ops is a follow-on task).
+				return true;
+			default:
+				if (Object.prototype.hasOwnProperty.call(params, name)) {
+					return params[name as keyof ToolExecutorParams];
+				}
+				return originalGetNodeParameter(name, index, fallbackValue, options);
+		}
+	}) as typeof context.getNodeParameter;
 
-    try {
-        // Compound operation short-circuit: createIfNotExists bypasses the standard executor
-        if (effectiveOperation === 'createIfNotExists') {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            let compoundResult: any;
+	try {
+		// Compound operation short-circuit: createIfNotExists bypasses the standard executor
+		if (effectiveOperation === 'createIfNotExists') {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			let compoundResult: any;
 
-            // createFields comes from fieldValues (already validated + label-resolved above)
-            // Convert date fields from user timezone to UTC before passing to compound helpers,
-            // which bypass CreateOperation.execute() and therefore convertDatesToUTC.
-            const createFields: Record<string, unknown> = await convertDatesToUTC(
-                { ...fieldValues } as IDataObject,
-                resource,
-                context,
-                'createIfNotExists',
-            ) as Record<string, unknown>;
-            const DEFAULT_DEDUP_FIELDS: Record<string, string[]> = {
-                contractCharge: ['name', 'datePurchased'],
-                ticketCharge: ['name', 'datePurchased'],
-                projectCharge: ['name', 'datePurchased'],
-                configurationItems: ['serialNumber'],
-                timeEntry: ['dateWorked', 'hoursWorked'],
-                contractService: ['serviceID'],
-                contract: ['contractName'],
-                expenseItem: ['expenseDate', 'description'],
-                holiday: ['holidayDate'],
-                holidaySet: ['holidaySetName'],
-                opportunity: ['title'],
-                ticketAdditionalConfigurationItem: ['configurationItemID'],
-                ticketAdditionalContact: ['contactID'],
-                changeRequestLink: ['changeRequestTicketID', 'problemOrIncidentTicketID'],
-            };
-            const dedupFields = (params.dedupFields as string[]) ?? DEFAULT_DEDUP_FIELDS[resource] ?? [];
-            const errorOnDuplicate = params.errorOnDuplicate === true;
-            const updateFields = (params.updateFields as string[] | undefined) ?? [];
+			// createFields comes from fieldValues (already validated + label-resolved above)
+			// Convert date fields from user timezone to UTC before passing to compound helpers,
+			// which bypass CreateOperation.execute() and therefore convertDatesToUTC.
+			const createFields: Record<string, unknown> = (await convertDatesToUTC(
+				{ ...fieldValues } as IDataObject,
+				resource,
+				context,
+				'createIfNotExists',
+			)) as Record<string, unknown>;
+			const DEFAULT_DEDUP_FIELDS: Record<string, string[]> = {
+				contractCharge: ['name', 'datePurchased'],
+				ticketCharge: ['name', 'datePurchased'],
+				projectCharge: ['name', 'datePurchased'],
+				configurationItems: ['serialNumber'],
+				timeEntry: ['dateWorked', 'hoursWorked'],
+				contractService: ['serviceID'],
+				contract: ['contractName'],
+				expenseItem: ['expenseDate', 'description'],
+				holiday: ['holidayDate'],
+				holidaySet: ['holidaySetName'],
+				opportunity: ['title'],
+				ticketAdditionalConfigurationItem: ['configurationItemID'],
+				ticketAdditionalContact: ['contactID'],
+				changeRequestLink: ['changeRequestTicketID', 'problemOrIncidentTicketID'],
+			};
+			const dedupFields = (params.dedupFields as string[]) ?? DEFAULT_DEDUP_FIELDS[resource] ?? [];
+			const errorOnDuplicate = params.errorOnDuplicate === true;
+			const updateFields = (params.updateFields as string[] | undefined) ?? [];
 
-            const compoundOptions = {
-                createFields,
-                dedupFields,
-                errorOnDuplicate,
-                updateFields,
-                impersonationResourceId: resolvedImpersonationId,
-                proceedWithoutImpersonationIfDenied: params.proceedWithoutImpersonationIfDenied !== false,
-            };
+			const compoundOptions = {
+				createFields,
+				dedupFields,
+				errorOnDuplicate,
+				updateFields,
+				impersonationResourceId: resolvedImpersonationId,
+				proceedWithoutImpersonationIfDenied: params.proceedWithoutImpersonationIfDenied !== false,
+			};
 
-            if (resource === 'contractCharge') {
-                const { createContractChargeIfNotExists } = await import('../helpers/contract-charge-creator');
-                compoundResult = await createContractChargeIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'ticketCharge') {
-                const { createTicketChargeIfNotExists } = await import('../helpers/ticket-charge-creator');
-                compoundResult = await createTicketChargeIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'projectCharge') {
-                const { createProjectChargeIfNotExists } = await import('../helpers/project-charge-creator');
-                compoundResult = await createProjectChargeIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'configurationItems') {
-                const { createConfigurationItemIfNotExists } = await import('../helpers/configuration-item-creator');
-                compoundResult = await createConfigurationItemIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'timeEntry') {
-                const { createTimeEntryIfNotExists } = await import('../helpers/time-entry-creator');
-                compoundResult = await createTimeEntryIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'contractService') {
-                const { createContractServiceIfNotExists } = await import('../helpers/contract-service-creator');
-                compoundResult = await createContractServiceIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'contract') {
-                const { createContractIfNotExists } = await import('../helpers/contract-creator');
-                compoundResult = await createContractIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'opportunity') {
-                const { createOpportunityIfNotExists } = await import('../helpers/opportunity-creator');
-                compoundResult = await createOpportunityIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'expenseItem') {
-                const { createExpenseItemIfNotExists } = await import('../helpers/expense-item-creator');
-                compoundResult = await createExpenseItemIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'ticketAdditionalConfigurationItem') {
-                const { createTicketAdditionalCIIfNotExists } = await import('../helpers/ticket-additional-ci-creator');
-                compoundResult = await createTicketAdditionalCIIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'ticketAdditionalContact') {
-                const { createTicketAdditionalContactIfNotExists } = await import('../helpers/ticket-additional-contact-creator');
-                compoundResult = await createTicketAdditionalContactIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'changeRequestLink') {
-                const { createChangeRequestLinkIfNotExists } = await import('../helpers/change-request-link-creator');
-                compoundResult = await createChangeRequestLinkIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'holidaySet') {
-                const { createHolidaySetIfNotExists } = await import('../helpers/holiday-set-creator');
-                compoundResult = await createHolidaySetIfNotExists(context, 0, compoundOptions);
-            } else if (resource === 'holiday') {
-                const { createHolidayIfNotExists } = await import('../helpers/holiday-creator');
-                compoundResult = await createHolidayIfNotExists(context, 0, compoundOptions);
-            } else {
-                return attachCorrelation(JSON.stringify(wrapError(resource, 'createIfNotExists', ERROR_TYPES.INVALID_OPERATION,
-                    `createIfNotExists is not implemented for resource '${resource}'.`,
-                    `Use autotask_${resource} with operation 'create' instead.`,
-                )), correlationId);
-            }
+			if (resource === 'contractCharge') {
+				const { createContractChargeIfNotExists } =
+					await import('../helpers/contract-charge-creator');
+				compoundResult = await createContractChargeIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'ticketCharge') {
+				const { createTicketChargeIfNotExists } = await import('../helpers/ticket-charge-creator');
+				compoundResult = await createTicketChargeIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'projectCharge') {
+				const { createProjectChargeIfNotExists } =
+					await import('../helpers/project-charge-creator');
+				compoundResult = await createProjectChargeIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'configurationItems') {
+				const { createConfigurationItemIfNotExists } =
+					await import('../helpers/configuration-item-creator');
+				compoundResult = await createConfigurationItemIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'timeEntry') {
+				const { createTimeEntryIfNotExists } = await import('../helpers/time-entry-creator');
+				compoundResult = await createTimeEntryIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'contractService') {
+				const { createContractServiceIfNotExists } =
+					await import('../helpers/contract-service-creator');
+				compoundResult = await createContractServiceIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'contract') {
+				const { createContractIfNotExists } = await import('../helpers/contract-creator');
+				compoundResult = await createContractIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'opportunity') {
+				const { createOpportunityIfNotExists } = await import('../helpers/opportunity-creator');
+				compoundResult = await createOpportunityIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'expenseItem') {
+				const { createExpenseItemIfNotExists } = await import('../helpers/expense-item-creator');
+				compoundResult = await createExpenseItemIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'ticketAdditionalConfigurationItem') {
+				const { createTicketAdditionalCIIfNotExists } =
+					await import('../helpers/ticket-additional-ci-creator');
+				compoundResult = await createTicketAdditionalCIIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'ticketAdditionalContact') {
+				const { createTicketAdditionalContactIfNotExists } =
+					await import('../helpers/ticket-additional-contact-creator');
+				compoundResult = await createTicketAdditionalContactIfNotExists(
+					context,
+					0,
+					compoundOptions,
+				);
+			} else if (resource === 'changeRequestLink') {
+				const { createChangeRequestLinkIfNotExists } =
+					await import('../helpers/change-request-link-creator');
+				compoundResult = await createChangeRequestLinkIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'holidaySet') {
+				const { createHolidaySetIfNotExists } = await import('../helpers/holiday-set-creator');
+				compoundResult = await createHolidaySetIfNotExists(context, 0, compoundOptions);
+			} else if (resource === 'holiday') {
+				const { createHolidayIfNotExists } = await import('../helpers/holiday-creator');
+				compoundResult = await createHolidayIfNotExists(context, 0, compoundOptions);
+			} else {
+				return attachCorrelation(
+					JSON.stringify(
+						wrapError(
+							resource,
+							'createIfNotExists',
+							ERROR_TYPES.INVALID_OPERATION,
+							`createIfNotExists is not implemented for resource '${resource}'.`,
+							`Use autotask_${resource} with operation 'create' instead.`,
+						),
+					),
+					correlationId,
+				);
+			}
 
-            if (compoundResult) {
-                // Reclassify not-found outcomes as errors
-                if (PARENT_NOT_FOUND_OUTCOMES.has(compoundResult.outcome)) {
-                    const parentRef = compoundResult.parentLookupValue ?? compoundResult.companyID ?? compoundResult.ticketID ?? 'unknown';
-                    return attachCorrelation(JSON.stringify(wrapError(
-                        resource,
-                        'createIfNotExists',
-                        ERROR_TYPES.ENTITY_NOT_FOUND,
-                        `Parent entity not found: ${parentRef}`,
-                        `Verify the parent entity identifier and retry.`,
-                        { outcome: compoundResult.outcome },
-                    )), correlationId);
-                }
+			if (compoundResult) {
+				// Reclassify not-found outcomes as errors
+				if (PARENT_NOT_FOUND_OUTCOMES.has(compoundResult.outcome)) {
+					const parentRef =
+						compoundResult.parentLookupValue ??
+						compoundResult.companyID ??
+						compoundResult.ticketID ??
+						'unknown';
+					return attachCorrelation(
+						JSON.stringify(
+							wrapError(
+								resource,
+								'createIfNotExists',
+								ERROR_TYPES.ENTITY_NOT_FOUND,
+								`Parent entity not found: ${parentRef}`,
+								`Verify the parent entity identifier and retry.`,
+								{ outcome: compoundResult.outcome },
+							),
+						),
+						correlationId,
+					);
+				}
 
-                // Merge compound warnings with label resolution warnings
-                const rawCompoundWarnings: string[] = Array.isArray(compoundResult.warnings) ? compoundResult.warnings : [];
-                const allWarnings = [...rawCompoundWarnings, ...labelWarnings];
-                const partial = allWarnings.some(isResolutionFailureWarning);
+				// Merge compound warnings with label resolution warnings
+				const rawCompoundWarnings: string[] = Array.isArray(compoundResult.warnings)
+					? compoundResult.warnings
+					: [];
+				const allWarnings = [...rawCompoundWarnings, ...labelWarnings];
+				const partial = allWarnings.some(isResolutionFailureWarning);
 
-                const entityId = buildCompoundEntityId(resource, compoundResult);
-                const existingEntityId = buildCompoundExistingId(resource, compoundResult);
-                const compoundContext = buildCompoundContext(resource, compoundResult);
+				const entityId = buildCompoundEntityId(resource, compoundResult);
+				const existingEntityId = buildCompoundExistingId(resource, compoundResult);
+				const compoundContext = buildCompoundContext(resource, compoundResult);
 
-                const compoundData: Record<string, unknown> = {
-                    outcome: compoundResult.outcome,
-                };
-                if (entityId !== undefined) compoundData.id = entityId;
-                if (existingEntityId !== undefined) compoundData.existingId = existingEntityId;
-                if (compoundResult.matchedDedupFields !== undefined) compoundData.matchedDedupFields = compoundResult.matchedDedupFields;
-                if (compoundResult.fieldsUpdated !== undefined) compoundData.fieldsUpdated = compoundResult.fieldsUpdated;
-                if (compoundResult.fieldsCompared !== undefined) compoundData.fieldsCompared = compoundResult.fieldsCompared;
-                if (compoundContext !== undefined) compoundData.context = compoundContext;
+				const compoundData: Record<string, unknown> = {
+					outcome: compoundResult.outcome,
+				};
+				if (entityId !== undefined) compoundData.id = entityId;
+				if (existingEntityId !== undefined) compoundData.existingId = existingEntityId;
+				if (compoundResult.matchedDedupFields !== undefined)
+					compoundData.matchedDedupFields = compoundResult.matchedDedupFields;
+				if (compoundResult.fieldsUpdated !== undefined)
+					compoundData.fieldsUpdated = compoundResult.fieldsUpdated;
+				if (compoundResult.fieldsCompared !== undefined)
+					compoundData.fieldsCompared = compoundResult.fieldsCompared;
+				if (compoundContext !== undefined) compoundData.context = compoundContext;
 
-                return attachCorrelation(JSON.stringify(wrapSuccess(resource, 'createIfNotExists',
-                    buildResultPayload('compound', compoundData,
-                        {
-                            mutated: compoundResult.outcome !== 'skipped',
-                            retryable: compoundResult.outcome !== 'created',
-                            partial,
-                        }, {
-                            warnings: allWarnings,
-                            pendingConfirmations: labelPendingConfirmations,
-                            appliedResolutions: labelResolutions,
-                        },
-                    ),
-                )), correlationId);
-            }
-        }
+				return attachCorrelation(
+					JSON.stringify(
+						wrapSuccess(
+							resource,
+							'createIfNotExists',
+							buildResultPayload(
+								'compound',
+								compoundData,
+								{
+									mutated: compoundResult.outcome !== 'skipped',
+									retryable: compoundResult.outcome !== 'created',
+									partial,
+								},
+								{
+									warnings: allWarnings,
+									pendingConfirmations: labelPendingConfirmations,
+									appliedResolutions: labelResolutions,
+								},
+							),
+						),
+					),
+					correlationId,
+				);
+			}
+		}
 
-        const result = await executeToolOperation.call(context);
-        const items = result[0] ?? [];
-        const fetchedRecords = items.map((item) => item.json);
-        let records = fetchedRecords;
-        const supportsListResponse = ['getMany', 'getPosted', 'getUnposted'].includes(effectiveOperation);
-        // Recency takes priority: reverse-sort by date and take first N. Offset is not
-        // compatible with recency (recency re-sorts the full window), so ignore offset here.
-        if (recencyResult.isActive && supportsListResponse) {
-            records = fetchedRecords.slice().reverse().slice(0, effectiveLimit);
-        } else if (effectiveOffset > 0 && supportsListResponse) {
-            records = fetchedRecords.slice(effectiveOffset, effectiveOffset + effectiveLimit);
-            // Detect offset beyond available records — return clear error instead of
-            // misleading "no results found" which could trigger LLM data fabrication.
-            if (records.length === 0 && fetchedRecords.length > 0) {
-                return attachCorrelation(JSON.stringify(wrapError(
-                    resource, effectiveOperation, ERROR_TYPES.INVALID_FILTER_CONSTRAINT,
-                    `Offset ${effectiveOffset} is beyond the available ${fetchedRecords.length} records. No records remain at this offset.`,
-                    `Use offset=0 to start from the beginning, or use narrower filters to find specific records.`,
-                )), correlationId);
-            }
-        }
-        // Merge write label resolutions and filter label resolutions
-        const allResolutions = [...labelResolutions, ...filterResolutions];
-        const allWarnings = [...labelWarnings, ...filterWarnings];
-        const allPendingConfirmations = [...labelPendingConfirmations, ...filterPendingConfirmations];
-        // When recency is active, offset-based pagination is not supported — add a note
-        const recencyOffsetNote = recencyResult.isActive && effectiveOffset > 0
-            ? 'Offset is ignored when recency or since/until is active (recency re-sorts results by date).'
-            : undefined;
-        const responseContext: ToolResponseContext = {
-            recencyActive: recencyResult.isActive,
-            recencyNote: recencyResult.note ?? recencyOffsetNote,
-            recencyWindowLimited:
-                recencyResult.isActive &&
-                supportsListResponse &&
-                fetchedRecords.length >= RECENCY_OVER_REQUEST_LIMIT,
-            resolutions: allResolutions.length > 0 ? allResolutions : undefined,
-            resolutionWarnings: allWarnings.length > 0 ? allWarnings : undefined,
-            pendingConfirmations: allPendingConfirmations.length > 0 ? allPendingConfirmations : undefined,
-            effectiveOffset: recencyResult.isActive ? 0 : effectiveOffset,
-        };
+		traceExecutor({
+			phase: 'api-call-start',
+			resource,
+			operation: effectiveOperation,
+			correlationId,
+			summary: {
+				queryLimit,
+				hasFilters: combinedFilters.length > 0,
+				selectedColumnsCount: selectedColumns.length,
+			},
+		});
+		const result = await executeToolOperation.call(context);
+		const items = result[0] ?? [];
+		const fetchedRecords = items.map((item) => item.json);
+		let records = fetchedRecords;
+		const supportsListResponse = ['getMany', 'getPosted', 'getUnposted'].includes(
+			effectiveOperation,
+		);
+		// Recency takes priority: reverse-sort by date and take first N. Offset is not
+		// compatible with recency (recency re-sorts the full window), so ignore offset here.
+		if (recencyResult.isActive && supportsListResponse) {
+			records = fetchedRecords.slice().reverse().slice(0, effectiveLimit);
+		} else if (effectiveOffset > 0 && supportsListResponse) {
+			records = fetchedRecords.slice(effectiveOffset, effectiveOffset + effectiveLimit);
+			// Detect offset beyond available records — return clear error instead of
+			// misleading "no results found" which could trigger LLM data fabrication.
+			if (records.length === 0 && fetchedRecords.length > 0) {
+				return attachCorrelation(
+					JSON.stringify(
+						wrapError(
+							resource,
+							effectiveOperation,
+							ERROR_TYPES.INVALID_FILTER_CONSTRAINT,
+							`Offset ${effectiveOffset} is beyond the available ${fetchedRecords.length} records. No records remain at this offset.`,
+							`Use offset=0 to start from the beginning, or use narrower filters to find specific records.`,
+						),
+					),
+					correlationId,
+				);
+			}
+		}
+		// Merge write label resolutions and filter label resolutions
+		const allResolutions = [...labelResolutions, ...filterResolutions];
+		const allWarnings = [...labelWarnings, ...filterWarnings];
+		const allPendingConfirmations = [...labelPendingConfirmations, ...filterPendingConfirmations];
+		// When recency is active, offset-based pagination is not supported — add a note
+		const recencyOffsetNote =
+			recencyResult.isActive && effectiveOffset > 0
+				? 'Offset is ignored when recency or since/until is active (recency re-sorts results by date).'
+				: undefined;
+		const responseContext: ToolResponseContext = {
+			recencyActive: recencyResult.isActive,
+			recencyNote: recencyResult.note ?? recencyOffsetNote,
+			recencyWindowLimited:
+				recencyResult.isActive &&
+				supportsListResponse &&
+				fetchedRecords.length >= RECENCY_OVER_REQUEST_LIMIT,
+			resolutions: allResolutions.length > 0 ? allResolutions : undefined,
+			resolutionWarnings: allWarnings.length > 0 ? allWarnings : undefined,
+			pendingConfirmations:
+				allPendingConfirmations.length > 0 ? allPendingConfirmations : undefined,
+			effectiveOffset: recencyResult.isActive ? 0 : effectiveOffset,
+		};
 
-        // Apply Change Info Field aliases to ticket read results.
-        // Note: 'summary' applies aliases internally via buildTicketSummary — do not apply here.
-        if (resource === 'ticket' && effectiveOperation !== 'summary') {
-            const creds = await context.getCredentials('autotaskApi') as IAutotaskCredentials;
-            if (shouldApplyAliases(creds)) {
-                const aliasMap = buildAliasMap(creds);
-                if (effectiveOperation === 'slaHealthCheck') {
-                    const ticketData = (records[0] as Record<string, unknown>)?.ticket;
-                    if (ticketData) applyChangeInfoAliases(ticketData as Record<string, unknown>, aliasMap);
-                } else {
-                    for (const rec of records) {
-                        applyChangeInfoAliases(rec as Record<string, unknown>, aliasMap);
-                    }
-                }
-            }
-        }
+		// Apply Change Info Field aliases to ticket read results.
+		// Note: 'summary' applies aliases internally via buildTicketSummary — do not apply here.
+		if (resource === 'ticket' && effectiveOperation !== 'summary') {
+			const creds = (await context.getCredentials('autotaskApi')) as IAutotaskCredentials;
+			if (shouldApplyAliases(creds)) {
+				const aliasMap = buildAliasMap(creds);
+				if (effectiveOperation === 'slaHealthCheck') {
+					const ticketData = (records[0] as Record<string, unknown>)?.ticket;
+					if (ticketData) applyChangeInfoAliases(ticketData as Record<string, unknown>, aliasMap);
+				} else {
+					for (const rec of records) {
+						applyChangeInfoAliases(rec as Record<string, unknown>, aliasMap);
+					}
+				}
+			}
+		}
 
-        // Build structured response per operation type
-        return attachCorrelation(formatToolResponse(resource, effectiveOperation, records, params, responseContext), correlationId);
-    } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return attachCorrelation(JSON.stringify(formatApiError(message, resource, effectiveOperation)), correlationId);
-    } finally {
-        context.getNodeParameter = originalGetNodeParameter;
-    }
+		// Build structured response per operation type
+		const formattedResponse = formatToolResponse(
+			resource,
+			effectiveOperation,
+			records,
+			params,
+			responseContext,
+		);
+		traceResponse({
+			phase: 'operation-complete',
+			resource,
+			operation: effectiveOperation,
+			correlationId,
+			durationMs: Date.now() - startedAt,
+			summary: {
+				...summariseResponseEnvelope(formattedResponse),
+				recordsFetchedCount: fetchedRecords.length,
+				noResultsClassification: records.length === 0 ? 'empty' : 'non-empty',
+			},
+		});
+		return attachCorrelation(formattedResponse, correlationId);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		traceError({
+			phase: 'execute-catch',
+			resource,
+			operation: effectiveOperation,
+			correlationId,
+			durationMs: Date.now() - startedAt,
+			summary: {
+				errorMessage: message,
+				beforeApiCall: false,
+			},
+		});
+		return attachCorrelation(
+			JSON.stringify(formatApiError(message, resource, effectiveOperation)),
+			correlationId,
+		);
+	} finally {
+		context.getNodeParameter = originalGetNodeParameter;
+	}
 }
 
 /**
  * Format the raw execution result into a consistent, structured JSON response.
  */
 function formatToolResponse(
-    resource: string,
-    operation: string,
-    records: Record<string, unknown>[],
-    params: ToolExecutorParams,
-    context: ToolResponseContext = {},
+	resource: string,
+	operation: string,
+	records: Record<string, unknown>[],
+	params: ToolExecutorParams,
+	context: ToolResponseContext = {},
 ): string {
-    const firstRecord = records[0] ?? null;
-    const extractOperationId = (record: Record<string, unknown> | null): number | string | null => {
-        if (!record) return null;
-        const idCandidate = record.itemId ?? record.id;
-        if (typeof idCandidate === 'number' || typeof idCandidate === 'string') {
-            return idCandidate;
-        }
-        return null;
-    };
+	const firstRecord = records[0] ?? null;
+	const extractOperationId = (record: Record<string, unknown> | null): number | string | null => {
+		if (!record) return null;
+		const idCandidate = record.itemId ?? record.id;
+		if (typeof idCandidate === 'number' || typeof idCandidate === 'string') {
+			return idCandidate;
+		}
+		return null;
+	};
 
-    switch (operation) {
-        case 'get': {
-            const entity = firstRecord;
-            if (
-                entity === null ||
-                entity === undefined ||
-                (Array.isArray(entity) && entity.length === 0) ||
-                (typeof entity === 'object' && !Array.isArray(entity) && Object.keys(entity).length === 0)
-            ) {
-                const id = params.id ?? 'unknown';
-                return JSON.stringify(formatNotFoundError(resource, operation, id as number | string));
-            }
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('item', entity, { mutated: false, retryable: true }, {
-                    warnings: context.resolutionWarnings ?? [],
-                    pendingConfirmations: context.pendingConfirmations ?? [],
-                    appliedResolutions: context.resolutions ?? [],
-                }),
-            ));
-        }
+	switch (operation) {
+		case 'get': {
+			const entity = firstRecord;
+			if (
+				entity === null ||
+				entity === undefined ||
+				(Array.isArray(entity) && entity.length === 0) ||
+				(typeof entity === 'object' && !Array.isArray(entity) && Object.keys(entity).length === 0)
+			) {
+				const id = params.id ?? 'unknown';
+				return JSON.stringify(formatNotFoundError(resource, operation, id as number | string));
+			}
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'item',
+						entity,
+						{ mutated: false, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'getMany':
-        case 'getPosted':
-        case 'getUnposted': {
-            const hasFilters = !!(
-                params.filter_field ||
-                params.filter_field_2 ||
-                params.filtersJson ||
-                params.recency ||
-                params.since ||
-                params.until
-            );
-            if (hasFilters && records.length === 0) {
-                const filtersUsed: Record<string, unknown> = {};
-                if (params.filter_field) {
-                    filtersUsed.filter_field = params.filter_field;
-                    filtersUsed.filter_op = params.filter_op;
-                    filtersUsed.filter_value = params.filter_value;
-                }
-                if (params.filter_field_2) {
-                    filtersUsed.filter_field_2 = params.filter_field_2;
-                    filtersUsed.filter_op_2 = params.filter_op_2;
-                    filtersUsed.filter_value_2 = params.filter_value_2;
-                }
-                if (params.filter_logic && params.filter_logic !== 'and') filtersUsed.filter_logic = params.filter_logic;
-                if (params.filtersJson) filtersUsed.filtersJson = params.filtersJson;
-                if (params.recency) filtersUsed.recency = params.recency;
-                if (params.since) filtersUsed.since = params.since;
-                if (params.until) filtersUsed.until = params.until;
-                const noResultsError = formatNoResultsFound(resource, operation, filtersUsed);
-                // Surface any filter label resolution failures in the error context so the
-                // LLM can correlate empty results with a failed label lookup.
-                const unresolvedFilterWarnings = context.resolutionWarnings ?? [];
-                if (unresolvedFilterWarnings.length > 0) {
-                    noResultsError.context = {
-                        ...noResultsError.context,
-                        filterResolutionWarnings: unresolvedFilterWarnings,
-                    };
-                }
-                return JSON.stringify(noResultsError);
-            }
+		case 'getMany':
+		case 'getPosted':
+		case 'getUnposted': {
+			const hasFilters = !!(
+				params.filter_field ||
+				params.filter_field_2 ||
+				params.filtersJson ||
+				params.recency ||
+				params.since ||
+				params.until
+			);
+			if (hasFilters && records.length === 0) {
+				const filtersUsed: Record<string, unknown> = {};
+				if (params.filter_field) {
+					filtersUsed.filter_field = params.filter_field;
+					filtersUsed.filter_op = params.filter_op;
+					filtersUsed.filter_value = params.filter_value;
+				}
+				if (params.filter_field_2) {
+					filtersUsed.filter_field_2 = params.filter_field_2;
+					filtersUsed.filter_op_2 = params.filter_op_2;
+					filtersUsed.filter_value_2 = params.filter_value_2;
+				}
+				if (params.filter_logic && params.filter_logic !== 'and')
+					filtersUsed.filter_logic = params.filter_logic;
+				if (params.filtersJson) filtersUsed.filtersJson = params.filtersJson;
+				if (params.recency) filtersUsed.recency = params.recency;
+				if (params.since) filtersUsed.since = params.since;
+				if (params.until) filtersUsed.until = params.until;
+				const noResultsError = formatNoResultsFound(resource, operation, filtersUsed);
+				// Surface any filter label resolution failures in the error context so the
+				// LLM can correlate empty results with a failed label lookup.
+				const unresolvedFilterWarnings = context.resolutionWarnings ?? [];
+				if (unresolvedFilterWarnings.length > 0) {
+					noResultsError.context = {
+						...noResultsError.context,
+						filterResolutionWarnings: unresolvedFilterWarnings,
+					};
+				}
+				return JSON.stringify(noResultsError);
+			}
 
-            const total = records.length;
-            const truncated = total > MAX_RESPONSE_RECORDS;
-            const items = truncated ? records.slice(0, MAX_RESPONSE_RECORDS) : records;
-            const currentOffset = context.effectiveOffset ?? 0;
+			const total = records.length;
+			const truncated = total > MAX_RESPONSE_RECORDS;
+			const items = truncated ? records.slice(0, MAX_RESPONSE_RECORDS) : records;
+			const currentOffset = context.effectiveOffset ?? 0;
 
-            // Build pagination
-            let hasMore = false;
-            let nextOffset: number | undefined;
-            let totalAvailable: number | undefined;
+			// Build pagination
+			let hasMore = false;
+			let nextOffset: number | undefined;
+			let totalAvailable: number | undefined;
 
-            if (context.recencyActive) {
-                hasMore = false;
-                if (truncated) {
-                    totalAvailable = total;
-                }
-            } else if (params.returnAll) {
-                // returnAll=true: all matching API records were fetched; response may be truncated
-                // but there are no more pages — hasMore must be false.
-                hasMore = false;
-                if (truncated) {
-                    totalAvailable = total;
-                }
-            } else if (truncated) {
-                totalAvailable = total;
-                const truncatedNextOffset = currentOffset + MAX_RESPONSE_RECORDS;
-                hasMore = truncatedNextOffset < MAX_QUERY_LIMIT;
-                if (hasMore) nextOffset = truncatedNextOffset;
-            } else if (items.length > 0) {
-                const requestedLimit = getEffectiveLimit(params.limit);
-                const candidateNext = currentOffset + items.length;
-                hasMore = items.length >= requestedLimit && candidateNext < MAX_QUERY_LIMIT;
-                if (hasMore) nextOffset = candidateNext;
-            }
+			if (context.recencyActive) {
+				hasMore = false;
+				if (truncated) {
+					totalAvailable = total;
+				}
+			} else if (params.returnAll) {
+				// returnAll=true: all matching API records were fetched; response may be truncated
+				// but there are no more pages — hasMore must be false.
+				hasMore = false;
+				if (truncated) {
+					totalAvailable = total;
+				}
+			} else if (truncated) {
+				totalAvailable = total;
+				const truncatedNextOffset = currentOffset + MAX_RESPONSE_RECORDS;
+				hasMore = truncatedNextOffset < MAX_QUERY_LIMIT;
+				if (hasMore) nextOffset = truncatedNextOffset;
+			} else if (items.length > 0) {
+				const requestedLimit = getEffectiveLimit(params.limit);
+				const candidateNext = currentOffset + items.length;
+				hasMore = items.length >= requestedLimit && candidateNext < MAX_QUERY_LIMIT;
+				if (hasMore) nextOffset = candidateNext;
+			}
 
-            const pagination: PaginationInfo = {
-                offset: currentOffset,
-                hasMore,
-                ...(nextOffset !== undefined ? { nextOffset } : {}),
-                ...(totalAvailable !== undefined ? { totalAvailable } : {}),
-            };
+			const pagination: PaginationInfo = {
+				offset: currentOffset,
+				hasMore,
+				...(nextOffset !== undefined ? { nextOffset } : {}),
+				...(totalAvailable !== undefined ? { totalAvailable } : {}),
+			};
 
-            // Notes — informational context only
-            const notes: string[] = [];
-            if (context.recencyNote) notes.push(context.recencyNote);
-            if (truncated) {
-                if (params.returnAll) {
-                    notes.push(
-                        `Fetched all ${total} matching records via returnAll; showing first ${MAX_RESPONSE_RECORDS} in this response. ` +
-                        `Use 'fields' to reduce payload size, or narrow filters to reduce match count.`,
-                    );
-                } else {
-                    notes.push(
-                        hasMore
-                            ? `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Use offset=${nextOffset} to see the next page, or use a narrower filter.`
-                            : `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Offset pagination limit (${MAX_QUERY_LIMIT}) reached — use narrower filters to access more records.`,
-                    );
-                }
-            }
+			// Notes — informational context only
+			const notes: string[] = [];
+			if (context.recencyNote) notes.push(context.recencyNote);
+			if (truncated) {
+				if (params.returnAll) {
+					notes.push(
+						`Fetched all ${total} matching records via returnAll; showing first ${MAX_RESPONSE_RECORDS} in this response. ` +
+							`Use 'fields' to reduce payload size, or narrow filters to reduce match count.`,
+					);
+				} else {
+					notes.push(
+						hasMore
+							? `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Use offset=${nextOffset} to see the next page, or use a narrower filter.`
+							: `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Offset pagination limit (${MAX_QUERY_LIMIT}) reached — use narrower filters to access more records.`,
+					);
+				}
+			}
 
-            // Warnings — actionable signals
-            const listWarnings: string[] = [...(context.resolutionWarnings ?? [])];
-            if (context.recencyWindowLimited) {
-                listWarnings.push(
-                    '500 records were returned for the current recency window. Narrow recency, or provide since/until, to ensure the newest records are included.',
-                );
-            }
+			// Warnings — actionable signals
+			const listWarnings: string[] = [...(context.resolutionWarnings ?? [])];
+			if (context.recencyWindowLimited) {
+				listWarnings.push(
+					'500 records were returned for the current recency window. Narrow recency, or provide since/until, to ensure the newest records are included.',
+				);
+			}
 
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('list', { items, count: items.length },
-                    { mutated: false, retryable: true, truncated }, {
-                        warnings: listWarnings,
-                        pendingConfirmations: context.pendingConfirmations ?? [],
-                        appliedResolutions: context.resolutions ?? [],
-                        pagination,
-                        notes: notes.length > 0 ? notes : undefined,
-                    },
-                ),
-            ));
-        }
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'list',
+						{ items, count: items.length },
+						{ mutated: false, retryable: true, truncated },
+						{
+							warnings: listWarnings,
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+							pagination,
+							notes: notes.length > 0 ? notes : undefined,
+						},
+					),
+				),
+			);
+		}
 
-        case 'whoAmI': {
-            if (firstRecord === null || firstRecord === undefined) {
-                return JSON.stringify(formatNotFoundError(resource, operation, 'authenticated user'));
-            }
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('item', firstRecord, { mutated: false, retryable: true }, {
-                    warnings: context.resolutionWarnings ?? [],
-                    pendingConfirmations: context.pendingConfirmations ?? [],
-                    appliedResolutions: context.resolutions ?? [],
-                }),
-            ));
-        }
+		case 'whoAmI': {
+			if (firstRecord === null || firstRecord === undefined) {
+				return JSON.stringify(formatNotFoundError(resource, operation, 'authenticated user'));
+			}
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'item',
+						firstRecord,
+						{ mutated: false, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'searchByDomain': {
-            if (records.length === 0) {
-                return JSON.stringify(wrapError(
-                    resource, operation, ERROR_TYPES.NO_RESULTS_FOUND,
-                    'No company found matching the supplied domain.',
-                    `Verify the domain and retry, or use autotask_${resource} with operation 'getMany' with a filter.`,
-                ));
-            }
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('list', { items: records, count: records.length },
-                    { mutated: false, retryable: true }, {
-                        warnings: context.resolutionWarnings ?? [],
-                        pendingConfirmations: context.pendingConfirmations ?? [],
-                        appliedResolutions: context.resolutions ?? [],
-                        pagination: { offset: 0, hasMore: false },
-                    },
-                ),
-            ));
-        }
+		case 'searchByDomain': {
+			if (records.length === 0) {
+				return JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.NO_RESULTS_FOUND,
+						'No company found matching the supplied domain.',
+						`Verify the domain and retry, or use autotask_${resource} with operation 'getMany' with a filter.`,
+					),
+				);
+			}
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'list',
+						{ items: records, count: records.length },
+						{ mutated: false, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+							pagination: { offset: 0, hasMore: false },
+						},
+					),
+				),
+			);
+		}
 
-        case 'slaHealthCheck': {
-            if (firstRecord === null || firstRecord === undefined) {
-                const identifier = params.ticketNumber ?? params.id ?? 'unknown';
-                return JSON.stringify(formatNotFoundError(resource, operation, identifier as number | string));
-            }
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('item', firstRecord, { mutated: false, retryable: true }, {
-                    warnings: context.resolutionWarnings ?? [],
-                    pendingConfirmations: context.pendingConfirmations ?? [],
-                    appliedResolutions: context.resolutions ?? [],
-                }),
-            ));
-        }
+		case 'slaHealthCheck': {
+			if (firstRecord === null || firstRecord === undefined) {
+				const identifier = params.ticketNumber ?? params.id ?? 'unknown';
+				return JSON.stringify(
+					formatNotFoundError(resource, operation, identifier as number | string),
+				);
+			}
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'item',
+						firstRecord,
+						{ mutated: false, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'summary': {
-            if (firstRecord === null || firstRecord === undefined) {
-                const identifier = params.ticketNumber ?? params.id ?? 'unknown';
-                return JSON.stringify(formatNotFoundError(resource, operation, identifier as number | string));
-            }
-            const summaryRecord = firstRecord as { _meta?: { countsPartial?: boolean; truncationApplied?: boolean } };
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('summary', firstRecord, {
-                    mutated: false,
-                    retryable: true,
-                    partial: summaryRecord._meta?.countsPartial === true,
-                    truncated: summaryRecord._meta?.truncationApplied === true,
-                }, {
-                    warnings: context.resolutionWarnings ?? [],
-                    pendingConfirmations: context.pendingConfirmations ?? [],
-                    appliedResolutions: context.resolutions ?? [],
-                }),
-            ));
-        }
+		case 'summary': {
+			if (firstRecord === null || firstRecord === undefined) {
+				const identifier = params.ticketNumber ?? params.id ?? 'unknown';
+				return JSON.stringify(
+					formatNotFoundError(resource, operation, identifier as number | string),
+				);
+			}
+			const summaryRecord = firstRecord as {
+				_meta?: { countsPartial?: boolean; truncationApplied?: boolean };
+			};
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'summary',
+						firstRecord,
+						{
+							mutated: false,
+							retryable: true,
+							partial: summaryRecord._meta?.countsPartial === true,
+							truncated: summaryRecord._meta?.truncationApplied === true,
+						},
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'moveConfigurationItem': {
-            if (firstRecord === null || firstRecord === undefined) {
-                const id = params.id ?? 'unknown';
-                return JSON.stringify(formatNotFoundError(resource, operation, id as number | string));
-            }
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('mutation',
-                    { id: extractOperationId(firstRecord), entity: firstRecord },
-                    { mutated: true, retryable: true }, {
-                        warnings: context.resolutionWarnings ?? [],
-                        pendingConfirmations: context.pendingConfirmations ?? [],
-                        appliedResolutions: context.resolutions ?? [],
-                    },
-                ),
-            ));
-        }
+		case 'moveConfigurationItem': {
+			if (firstRecord === null || firstRecord === undefined) {
+				const id = params.id ?? 'unknown';
+				return JSON.stringify(formatNotFoundError(resource, operation, id as number | string));
+			}
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'mutation',
+						{ id: extractOperationId(firstRecord), entity: firstRecord },
+						{ mutated: true, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'moveToCompany': {
-            if (firstRecord === null || firstRecord === undefined) {
-                const id = params.id ?? 'unknown';
-                return JSON.stringify(formatNotFoundError(resource, operation, id as number | string));
-            }
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('mutation',
-                    { id: extractOperationId(firstRecord), entity: firstRecord },
-                    { mutated: true, retryable: true }, {
-                        warnings: context.resolutionWarnings ?? [],
-                        pendingConfirmations: context.pendingConfirmations ?? [],
-                        appliedResolutions: context.resolutions ?? [],
-                    },
-                ),
-            ));
-        }
+		case 'moveToCompany': {
+			if (firstRecord === null || firstRecord === undefined) {
+				const id = params.id ?? 'unknown';
+				return JSON.stringify(formatNotFoundError(resource, operation, id as number | string));
+			}
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'mutation',
+						{ id: extractOperationId(firstRecord), entity: firstRecord },
+						{ mutated: true, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'approve':
-        case 'reject': {
-            if (firstRecord === null || firstRecord === undefined) {
-                const id = params.id ?? 'unknown';
-                return JSON.stringify(formatNotFoundError(resource, operation, id as number | string));
-            }
-            // Use params.id as canonical id — API may return { success: true } stub without an id field
-            const approveId = (params.id as number | undefined) ?? extractOperationId(firstRecord);
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('mutation',
-                    { id: approveId, entity: firstRecord },
-                    { mutated: true, retryable: true }, {
-                        warnings: context.resolutionWarnings ?? [],
-                        pendingConfirmations: context.pendingConfirmations ?? [],
-                        appliedResolutions: context.resolutions ?? [],
-                    },
-                ),
-            ));
-        }
+		case 'approve':
+		case 'reject': {
+			if (firstRecord === null || firstRecord === undefined) {
+				const id = params.id ?? 'unknown';
+				return JSON.stringify(formatNotFoundError(resource, operation, id as number | string));
+			}
+			// Use params.id as canonical id — API may return { success: true } stub without an id field
+			const approveId = (params.id as number | undefined) ?? extractOperationId(firstRecord);
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'mutation',
+						{ id: approveId, entity: firstRecord },
+						{ mutated: true, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'transferOwnership': {
-            if (firstRecord === null || firstRecord === undefined) {
-                return JSON.stringify(wrapError(
-                    resource, operation, ERROR_TYPES.ENTITY_NOT_FOUND,
-                    'Transfer ownership returned no result.',
-                    `Verify source and destination resource IDs, then retry.`,
-                ));
-            }
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('mutation',
-                    { id: extractOperationId(firstRecord), entity: firstRecord },
-                    { mutated: true, retryable: true }, {
-                        warnings: context.resolutionWarnings ?? [],
-                        pendingConfirmations: context.pendingConfirmations ?? [],
-                        appliedResolutions: context.resolutions ?? [],
-                    },
-                ),
-            ));
-        }
+		case 'transferOwnership': {
+			if (firstRecord === null || firstRecord === undefined) {
+				return JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.ENTITY_NOT_FOUND,
+						'Transfer ownership returned no result.',
+						`Verify source and destination resource IDs, then retry.`,
+					),
+				);
+			}
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'mutation',
+						{ id: extractOperationId(firstRecord), entity: firstRecord },
+						{ mutated: true, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'count': {
-            const countValue = records[0]?.count ?? records.length;
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('count', { count: countValue }, { mutated: false, retryable: true }),
-            ));
-        }
+		case 'count': {
+			const countValue = records[0]?.count ?? records.length;
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload('count', { count: countValue }, { mutated: false, retryable: true }),
+				),
+			);
+		}
 
-        case 'create': {
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('mutation',
-                    { id: extractOperationId(firstRecord), entity: firstRecord },
-                    { mutated: true, retryable: false }, {
-                        warnings: context.resolutionWarnings ?? [],
-                        pendingConfirmations: context.pendingConfirmations ?? [],
-                        appliedResolutions: context.resolutions ?? [],
-                    },
-                ),
-            ));
-        }
+		case 'create': {
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'mutation',
+						{ id: extractOperationId(firstRecord), entity: firstRecord },
+						{ mutated: true, retryable: false },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'update': {
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('mutation',
-                    { id: extractOperationId(firstRecord), entity: firstRecord },
-                    { mutated: true, retryable: true }, {
-                        warnings: context.resolutionWarnings ?? [],
-                        pendingConfirmations: context.pendingConfirmations ?? [],
-                        appliedResolutions: context.resolutions ?? [],
-                    },
-                ),
-            ));
-        }
+		case 'update': {
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'mutation',
+						{ id: extractOperationId(firstRecord), entity: firstRecord },
+						{ mutated: true, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'delete': {
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('mutation', { id: params.id, deleted: true }, { mutated: true, retryable: true }, {
-                    warnings: context.resolutionWarnings ?? [],
-                    pendingConfirmations: context.pendingConfirmations ?? [],
-                    appliedResolutions: context.resolutions ?? [],
-                }),
-            ));
-        }
+		case 'delete': {
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'mutation',
+						{ id: params.id, deleted: true },
+						{ mutated: true, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'getByResource': {
-            const entity = firstRecord;
-            if (
-                entity === null ||
-                entity === undefined ||
-                (typeof entity === 'object' && !Array.isArray(entity) && Object.keys(entity as object).length === 0)
-            ) {
-                const rid = params.resourceID ?? 'unknown';
-                return JSON.stringify(formatNotFoundError(resource, operation, rid as number | string));
-            }
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('item', entity, { mutated: false, retryable: true }, {
-                    warnings: context.resolutionWarnings ?? [],
-                    pendingConfirmations: context.pendingConfirmations ?? [],
-                    appliedResolutions: context.resolutions ?? [],
-                }),
-            ));
-        }
+		case 'getByResource': {
+			const entity = firstRecord;
+			if (
+				entity === null ||
+				entity === undefined ||
+				(typeof entity === 'object' &&
+					!Array.isArray(entity) &&
+					Object.keys(entity as object).length === 0)
+			) {
+				const rid = params.resourceID ?? 'unknown';
+				return JSON.stringify(formatNotFoundError(resource, operation, rid as number | string));
+			}
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'item',
+						entity,
+						{ mutated: false, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        case 'getByYear': {
-            const entity = firstRecord;
-            if (
-                entity === null ||
-                entity === undefined ||
-                (typeof entity === 'object' && !Array.isArray(entity) && Object.keys(entity as object).length === 0)
-            ) {
-                const rid = params.resourceID ?? 'unknown';
-                const yr = params.year ?? 'unknown';
-                return JSON.stringify(formatNotFoundError(resource, operation, `resource ${rid}, year ${yr}`));
-            }
-            return JSON.stringify(wrapSuccess(resource, operation,
-                buildResultPayload('item', entity, { mutated: false, retryable: true }, {
-                    warnings: context.resolutionWarnings ?? [],
-                    pendingConfirmations: context.pendingConfirmations ?? [],
-                    appliedResolutions: context.resolutions ?? [],
-                }),
-            ));
-        }
+		case 'getByYear': {
+			const entity = firstRecord;
+			if (
+				entity === null ||
+				entity === undefined ||
+				(typeof entity === 'object' &&
+					!Array.isArray(entity) &&
+					Object.keys(entity as object).length === 0)
+			) {
+				const rid = params.resourceID ?? 'unknown';
+				const yr = params.year ?? 'unknown';
+				return JSON.stringify(
+					formatNotFoundError(resource, operation, `resource ${rid}, year ${yr}`),
+				);
+			}
+			return JSON.stringify(
+				wrapSuccess(
+					resource,
+					operation,
+					buildResultPayload(
+						'item',
+						entity,
+						{ mutated: false, retryable: true },
+						{
+							warnings: context.resolutionWarnings ?? [],
+							pendingConfirmations: context.pendingConfirmations ?? [],
+							appliedResolutions: context.resolutions ?? [],
+						},
+					),
+				),
+			);
+		}
 
-        default:
-            return JSON.stringify(wrapError(
-                resource, operation, ERROR_TYPES.INVALID_OPERATION,
-                `Unknown operation '${operation}'.`,
-                `Use a supported operation for autotask_${resource}.`,
-            ));
-    }
+		default:
+			return JSON.stringify(
+				wrapError(
+					resource,
+					operation,
+					ERROR_TYPES.INVALID_OPERATION,
+					`Unknown operation '${operation}'.`,
+					`Use a supported operation for autotask_${resource}.`,
+				),
+			);
+	}
 }


### PR DESCRIPTION
### Motivation

- Provide an opt-in, low-noise tracing system to capture structured events during AI tool construction and execution for diagnosing schema/description generation, filter/label resolution, write-guard decisions, executor lifecycle, and error paths without impacting runtime behaviour.

### Description

- Add `nodes/Autotask/ai-tools/debug-trace.ts` implementing a best-effort JSONL trace writer plus helpers and helpers such as `AI_TOOL_DEBUG_ENABLED`, `AI_TOOL_DEBUG_VERBOSE`, `AI_TOOL_DEBUG_FILE_PATH`, `traceToolBuild`, `traceSchemaBuild`, `traceDescriptionBuild`, `traceToolCall`, `traceFilterBuild`, `traceLabelResolution`, `traceWriteGuard`, `traceExecutor`, `traceResponse`, and `traceError`.
- Integrate tracing into `nodes/Autotask/AutotaskAiTools.node.ts`, `description-builders.ts`, `schema-generator.ts`, and `tool-executor.ts` to emit structured trace events for key phases (tool construction, metadata fetch, schema/description build, filter planning, label resolution, pre-write guards, API calls, and response envelopes); tracing is disabled by default and is best-effort so it never affects node execution.
- Add helper utilities for safe introspection and redaction (`safeKeys`, `redactForVerbose`, `summariseFields`, `summariseFilters`, `summariseResponseEnvelope`, etc.), and enrich schema/description builders and executor with summarised metadata and additional diagnostics while preserving existing runtime behaviour.
- Update `CHANGELOG.md` to document the new optional debug trace and other related changes.

### Testing

- Ran a TypeScript build with `npm run build` to validate types and compilation, which completed successfully.
- Ran lint/static checks with `npm run lint` to validate formatting and static rules, which completed successfully.
- Ran the existing automated test suite with `npm test`, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8e2392bfc83208be1dedfdadc265c)