### PR TITLE
Remove obsolete AI dry-run response handling

### DIFF
--- a/nodes/Autotask/ai-tools/debug-trace.ts
+++ b/nodes/Autotask/ai-tools/debug-trace.ts
@@ -172,7 +172,6 @@ export function summariseResponseEnvelope(serialized: string): Record<string, un
 		let resultKind: string;
 		if (isError) resultKind = 'error';
 		else if (typeof parsed.matchCount === 'number') resultKind = 'count';
-		else if (parsed.dryRun === true) resultKind = 'dryRun';
 		else if (records !== undefined) resultKind = 'list';
 		else if (ticketSummary !== undefined) resultKind = 'ticketSummary';
 		else if (parsed.outcome !== undefined) resultKind = 'compound';

--- a/nodes/Autotask/ai-tools/response-builder.ts
+++ b/nodes/Autotask/ai-tools/response-builder.ts
@@ -295,28 +295,6 @@ export function buildCompoundResponse(
     return response;
 }
 
-export function buildDryRunResponse(
-    resource: string,
-    operation: string,
-    resolvedFieldValues: Record<string, unknown>,
-    context: ToolResponseContext = {},
-): Record<string, unknown> {
-    const resolvedLabels = toResolvedLabels(context.resolutions);
-    const fieldCount = Object.keys(resolvedFieldValues).length;
-    const labelCount = resolvedLabels.length;
-    const summary = `Dry run: ${labelCount} label${labelCount !== 1 ? 's' : ''} resolved, ${fieldCount} field${fieldCount !== 1 ? 's' : ''} validated. No API call made.`;
-    return {
-        summary,
-        resource,
-        operation: `${resource}.${operation}`,
-        dryRun: true,
-        resolvedFieldValues,
-        resolvedLabels,
-        pendingConfirmations: context.pendingConfirmations ?? [],
-        warnings: context.resolutionWarnings ?? [],
-    };
-}
-
 type MetadataPayload =
     | { kind: 'describeFields'; fields: FieldMeta[]; mode: string }
     | { kind: 'listPicklistValues'; fieldId: string; picklistValues: unknown[] }


### PR DESCRIPTION
### Motivation
- AI/MCP response envelopes no longer include a `dryRun` discriminator and the dry-run response builder is unused, so the code should stop producing and detecting that shape.

### Description
- Remove the `buildDryRunResponse` export from `nodes/Autotask/ai-tools/response-builder.ts` and delete its implementation.
- Simplify response-kind detection by removing the `parsed.dryRun === true` branch from `nodes/Autotask/ai-tools/debug-trace.ts` so classification relies on current envelope shapes.

### Testing
- Ran `pnpm -s typecheck` and verified `rg "buildDryRunResponse" -n nodes/Autotask` returned no matches, with the typecheck completing successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db0e9fd3a883208f26de15bbd3b46c)