### PR TITLE
Add operation contract validation and incorporate rules into schemas and docs

### DIFF
--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -2,6 +2,7 @@ import type { FieldMeta } from '../helpers/aiHelper';
 import { getEntityMetadata } from '../constants/entities';
 import { getAiIdentityHint } from '../constants/ai-identity';
 import { AI_TOOL_DEBUG_VERBOSE, redactForVerbose, traceDescriptionBuild } from './debug-trace';
+import { getOperationContractRuleText } from './operation-contracts';
 
 export const DESCRIPTION_REFERENCE_PLACEHOLDER = '__REFERENCE_UTC__';
 
@@ -286,9 +287,11 @@ export function buildCompanySearchByDomainDescription(resourceName: string): str
 }
 
 export function buildTicketSummaryDescription(resourceName: string): string {
+	const ruleText = getOperationContractRuleText(resourceName, 'summary');
+	const identifierRule = ruleText.length > 0 ? `${ruleText.join(' ')} ` : '';
 	return (
 		'Get a compact, type-aware summary of any Autotask ticket. ' +
-		`Requires 'id' (numeric Ticket ID) or 'ticketNumber' (format T{date}.{seq}, e.g. T20240615.0001) — calls with neither identifier are rejected immediately. ` +
+		identifierRule +
 		'Automatically detects ticket type (Service Request, Incident, Problem, Change Request, Alert) and prioritises the most relevant fields. ' +
 		'Filters out null and empty fields to reduce noise. ' +
 		"Includes a 'computed' block with pre-calculated values: ageHours, daysSinceLastActivity, isAssigned; for open tickets: isOverdue, plus hoursUntilDue (not yet overdue) or hoursOverdue (past due); when SLA is assigned: slaStatus, slaNextMilestoneDueHours, slaEarliestBreachHours. " +
@@ -302,8 +305,10 @@ export function buildTicketSummaryDescription(resourceName: string): string {
 }
 
 export function buildTicketSlaHealthCheckDescription(resourceName: string): string {
+	const ruleText = getOperationContractRuleText(resourceName, 'slaHealthCheck');
+	const identifierRule = ruleText.length > 0 ? `${ruleText.join(' ')} ` : '';
 	return (
-		`Run an SLA health check on a ticket — provide either 'id' (numeric Ticket ID) or 'ticketNumber' (format T{date}.{seq}, e.g. T20240615.0001); calls with neither identifier are rejected immediately. ` +
+		`Run an SLA health check on a ticket. ${identifierRule}` +
 		'Returns first-response, resolution-plan, and resolution milestone timing and status in consistent hours (2 decimal places). ' +
 		"Use 'ticketFields' to limit which ticket fields are returned in the ticket section. " +
 		'Includes wallClockRemainingHours, where negative values indicate overdue milestones. ' +
@@ -624,10 +629,6 @@ const DEDUP_NOTES = [
 	'errorOnDuplicate: when true, errors on duplicate instead of skipping. Default false.',
 	'updateFields: field names to compare against the duplicate — values that differ cause an update. Requires errorOnDuplicate=false.',
 	'Returns outcome: created, skipped, updated, or a resource-specific not_found variant.',
-];
-const IDENTIFIER_PAIR_NOTES = [
-	"Requires either 'id' (numeric entity ID) or the alternative string identifier (e.g. 'ticketNumber' with format T{date}.{seq}).",
-	'Calls with neither identifier are rejected immediately with INVALID_FILTER_CONSTRAINT.',
 ];
 const LIST_ADVANCED_NOTES = [
 	'filtersJson: JSON array of Autotask IFilterCondition objects for 3+ conditions or nested OR. Mutually exclusive with flat filter_field triplets. No label resolution — pass numeric IDs.',
@@ -1117,22 +1118,23 @@ function getOperationPurpose(
 	}
 }
 
-function getOperationNotes(operation: string): string[] {
+function getOperationNotes(resource: string, operation: string): string[] {
+	const contractNotes = getOperationContractRuleText(resource, operation);
 	switch (operation) {
 		case 'create':
 		case 'update':
-			return [...LABEL_RESOLUTION_NOTES];
+			return [...contractNotes, ...LABEL_RESOLUTION_NOTES];
 		case 'createIfNotExists':
-			return [...LABEL_RESOLUTION_NOTES, ...DEDUP_NOTES];
+			return [...contractNotes, ...LABEL_RESOLUTION_NOTES, ...DEDUP_NOTES];
 		case 'slaHealthCheck':
 		case 'summary':
-			return [...IDENTIFIER_PAIR_NOTES];
+			return [...contractNotes];
 		case 'getMany':
 		case 'getPosted':
 		case 'getUnposted':
-			return [...LIST_ADVANCED_NOTES];
+			return [...contractNotes, ...LIST_ADVANCED_NOTES];
 		default:
-			return [];
+			return [...contractNotes];
 	}
 }
 
@@ -1163,6 +1165,6 @@ export function buildOperationDoc(
 		parameters = READ_OP_PARAMS[targetOperation] ?? { required: [], optional: [] };
 	}
 
-	const notes = getOperationNotes(targetOperation);
+	const notes = getOperationNotes(resource, targetOperation);
 	return { operation: targetOperation, purpose, parameters, notes };
 }

--- a/nodes/Autotask/ai-tools/operation-contracts.ts
+++ b/nodes/Autotask/ai-tools/operation-contracts.ts
@@ -1,0 +1,172 @@
+import { getIdentifierPairConfig } from '../constants/resource-operations';
+
+export interface OperationContract {
+	requiredFields?: string[];
+	forbiddenFields?: string[];
+	xorGroups?: string[][];
+}
+
+type ResourceOperationContracts = Record<string, Record<string, OperationContract>>;
+
+export interface OperationContractViolation {
+	message: string;
+	path?: string[];
+}
+
+export const OPERATION_CONTRACTS: ResourceOperationContracts = {
+	'*': {
+		get: {
+			requiredFields: ['id'],
+			forbiddenFields: [
+				'filter_field',
+				'filter_op',
+				'filter_value',
+				'filter_field_2',
+				'filter_op_2',
+				'filter_value_2',
+				'filter_logic',
+				'filtersJson',
+				'recency',
+				'recency_field',
+				'since',
+				'until',
+				'returnAll',
+				'offset',
+			],
+		},
+		update: {
+			requiredFields: ['id'],
+		},
+		delete: {
+			requiredFields: ['id'],
+		},
+		approve: {
+			requiredFields: ['id'],
+		},
+		reject: {
+			requiredFields: ['id'],
+		},
+		getByResource: {
+			requiredFields: ['resourceID'],
+		},
+		getByYear: {
+			requiredFields: ['resourceID', 'year'],
+		},
+		listPicklistValues: {
+			requiredFields: ['fieldId'],
+		},
+		describeOperation: {
+			requiredFields: ['targetOperation'],
+		},
+	},
+	ticket: {
+		slaHealthCheck: {
+			xorGroups: [['id', 'ticketNumber']],
+		},
+		summary: {
+			xorGroups: [['id', 'ticketNumber']],
+		},
+	},
+};
+
+function hasProvidedValue(value: unknown): boolean {
+	if (value === undefined || value === null) return false;
+	if (typeof value === 'string') return value.trim() !== '';
+	if (typeof value === 'number') return Number.isFinite(value);
+	return true;
+}
+
+function quoteFields(fields: string[]): string {
+	return fields.map((field) => `'${field}'`).join(' or ');
+}
+
+function getXorMessage(resource: string, operation: string, fields: string[]): string {
+	const idPairConfig = getIdentifierPairConfig(resource, operation);
+	if (
+		idPairConfig &&
+		fields.length === 2 &&
+		fields.includes('id') &&
+		fields.includes(idPairConfig.altIdField)
+	) {
+		return (
+			`Operation '${operation}' requires exactly one identifier: either 'id' (numeric Ticket ID) ` +
+			`or '${idPairConfig.altIdField}' (format ${idPairConfig.altIdFormat}, e.g. ${idPairConfig.altIdExample}).`
+		);
+	}
+	return `Operation '${operation}' requires exactly one of ${quoteFields(fields)}.`;
+}
+
+export function getOperationContract(resource: string, operation: string): OperationContract | null {
+	const globalContract = OPERATION_CONTRACTS['*']?.[operation];
+	const resourceContract = OPERATION_CONTRACTS[resource]?.[operation];
+	if (!globalContract && !resourceContract) return null;
+
+	return {
+		requiredFields: [
+			...new Set([...(globalContract?.requiredFields ?? []), ...(resourceContract?.requiredFields ?? [])]),
+		],
+		forbiddenFields: [
+			...new Set([
+				...(globalContract?.forbiddenFields ?? []),
+				...(resourceContract?.forbiddenFields ?? []),
+			]),
+		],
+		xorGroups: [...(globalContract?.xorGroups ?? []), ...(resourceContract?.xorGroups ?? [])],
+	};
+}
+
+export function validateOperationContract(
+	resource: string,
+	operation: string,
+	params: Record<string, unknown>,
+): OperationContractViolation[] {
+	const contract = getOperationContract(resource, operation);
+	if (!contract) return [];
+
+	const violations: OperationContractViolation[] = [];
+	for (const field of contract.requiredFields ?? []) {
+		if (!hasProvidedValue(params[field])) {
+			violations.push({
+				message: `Operation '${operation}' requires '${field}'.`,
+				path: [field],
+			});
+		}
+	}
+	for (const field of contract.forbiddenFields ?? []) {
+		if (hasProvidedValue(params[field])) {
+			violations.push({
+				message: `Operation '${operation}' does not allow '${field}'.`,
+				path: [field],
+			});
+		}
+	}
+	for (const xorGroup of contract.xorGroups ?? []) {
+		const provided = xorGroup.filter((field) => hasProvidedValue(params[field]));
+		if (provided.length !== 1) {
+			violations.push({
+				message: getXorMessage(resource, operation, xorGroup),
+				path: [...xorGroup],
+			});
+		}
+	}
+
+	return violations;
+}
+
+export function getOperationContractRuleText(resource: string, operation: string): string[] {
+	const contract = getOperationContract(resource, operation);
+	if (!contract) return [];
+
+	const lines: string[] = [];
+	for (const field of contract.requiredFields ?? []) {
+		lines.push(`Requires '${field}'.`);
+	}
+	for (const field of contract.forbiddenFields ?? []) {
+		lines.push(`Does not allow '${field}'.`);
+	}
+	for (const xorGroup of contract.xorGroups ?? []) {
+		lines.push(getXorMessage(resource, operation, xorGroup));
+	}
+
+	return lines;
+}

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -3,6 +3,7 @@ import { FilterOperators } from '../constants/filters';
 import type { RuntimeZod } from './runtime';
 import { IDENTIFIER_PAIR_OPERATIONS } from '../constants/resource-operations';
 import { safeKeys, summariseFields, traceSchemaBuild } from './debug-trace';
+import { validateOperationContract } from './operation-contracts';
 
 /** Maximum number of picklist values to inline in a field description */
 const MAX_INLINE_PICKLIST_VALUES = 8;
@@ -222,7 +223,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		// operation — required enum
 		let operationDesc = `Operation to perform. One of: ${allOps.join(', ')}`;
 		if (hasIdPairOps && idPairConfig) {
-			operationDesc += ` — NOTE: ${idPairOps.join(' and ')} each require either 'id' (numeric) or '${idPairConfig.altIdField}' (${idPairConfig.altIdFormat}); calls with neither identifier are rejected immediately.`;
+			operationDesc += ` — NOTE: ${idPairOps.join(' and ')} require exactly one identifier: 'id' (numeric) or '${idPairConfig.altIdField}' (${idPairConfig.altIdFormat}).`;
 		}
 		shape.operation = rz.enum(allOps).describe(operationDesc);
 		const hasSearchByDomain = operations.includes('searchByDomain');
@@ -245,7 +246,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				idDesc += ` Required for: ${strictIdOps.join(', ')}.`;
 			}
 			if (hasIdPairOps && idPairConfig) {
-				idDesc += ` For ${idPairOps.join(', ')}: provide 'id' OR '${idPairConfig.altIdField}' — exactly one must be present; calls with neither identifier are rejected immediately with INVALID_FILTER_CONSTRAINT.`;
+				idDesc += ` For ${idPairOps.join(', ')}: provide exactly one identifier: 'id' OR '${idPairConfig.altIdField}'.`;
 			}
 			shape.id = rz.number().optional().describe(idDesc);
 		}
@@ -440,7 +441,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.string()
 				.optional()
 				.describe(
-					`Alternative identifier for ${idPairOps.join(', ')}. Format: ${idPairConfig.altIdFormat} (e.g. ${idPairConfig.altIdExample}). Provide this OR numeric 'id' — exactly one MUST be present for these operations; calls with neither identifier are rejected immediately.`,
+					`Alternative identifier for ${idPairOps.join(', ')}. Format: ${idPairConfig.altIdFormat} (e.g. ${idPairConfig.altIdExample}). Provide this OR numeric 'id' (exactly one).`,
 				);
 		}
 
@@ -929,7 +930,23 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				exposesImpersonationResourceId: Boolean(shape.impersonationResourceId),
 			},
 		});
-		const schema = rz.object(shape);
+		const schema = rz.object(shape).superRefine((input: Record<string, unknown>, ctx: unknown) => {
+			const operationValue = input.operation;
+			if (typeof operationValue !== 'string') return;
+			const violations = validateOperationContract(resource, operationValue, input);
+			if (violations.length === 0) return;
+			for (const violation of violations) {
+				(
+					ctx as {
+						addIssue: (issue: { code: 'custom'; message: string; path?: string[] }) => void;
+					}
+				).addIssue({
+					code: 'custom',
+					message: violation.message,
+					path: violation.path,
+				});
+			}
+		});
 		if (isReadOnlyOpsSet) {
 			const cacheKey = getReadOnlySchemaCacheKey(resource, operations, readFields);
 			setReadOnlySchemaCache(cacheKey, schema);

--- a/nodes/Autotask/ai-tools/tool-executor.ts
+++ b/nodes/Autotask/ai-tools/tool-executor.ts
@@ -64,6 +64,7 @@ import {
 	COMPOUND_REGISTRY,
 	COMPOUND_PARENT_NOT_FOUND_OUTCOMES,
 } from '../constants/compound-registry';
+import { validateOperationContract } from './operation-contracts';
 
 export interface ToolExecutorParams {
 	resource: string;
@@ -709,28 +710,25 @@ export async function executeAiTool(
 		return attachCorrelation(JSON.stringify(idValidation.error), correlationId);
 	}
 
-	// Pre-flight: operations using the identifier-pair pattern (id OR altIdField) require at least one.
-	// This returns a structured error before the runtime handler throws an unhandled exception.
-	const idPairConfig = getIdentifierPairConfig(resource, effectiveOperation);
-	if (idPairConfig) {
-		const hasId = typeof params.id === 'number' && params.id > 0;
-		const hasAltId =
-			typeof params[idPairConfig.altIdField as keyof typeof params] === 'string' &&
-			(params[idPairConfig.altIdField as keyof typeof params] as string).trim() !== '';
-		if (!hasId && !hasAltId) {
-			return attachCorrelation(
-				JSON.stringify(
-					wrapError(
-						resource,
-						operation,
-						ERROR_TYPES.INVALID_FILTER_CONSTRAINT,
-						`${effectiveOperation} requires a ticket identifier: provide 'id' (numeric Ticket ID) or '${idPairConfig.altIdField}' (format ${idPairConfig.altIdFormat}, e.g. ${idPairConfig.altIdExample}).`,
-						`Call autotask_${resource} with operation '${effectiveOperation}' and include either 'id' (numeric Ticket ID) or '${idPairConfig.altIdField}' (format ${idPairConfig.altIdFormat}, e.g. ${idPairConfig.altIdExample}).`,
-					),
+	const contractViolations = validateOperationContract(
+		resource,
+		effectiveOperation,
+		params as Record<string, unknown>,
+	);
+	if (contractViolations.length > 0) {
+		const message = contractViolations.map((violation) => violation.message).join(' ');
+		return attachCorrelation(
+			JSON.stringify(
+				wrapError(
+					resource,
+					effectiveOperation,
+					ERROR_TYPES.INVALID_FILTER_CONSTRAINT,
+					message,
+					`Call autotask_${resource} with operation '${effectiveOperation}' and provide arguments that satisfy the operation contract.`,
 				),
-				correlationId,
-			);
-		}
+			),
+			correlationId,
+		);
 	}
 
 	if (
@@ -937,7 +935,7 @@ export async function executeAiTool(
 		name: string,
 		index: number,
 		fallbackValue?: unknown,
-		options?: IGetNodeParameterOptions,
+		_options?: IGetNodeParameterOptions,
 	): unknown => {
 		switch (name) {
 			case 'resource':
@@ -1114,7 +1112,6 @@ export async function executeAiTool(
 				// not listed above, it will get fallbackValue (safe) and the missing case
 				// will be discoverable — not silently use a wrong node-level config value.
 				if (process.env.N8N_AI_TOOL_STRICT_PARAMS === '1') {
-					// eslint-disable-next-line no-console
 					console.warn(
 						`[AutotaskAiTools] Unmapped getNodeParameter key "${name}" ` +
 						`for ${resource}.${effectiveOperation} — returning fallbackValue. ` +
@@ -1128,9 +1125,6 @@ export async function executeAiTool(
 	try {
 		// Compound operation short-circuit: createIfNotExists bypasses the standard executor
 		if (effectiveOperation === 'createIfNotExists') {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			let compoundResult: any;
-
 			// createFields comes from fieldValues (already validated + label-resolved above)
 			// Convert date fields from user timezone to UTC before passing to compound helpers,
 			// which bypass CreateOperation.execute() and therefore convertDatesToUTC.
@@ -1169,7 +1163,8 @@ export async function executeAiTool(
 			};
 
 			const handler = await registryEntry.getHandler();
-			compoundResult = await handler(context, 0, compoundOptions);
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const compoundResult: any = await handler(context, 0, compoundOptions);
 
 			if (compoundResult) {
 				// Reclassify not-found outcomes as errors
@@ -1356,4 +1351,3 @@ export async function executeAiTool(
 		context.getNodeParameter = originalGetNodeParameter;
 	}
 }
-


### PR DESCRIPTION
### Motivation

- Ensure Autotask AI tool operations enforce argument contracts (required/forbidden/xor) early and surface clear, actionable error messages. 
- Expose operation contract rules in generated user-facing descriptions and operation docs to help callers provide valid identifiers and parameters. 
- Validate input at both schema (LLM/runtime) and executor levels to prevent ambiguous failures and centralise identifier-pair handling.

### Description

- Add a new module `operation-contracts.ts` that defines `OPERATION_CONTRACTS`, `getOperationContract`, `validateOperationContract`, and `getOperationContractRuleText`, plus helper types and UX-friendly xor messages for identifier pairs. 
- Integrate contract rules into description and docs by importing `getOperationContractRuleText` in `description-builders.ts` and prepending rule text to relevant operation descriptions and notes. 
- Enforce contracts at schema build time by calling `validateOperationContract` in `schema-generator.ts` via a `superRefine` hook to convert contract violations into Zod custom issues. 
- Run pre-flight contract validation in `tool-executor.ts` using `validateOperationContract` and return a structured `INVALID_FILTER_CONSTRAINT` response when violations are found, replacing the previous ad-hoc identifier-pair check; include small related cleanups (unused param rename, `compoundResult` typing fix). 

### Testing

- Ran TypeScript build with `yarn build` and the project compiled successfully. 
- Executed unit tests with `yarn test` and all tests passed. 
- Ran linter with `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db05b9e5548320976f1b3746902880)