### PR TITLE
Remove AI/MCP dry-run handling from tool executor

### DIFF
--- a/nodes/Autotask/ai-tools/tool-executor.ts
+++ b/nodes/Autotask/ai-tools/tool-executor.ts
@@ -32,7 +32,6 @@ import { buildRecencyFilters, type RecencyBuildResult } from './recency';
 import {
 	attachCorrelation,
 	buildMetadataResponse,
-	buildDryRunResponse,
 	buildCompoundResponse,
 	type ToolResponseContext,
 } from './response-builder';
@@ -211,7 +210,7 @@ function normaliseOperation(operation: string): string {
 	}
 }
 
-/** n8n framework fields injected into every tool call — must not reach API request bodies */
+/** n8n framework fields injected into every tool call — must not reach API request bodies. */
 const N8N_METADATA_FIELDS = new Set([
 	'sessionId',
 	'action',
@@ -221,7 +220,7 @@ const N8N_METADATA_FIELDS = new Set([
 	'toolName',
 	'toolCallId',
 	'operation',
-	'dryRun',
+	'dryRun', // Defensive strip: AI/MCP no longer accepts dry-run, but ignore if injected.
 ]);
 
 /** Key prefixes injected by n8n that must be stripped regardless of suffix */
@@ -911,26 +910,6 @@ export async function executeAiTool(
 		);
 		if (blocker !== null) return attachCorrelation(blocker, correlationId);
 	}
-
-	if (rawParams.dryRun === true) {
-		const dryRunResponse = JSON.stringify(
-			buildDryRunResponse(resource, effectiveOperation, fieldValues, {
-				resolutions: labelResolutions,
-				resolutionWarnings: labelWarnings,
-				pendingConfirmations: labelPendingConfirmations,
-			}),
-		);
-		traceResponse({
-			phase: 'dry-run',
-			resource,
-			operation: effectiveOperation,
-			correlationId,
-			durationMs: Date.now() - startedAt,
-			summary: summariseResponseEnvelope(dryRunResponse),
-		});
-		return attachCorrelation(dryRunResponse, correlationId);
-	}
-
 	context.getNodeParameter = ((
 		name: string,
 		index: number,
@@ -1096,13 +1075,6 @@ export async function executeAiTool(
 				// redundant — the AI tool already ensures only the configured resource's
 				// operations reach executeAiTool(). Empty array disables the allowlist check.
 				return '[]';
-			case 'allowDryRunForWrites':
-				// The AI path manages its own dry-run response contract: params.dryRun is
-				// stripped from API bodies via N8N_METADATA_FIELDS. This must remain true
-				// to allow the downstream executor to process dryRun calls that originate
-				// from the AI schema (currently exposed on moveToCompany / moveConfigurationItem
-				// / transferOwnership; extending to all write ops is a follow-on task).
-				return true;
 			default:
 				if (Object.prototype.hasOwnProperty.call(params, name)) {
 					return params[name as keyof ToolExecutorParams];


### PR DESCRIPTION
### Motivation

- The AI/MCP executor previously returned a special dry-run envelope for `rawParams.dryRun === true` and provided a write-op “preview mode” override; the new contract requires removing that special-case behaviour. 
- Ensure the AI tools path no longer exposes a separate dry-run response and keep metadata sanitization defensive so injected `dryRun` keys cannot leak into API bodies.

### Description

- Removed the `rawParams.dryRun === true` branch in `executeAiTool` so the executor no longer returns `buildDryRunResponse(...)` and proceeds into the normal execution flow. 
- Removed the now-unused `buildDryRunResponse` import from `./response-builder`. 
- Removed the `getNodeParameter` override case `allowDryRunForWrites` and the associated explanatory comments about AI-managed dry-run behaviour. 
- Kept `dryRun` inside the `N8N_METADATA_FIELDS` set with an inline note marking it as a defensive strip to avoid metadata leaking into API request bodies.

### Testing

- Ran `npm run -s typecheck` and it completed successfully. 
- Attempted `npm run -s lint -- nodes/Autotask/ai-tools/tool-executor.ts` but the repository lint script does not accept a file argument and the command could not be executed against a single file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db0b2019888320b76784f441f91c7e)