### PR TITLE
Remove AI schema dryRun exposure from write operations

### DIFF
--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -477,13 +477,6 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 						'When true and impersonation is set, retry without impersonation if denied (default true).',
 					);
 			}
-			if (!shape.dryRun)
-				shape.dryRun = rz
-					.boolean()
-					.optional()
-					.describe(
-						'When true, resolves labels and validates fields but makes no API call (default false). Returns a summary of resolved field values.',
-					);
 		}
 
 		// moveConfigurationItem fields
@@ -502,11 +495,6 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					.positive()
 					.optional()
 					.describe('Destination company ID.');
-			if (!shape.dryRun)
-				shape.dryRun = rz
-					.boolean()
-					.optional()
-					.describe('When true, return a plan without mutations (default false).');
 			shape.destinationCompanyLocationId = rz
 				.number()
 				.int()
@@ -613,11 +601,6 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					.positive()
 					.optional()
 					.describe('Destination company ID for the cloned contact.');
-			if (!shape.dryRun)
-				shape.dryRun = rz
-					.boolean()
-					.optional()
-					.describe('When true, returns a plan without mutations (default false).');
 			shape.destinationCompanyLocationId = rz
 				.number()
 				.int()
@@ -682,11 +665,6 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					.positive()
 					.optional()
 					.describe('Receiving resource ID. Must be active.');
-			if (!shape.dryRun)
-				shape.dryRun = rz
-					.boolean()
-					.optional()
-					.describe('When true, returns a plan without mutations (default false).');
 			shape.includeTickets = rz
 				.boolean()
 				.optional()
@@ -867,13 +845,6 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 						'When true and impersonation is set, retry without impersonation if denied (default true).',
 					);
 			}
-			if (!shape.dryRun)
-				shape.dryRun = rz
-					.boolean()
-					.optional()
-					.describe(
-						'When true, resolves labels and validates fields but makes no API call (default false). Returns a summary of resolved field values.',
-					);
 		}
 
 		// describeFields fields
@@ -926,7 +897,8 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				exposesFiltersJson: Boolean(shape.filtersJson),
 				exposesReturnAll: Boolean(shape.returnAll),
 				exposesOutputMode: Boolean(shape.outputMode),
-				exposesDryRun: Boolean(shape.dryRun),
+				// AI schema no longer exposes dryRun (UI-node dry-run remains in non-AI paths).
+				exposesDryRun: false,
 				exposesImpersonationResourceId: Boolean(shape.impersonationResourceId),
 			},
 		});


### PR DESCRIPTION
### Motivation
- Prevent AI-generated schema from advertising a `dryRun` parameter on write operations so the AI contract no longer exposes write-mode dry-run behavior.
- Ensure telemetry accurately reflects the new contract by stopping stale `dryRun` exposure metrics for AI schema builds.

### Description
- Removed `shape.dryRun` additions from `buildUnifiedSchema()` write-operation branches for `create`/`update`, `moveConfigurationItem`, `moveToCompany`, `transferOwnership`, and `createIfNotExists` in `nodes/Autotask/ai-tools/schema-generator.ts`.
- Updated schema-build telemetry to set `exposesDryRun: false` for AI schema generation so metrics do not report dry-run exposure.
- Left UI-node / non-AI dry-run behavior unchanged; only the AI schema generator was modified.

### Testing
- Ran `pnpm -s typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db0a840d94832091e4dfa64f24419e)