### PR TITLE
Add list continuation contract and enrich pagination metadata in Autotask AI tools

### DIFF
--- a/nodes/Autotask/ai-tools/operation-handlers/operation-dispatch.ts
+++ b/nodes/Autotask/ai-tools/operation-handlers/operation-dispatch.ts
@@ -1,397 +1,403 @@
+import { wrapError, ERROR_TYPES } from '../error-formatter';
 import {
-    wrapError,
-    ERROR_TYPES,
-} from '../error-formatter';
-import {
-    buildListResponse,
-    buildItemResponse,
-    buildMutationResponse,
-    buildDeleteResponse,
-    buildCountResponse,
-    buildSlaHealthCheckResponse,
-    buildTicketSummaryResponse,
-    toResolvedLabels,
-    type ToolResponseContext,
-    type ListPaginationState,
+	buildListResponse,
+	buildItemResponse,
+	buildMutationResponse,
+	buildDeleteResponse,
+	buildCountResponse,
+	buildSlaHealthCheckResponse,
+	buildTicketSummaryResponse,
+	toResolvedLabels,
+	computeListContinuation,
+	type ToolResponseContext,
+	type ListPaginationState,
 } from '../response-builder';
-import {
-    MAX_QUERY_LIMIT,
-    getEffectiveLimit,
-} from '../tool-executor';
+import { MAX_QUERY_LIMIT, getEffectiveLimit } from '../tool-executor';
 
 const MAX_RESPONSE_RECORDS = 100;
 
 interface OperationResponseParams {
-    id?: number;
-    ticketNumber?: string;
-    resourceID?: string | number;
-    year?: string | number;
-    limit?: number;
-    returnAll?: boolean;
-    filtersJson?: string;
-    filter_field?: string;
-    filter_op?: string;
-    filter_value?: string | number | boolean | Array<string | number | boolean>;
-    filter_field_2?: string;
-    filter_op_2?: string;
-    filter_value_2?: string | number | boolean | Array<string | number | boolean>;
-    filter_logic?: 'and' | 'or';
-    recency?: string;
-    since?: string;
-    until?: string;
+	id?: number;
+	ticketNumber?: string;
+	resourceID?: string | number;
+	year?: string | number;
+	limit?: number;
+	returnAll?: boolean;
+	filtersJson?: string;
+	filter_field?: string;
+	filter_op?: string;
+	filter_value?: string | number | boolean | Array<string | number | boolean>;
+	filter_field_2?: string;
+	filter_op_2?: string;
+	filter_value_2?: string | number | boolean | Array<string | number | boolean>;
+	filter_logic?: 'and' | 'or';
+	recency?: string;
+	since?: string;
+	until?: string;
 }
 
 export function dispatchOperationResponse(
-    resource: string,
-    operation: string,
-    records: Record<string, unknown>[],
-    params: OperationResponseParams,
-    context: ToolResponseContext = {},
+	resource: string,
+	operation: string,
+	records: Record<string, unknown>[],
+	params: OperationResponseParams,
+	context: ToolResponseContext = {},
 ): string {
-    const firstRecord = records[0] ?? null;
+	const firstRecord = records[0] ?? null;
 
-    const extractId = (record: Record<string, unknown> | null): number | string | null => {
-        if (!record) return null;
-        const candidate = record.itemId ?? record.id;
-        return typeof candidate === 'number' || typeof candidate === 'string' ? candidate : null;
-    };
+	const extractId = (record: Record<string, unknown> | null): number | string | null => {
+		if (!record) return null;
+		const candidate = record.itemId ?? record.id;
+		return typeof candidate === 'number' || typeof candidate === 'string' ? candidate : null;
+	};
 
-    switch (operation) {
-        case 'get': {
-            if (
-                firstRecord === null ||
-                (typeof firstRecord === 'object' &&
-                    !Array.isArray(firstRecord) &&
-                    Object.keys(firstRecord).length === 0)
-            ) {
-                const id = params.id ?? 'unknown';
-                return JSON.stringify(
-                    wrapError(
-                        resource,
-                        operation,
-                        ERROR_TYPES.ENTITY_NOT_FOUND,
-                        `No ${resource} found with id ${id}.`,
-                        `Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
-                    ),
-                );
-            }
-            return JSON.stringify(buildItemResponse(resource, operation, firstRecord, {}, context));
-        }
+	switch (operation) {
+		case 'get': {
+			if (
+				firstRecord === null ||
+				(typeof firstRecord === 'object' &&
+					!Array.isArray(firstRecord) &&
+					Object.keys(firstRecord).length === 0)
+			) {
+				const id = params.id ?? 'unknown';
+				return JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.ENTITY_NOT_FOUND,
+						`No ${resource} found with id ${id}.`,
+						`Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
+					),
+				);
+			}
+			return JSON.stringify(buildItemResponse(resource, operation, firstRecord, {}, context));
+		}
 
-        case 'getMany':
-        case 'getPosted':
-        case 'getUnposted': {
-            const hasFilters = !!(
-                params.filter_field ||
-                params.filter_field_2 ||
-                params.filtersJson ||
-                params.recency ||
-                params.since ||
-                params.until
-            );
-            if (hasFilters && records.length === 0) {
-                const filtersUsed: Record<string, unknown> = {};
-                if (params.filter_field) {
-                    filtersUsed.filter_field = params.filter_field;
-                    filtersUsed.filter_op = params.filter_op;
-                    filtersUsed.filter_value = params.filter_value;
-                }
-                if (params.filter_field_2) {
-                    filtersUsed.filter_field_2 = params.filter_field_2;
-                    filtersUsed.filter_op_2 = params.filter_op_2;
-                    filtersUsed.filter_value_2 = params.filter_value_2;
-                }
-                if (params.filter_logic && params.filter_logic !== 'and') {
-                    filtersUsed.filter_logic = params.filter_logic;
-                }
-                if (params.filtersJson) filtersUsed.filtersJson = params.filtersJson;
-                if (params.recency) filtersUsed.recency = params.recency;
-                if (params.since) filtersUsed.since = params.since;
-                if (params.until) filtersUsed.until = params.until;
+		case 'getMany':
+		case 'getPosted':
+		case 'getUnposted': {
+			const hasFilters = !!(
+				params.filter_field ||
+				params.filter_field_2 ||
+				params.filtersJson ||
+				params.recency ||
+				params.since ||
+				params.until
+			);
+			if (hasFilters && records.length === 0) {
+				const filtersUsed: Record<string, unknown> = {};
+				if (params.filter_field) {
+					filtersUsed.filter_field = params.filter_field;
+					filtersUsed.filter_op = params.filter_op;
+					filtersUsed.filter_value = params.filter_value;
+				}
+				if (params.filter_field_2) {
+					filtersUsed.filter_field_2 = params.filter_field_2;
+					filtersUsed.filter_op_2 = params.filter_op_2;
+					filtersUsed.filter_value_2 = params.filter_value_2;
+				}
+				if (params.filter_logic && params.filter_logic !== 'and') {
+					filtersUsed.filter_logic = params.filter_logic;
+				}
+				if (params.filtersJson) filtersUsed.filtersJson = params.filtersJson;
+				if (params.recency) filtersUsed.recency = params.recency;
+				if (params.since) filtersUsed.since = params.since;
+				if (params.until) filtersUsed.until = params.until;
 
-                const usedFilterFields = new Set<string>(
-                    [
-                        typeof params.filter_field === 'string' ? params.filter_field : '',
-                        typeof params.filter_field_2 === 'string' ? params.filter_field_2 : '',
-                    ]
-                        .map((f) => f.trim().toLowerCase())
-                        .filter((f) => f !== ''),
-                );
-                const alternativeFilterFields = (context.readFields ?? [])
-                    .filter(
-                        (f) =>
-                            !f.udf &&
-                            typeof f.type === 'string' &&
-                            f.type.toLowerCase() === 'string' &&
-                            !usedFilterFields.has(f.id.toLowerCase()),
-                    )
-                    .map((f) => f.id)
-                    .slice(0, 10);
+				const usedFilterFields = new Set<string>(
+					[
+						typeof params.filter_field === 'string' ? params.filter_field : '',
+						typeof params.filter_field_2 === 'string' ? params.filter_field_2 : '',
+					]
+						.map((f) => f.trim().toLowerCase())
+						.filter((f) => f !== ''),
+				);
+				const alternativeFilterFields = (context.readFields ?? [])
+					.filter(
+						(f) =>
+							!f.udf &&
+							typeof f.type === 'string' &&
+							f.type.toLowerCase() === 'string' &&
+							!usedFilterFields.has(f.id.toLowerCase()),
+					)
+					.map((f) => f.id)
+					.slice(0, 10);
 
-                const contextFields: Record<string, unknown> = { filtersUsed };
-                if (alternativeFilterFields.length > 0) {
-                    contextFields.alternativeFilterFields = alternativeFilterFields;
-                }
-                const unresolvedFilterWarnings = context.resolutionWarnings ?? [];
-                if (unresolvedFilterWarnings.length > 0) {
-                    contextFields.filterResolutionWarnings = unresolvedFilterWarnings;
-                }
-                return JSON.stringify(
-                    wrapError(
-                        resource,
-                        operation,
-                        ERROR_TYPES.NO_RESULTS_FOUND,
-                        `No ${resource} records matched the supplied filters.`,
-                        `Definitive negative — do not retry with the same filters. Broaden or change filter_field/filter_value and retry.`,
-                        contextFields,
-                    ),
-                );
-            }
+				const contextFields: Record<string, unknown> = { filtersUsed };
+				if (alternativeFilterFields.length > 0) {
+					contextFields.alternativeFilterFields = alternativeFilterFields;
+				}
+				const unresolvedFilterWarnings = context.resolutionWarnings ?? [];
+				if (unresolvedFilterWarnings.length > 0) {
+					contextFields.filterResolutionWarnings = unresolvedFilterWarnings;
+				}
+				return JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.NO_RESULTS_FOUND,
+						`No ${resource} records matched the supplied filters.`,
+						`Definitive negative — do not retry with the same filters. Broaden or change filter_field/filter_value and retry.`,
+						contextFields,
+					),
+				);
+			}
 
-            const total = records.length;
-            const truncated = total > MAX_RESPONSE_RECORDS;
-            const items = truncated ? records.slice(0, MAX_RESPONSE_RECORDS) : records;
-            const currentOffset = context.effectiveOffset ?? 0;
+			const total = records.length;
+			const truncated = total > MAX_RESPONSE_RECORDS;
+			const items = truncated ? records.slice(0, MAX_RESPONSE_RECORDS) : records;
+			const currentOffset = context.effectiveOffset ?? 0;
+			let totalAvailable: number | undefined;
+			const continuationContract = computeListContinuation({
+				currentOffset,
+				recordsReturned: items.length,
+				recordsMatched: total,
+				requestedLimit: getEffectiveLimit(params.limit),
+				returnAll: params.returnAll === true,
+				recencyActive: context.recencyActive === true,
+				maxQueryLimit: MAX_QUERY_LIMIT,
+				serverCap: context.serverCap ?? MAX_QUERY_LIMIT,
+				clientCap: context.clientCap ?? MAX_RESPONSE_RECORDS,
+				serverCapReached:
+					context.serverCapReached === true || context.recencyWindowLimited === true,
+			});
+			const hasMore = continuationContract.continuation?.hasMore === true;
+			const nextOffset = continuationContract.continuation?.nextOffset;
 
-            let hasMore = false;
-            let nextOffset: number | undefined;
-            let totalAvailable: number | undefined;
+			if (truncated) totalAvailable = total;
 
-            if (context.recencyActive) {
-                hasMore = false;
-                if (truncated) totalAvailable = total;
-            } else if (params.returnAll) {
-                hasMore = false;
-                if (truncated) totalAvailable = total;
-            } else if (truncated) {
-                totalAvailable = total;
-                const truncatedNextOffset = currentOffset + MAX_RESPONSE_RECORDS;
-                hasMore = truncatedNextOffset < MAX_QUERY_LIMIT;
-                if (hasMore) nextOffset = truncatedNextOffset;
-            } else if (items.length > 0) {
-                const requestedLimit = getEffectiveLimit(params.limit);
-                const candidateNext = currentOffset + items.length;
-                hasMore = items.length >= requestedLimit && candidateNext < MAX_QUERY_LIMIT;
-                if (hasMore) nextOffset = candidateNext;
-            }
+			const notes: string[] = [];
+			if (context.recencyNote) notes.push(context.recencyNote);
+			if (continuationContract.truncationReason) {
+				notes.push(continuationContract.truncationReason);
+			}
+			if (truncated) {
+				if (params.returnAll) {
+					notes.push(
+						`Fetched all ${total} matching records via returnAll; showing first ${MAX_RESPONSE_RECORDS} in this response. ` +
+							`Use 'fields' to reduce payload size, or narrow filters to reduce match count.`,
+					);
+				} else {
+					notes.push(
+						hasMore
+							? `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Use offset=${nextOffset} to see the next page, or use a narrower filter.`
+							: `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Offset pagination limit (${MAX_QUERY_LIMIT}) reached — use narrower filters to access more records.`,
+					);
+				}
+			}
 
-            const notes: string[] = [];
-            if (context.recencyNote) notes.push(context.recencyNote);
-            if (truncated) {
-                if (params.returnAll) {
-                    notes.push(
-                        `Fetched all ${total} matching records via returnAll; showing first ${MAX_RESPONSE_RECORDS} in this response. ` +
-                            `Use 'fields' to reduce payload size, or narrow filters to reduce match count.`,
-                    );
-                } else {
-                    notes.push(
-                        hasMore
-                            ? `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Use offset=${nextOffset} to see the next page, or use a narrower filter.`
-                            : `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Offset pagination limit (${MAX_QUERY_LIMIT}) reached — use narrower filters to access more records.`,
-                    );
-                }
-            }
+			const listWarnings: string[] = [...(context.resolutionWarnings ?? [])];
+			if (context.recencyWindowLimited) {
+				listWarnings.push(
+					'500 records were returned for the current recency window. Narrow recency, or provide since/until, to ensure the newest records are included.',
+				);
+			}
 
-            const listWarnings: string[] = [...(context.resolutionWarnings ?? [])];
-            if (context.recencyWindowLimited) {
-                listWarnings.push(
-                    '500 records were returned for the current recency window. Narrow recency, or provide since/until, to ensure the newest records are included.',
-                );
-            }
+			const pagination: ListPaginationState = {
+				hasMore,
+				...(nextOffset !== undefined ? { nextOffset } : {}),
+				...(totalAvailable !== undefined ? { totalAvailable } : {}),
+				...(notes.length > 0 ? { notes } : {}),
+				continuation: continuationContract.continuation,
+				isTruncated: continuationContract.isTruncated,
+				truncationReason: continuationContract.truncationReason,
+				serverCap: continuationContract.serverCap,
+				clientCap: continuationContract.clientCap,
+			};
 
-            const pagination: ListPaginationState = {
-                hasMore,
-                ...(nextOffset !== undefined ? { nextOffset } : {}),
-                ...(totalAvailable !== undefined ? { totalAvailable } : {}),
-                ...(notes.length > 0 ? { notes } : {}),
-            };
+			const listContext: ToolResponseContext = {
+				...context,
+				resolutionWarnings: listWarnings,
+			};
 
-            const listContext: ToolResponseContext = {
-                ...context,
-                resolutionWarnings: listWarnings,
-            };
+			return JSON.stringify(buildListResponse(resource, operation, items, pagination, listContext));
+		}
 
-            return JSON.stringify(buildListResponse(resource, operation, items, pagination, listContext));
-        }
+		case 'whoAmI': {
+			if (firstRecord === null || firstRecord === undefined) {
+				return JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.ENTITY_NOT_FOUND,
+						`No ${resource} found for authenticated user.`,
+						`Use autotask_${resource} with operation 'getMany' to locate a valid record, then retry.`,
+					),
+				);
+			}
+			return JSON.stringify(
+				buildItemResponse(resource, operation, firstRecord, { verb: 'Authenticated as' }, context),
+			);
+		}
 
-        case 'whoAmI': {
-            if (firstRecord === null || firstRecord === undefined) {
-                return JSON.stringify(
-                    wrapError(
-                        resource,
-                        operation,
-                        ERROR_TYPES.ENTITY_NOT_FOUND,
-                        `No ${resource} found for authenticated user.`,
-                        `Use autotask_${resource} with operation 'getMany' to locate a valid record, then retry.`,
-                    ),
-                );
-            }
-            return JSON.stringify(
-                buildItemResponse(resource, operation, firstRecord, { verb: 'Authenticated as' }, context),
-            );
-        }
+		case 'searchByDomain': {
+			if (records.length === 0) {
+				return JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.NO_RESULTS_FOUND,
+						`No ${resource} found matching the supplied domain.`,
+						`Verify the domain and retry, or use autotask_${resource} with operation 'getMany' with a filter.`,
+					),
+				);
+			}
+			// searchByDomain uses list shape — no domain-specific qualifier in summary since params.domain is not passed
+			const resolvedLabels = toResolvedLabels(context.resolutions);
+			return JSON.stringify({
+				summary: `Found ${records.length} ${resource} records — complete set, no further calls needed.`,
+				resource,
+				operation: `${resource}.${operation}`,
+				records,
+				returnedCount: records.length,
+				hasMore: false,
+				continuation: null,
+				isTruncated: false,
+				truncationReason: null,
+				serverCap: MAX_QUERY_LIMIT,
+				clientCap: MAX_RESPONSE_RECORDS,
+				resolvedLabels,
+				pendingConfirmations: context.pendingConfirmations ?? [],
+				warnings: context.resolutionWarnings ?? [],
+			});
+		}
 
-        case 'searchByDomain': {
-            if (records.length === 0) {
-                return JSON.stringify(
-                    wrapError(
-                        resource,
-                        operation,
-                        ERROR_TYPES.NO_RESULTS_FOUND,
-                        `No ${resource} found matching the supplied domain.`,
-                        `Verify the domain and retry, or use autotask_${resource} with operation 'getMany' with a filter.`,
-                    ),
-                );
-            }
-            // searchByDomain uses list shape — no domain-specific qualifier in summary since params.domain is not passed
-            const resolvedLabels = toResolvedLabels(context.resolutions);
-            return JSON.stringify({
-                summary: `Found ${records.length} ${resource} records — complete set, no further calls needed.`,
-                resource,
-                operation: `${resource}.${operation}`,
-                records,
-                returnedCount: records.length,
-                hasMore: false,
-                resolvedLabels,
-                pendingConfirmations: context.pendingConfirmations ?? [],
-                warnings: context.resolutionWarnings ?? [],
-            });
-        }
+		case 'slaHealthCheck': {
+			if (firstRecord === null || firstRecord === undefined) {
+				const identifier = params.ticketNumber ?? params.id ?? 'unknown';
+				return JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.ENTITY_NOT_FOUND,
+						`No ${resource} found with id ${identifier}.`,
+						`Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
+					),
+				);
+			}
+			return JSON.stringify(buildSlaHealthCheckResponse(resource, operation, firstRecord, context));
+		}
 
-        case 'slaHealthCheck': {
-            if (firstRecord === null || firstRecord === undefined) {
-                const identifier = params.ticketNumber ?? params.id ?? 'unknown';
-                return JSON.stringify(
-                    wrapError(
-                        resource,
-                        operation,
-                        ERROR_TYPES.ENTITY_NOT_FOUND,
-                        `No ${resource} found with id ${identifier}.`,
-                        `Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
-                    ),
-                );
-            }
-            return JSON.stringify(buildSlaHealthCheckResponse(resource, operation, firstRecord, context));
-        }
+		case 'summary': {
+			if (firstRecord === null || firstRecord === undefined) {
+				const identifier = params.ticketNumber ?? params.id ?? 'unknown';
+				return JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.ENTITY_NOT_FOUND,
+						`No ${resource} found with id ${identifier}.`,
+						`Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
+					),
+				);
+			}
+			return JSON.stringify(buildTicketSummaryResponse(resource, operation, firstRecord, context));
+		}
 
-        case 'summary': {
-            if (firstRecord === null || firstRecord === undefined) {
-                const identifier = params.ticketNumber ?? params.id ?? 'unknown';
-                return JSON.stringify(
-                    wrapError(
-                        resource,
-                        operation,
-                        ERROR_TYPES.ENTITY_NOT_FOUND,
-                        `No ${resource} found with id ${identifier}.`,
-                        `Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
-                    ),
-                );
-            }
-            return JSON.stringify(buildTicketSummaryResponse(resource, operation, firstRecord, context));
-        }
+		case 'moveConfigurationItem':
+		case 'moveToCompany':
+		case 'approve':
+		case 'reject':
+		case 'transferOwnership':
+		case 'create':
+		case 'update': {
+			const isNullReturningOp =
+				operation === 'moveConfigurationItem' ||
+				operation === 'moveToCompany' ||
+				operation === 'approve' ||
+				operation === 'reject' ||
+				operation === 'transferOwnership';
 
-        case 'moveConfigurationItem':
-        case 'moveToCompany':
-        case 'approve':
-        case 'reject':
-        case 'transferOwnership':
-        case 'create':
-        case 'update': {
-            const isNullReturningOp =
-                operation === 'moveConfigurationItem' ||
-                operation === 'moveToCompany' ||
-                operation === 'approve' ||
-                operation === 'reject' ||
-                operation === 'transferOwnership';
+			if (isNullReturningOp && (firstRecord === null || firstRecord === undefined)) {
+				const id = params.id ?? 'unknown';
+				if (operation === 'transferOwnership') {
+					return JSON.stringify(
+						wrapError(
+							resource,
+							operation,
+							ERROR_TYPES.ENTITY_NOT_FOUND,
+							`Transfer ownership returned no result.`,
+							`Verify source and destination resource IDs, then retry.`,
+						),
+					);
+				}
+				return JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.ENTITY_NOT_FOUND,
+						`No ${resource} found with id ${id}.`,
+						`Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
+					),
+				);
+			}
 
-            if (isNullReturningOp && (firstRecord === null || firstRecord === undefined)) {
-                const id = params.id ?? 'unknown';
-                if (operation === 'transferOwnership') {
-                    return JSON.stringify(
-                        wrapError(
-                            resource,
-                            operation,
-                            ERROR_TYPES.ENTITY_NOT_FOUND,
-                            `Transfer ownership returned no result.`,
-                            `Verify source and destination resource IDs, then retry.`,
-                        ),
-                    );
-                }
-                return JSON.stringify(
-                    wrapError(
-                        resource,
-                        operation,
-                        ERROR_TYPES.ENTITY_NOT_FOUND,
-                        `No ${resource} found with id ${id}.`,
-                        `Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
-                    ),
-                );
-            }
+			const id =
+				operation === 'approve' || operation === 'reject'
+					? ((params.id as number | undefined) ?? extractId(firstRecord) ?? 'unknown')
+					: (extractId(firstRecord) ?? 'unknown');
 
-            const id =
-                operation === 'approve' || operation === 'reject'
-                    ? ((params.id as number | undefined) ?? extractId(firstRecord) ?? 'unknown')
-                    : (extractId(firstRecord) ?? 'unknown');
+			return JSON.stringify(
+				buildMutationResponse(resource, operation, id, firstRecord ?? undefined, context),
+			);
+		}
 
-            return JSON.stringify(buildMutationResponse(resource, operation, id, firstRecord ?? undefined, context));
-        }
+		case 'delete': {
+			const id = params.id ?? extractId(firstRecord) ?? 'unknown';
+			return JSON.stringify(buildDeleteResponse(resource, operation, id, context));
+		}
 
-        case 'delete': {
-            const id = params.id ?? extractId(firstRecord) ?? 'unknown';
-            return JSON.stringify(buildDeleteResponse(resource, operation, id, context));
-        }
+		case 'count': {
+			const countValue = records[0]?.count ?? records.length;
+			return JSON.stringify(buildCountResponse(resource, operation, countValue as number));
+		}
 
-        case 'count': {
-            const countValue = records[0]?.count ?? records.length;
-            return JSON.stringify(buildCountResponse(resource, operation, countValue as number));
-        }
+		case 'getByResource':
+		case 'getByYear': {
+			const entity = firstRecord;
+			if (
+				entity === null ||
+				entity === undefined ||
+				(typeof entity === 'object' &&
+					!Array.isArray(entity) &&
+					Object.keys(entity as object).length === 0)
+			) {
+				if (operation === 'getByYear') {
+					const rid = params.resourceID ?? 'unknown';
+					const yr = params.year ?? 'unknown';
+					return JSON.stringify(
+						wrapError(
+							resource,
+							operation,
+							ERROR_TYPES.ENTITY_NOT_FOUND,
+							`No ${resource} found for resource ${rid}, year ${yr}.`,
+							`Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
+						),
+					);
+				}
+				const rid = params.resourceID ?? 'unknown';
+				return JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.ENTITY_NOT_FOUND,
+						`No ${resource} found for resource ${rid}.`,
+						`Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
+					),
+				);
+			}
+			return JSON.stringify(buildItemResponse(resource, operation, entity, {}, context));
+		}
 
-        case 'getByResource':
-        case 'getByYear': {
-            const entity = firstRecord;
-            if (
-                entity === null ||
-                entity === undefined ||
-                (typeof entity === 'object' &&
-                    !Array.isArray(entity) &&
-                    Object.keys(entity as object).length === 0)
-            ) {
-                if (operation === 'getByYear') {
-                    const rid = params.resourceID ?? 'unknown';
-                    const yr = params.year ?? 'unknown';
-                    return JSON.stringify(
-                        wrapError(
-                            resource,
-                            operation,
-                            ERROR_TYPES.ENTITY_NOT_FOUND,
-                            `No ${resource} found for resource ${rid}, year ${yr}.`,
-                            `Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
-                        ),
-                    );
-                }
-                const rid = params.resourceID ?? 'unknown';
-                return JSON.stringify(
-                    wrapError(
-                        resource,
-                        operation,
-                        ERROR_TYPES.ENTITY_NOT_FOUND,
-                        `No ${resource} found for resource ${rid}.`,
-                        `Use autotask_${resource} with operation 'getMany' and the 'filter_field'/'filter_value' parameters to locate a valid record, extract its numeric 'id', then retry.`,
-                    ),
-                );
-            }
-            return JSON.stringify(buildItemResponse(resource, operation, entity, {}, context));
-        }
-
-        default:
-            return JSON.stringify(
-                wrapError(
-                    resource,
-                    operation,
-                    ERROR_TYPES.INVALID_OPERATION,
-                    `Unknown operation '${operation}'.`,
-                    `Use a supported operation for autotask_${resource}.`,
-                ),
-            );
-    }
+		default:
+			return JSON.stringify(
+				wrapError(
+					resource,
+					operation,
+					ERROR_TYPES.INVALID_OPERATION,
+					`Unknown operation '${operation}'.`,
+					`Use a supported operation for autotask_${resource}.`,
+				),
+			);
+	}
 }

--- a/nodes/Autotask/ai-tools/response-builder.ts
+++ b/nodes/Autotask/ai-tools/response-builder.ts
@@ -1,63 +1,57 @@
 import type { FieldMeta } from '../helpers/aiHelper';
-import type {
-    LabelResolution,
-    PendingLabelConfirmation,
-} from '../helpers/label-resolution';
+import type { LabelResolution, PendingLabelConfirmation } from '../helpers/label-resolution';
 import { getAiIdentityProfile } from '../constants/ai-identity';
 
 export interface ToolResponseContext {
-    resource?: string;
-    recencyActive?: boolean;
-    recencyWindowLimited?: boolean;
-    recencyNote?: string;
-    resolutions?: LabelResolution[];
-    resolutionWarnings?: string[];
-    pendingConfirmations?: PendingLabelConfirmation[];
-    effectiveOffset?: number;
-    readFields?: FieldMeta[];
+	resource?: string;
+	recencyActive?: boolean;
+	recencyWindowLimited?: boolean;
+	recencyNote?: string;
+	resolutions?: LabelResolution[];
+	resolutionWarnings?: string[];
+	pendingConfirmations?: PendingLabelConfirmation[];
+	effectiveOffset?: number;
+	readFields?: FieldMeta[];
+	serverCap?: number;
+	clientCap?: number;
+	serverCapReached?: boolean;
 }
 
 export function attachCorrelation(json: string, id: string | undefined): string {
-    if (!id) return json;
-    try {
-        const parsed = JSON.parse(json) as Record<string, unknown>;
-        return JSON.stringify({ correlationId: id, ...parsed });
-    } catch {
-        return json;
-    }
+	if (!id) return json;
+	try {
+		const parsed = JSON.parse(json) as Record<string, unknown>;
+		return JSON.stringify({ correlationId: id, ...parsed });
+	} catch {
+		return json;
+	}
 }
 
 function getFieldValue(
-    entity: Record<string, unknown>,
-    fields: string[],
+	entity: Record<string, unknown>,
+	fields: string[],
 ): string | number | undefined {
-    for (const field of fields) {
-        const value = entity[field];
-        if (
-            typeof value === 'number' ||
-            (typeof value === 'string' && value.trim() !== '')
-        ) {
-            return value;
-        }
-    }
-    return undefined;
+	for (const field of fields) {
+		const value = entity[field];
+		if (typeof value === 'number' || (typeof value === 'string' && value.trim() !== '')) {
+			return value;
+		}
+	}
+	return undefined;
 }
 
 function getFieldValueByKeyPattern(
-    entity: Record<string, unknown>,
-    pattern: RegExp,
+	entity: Record<string, unknown>,
+	pattern: RegExp,
 ): string | number | undefined {
-    // Pattern fallback keeps identity extraction resilient when schema-selected fields vary.
-    for (const [key, value] of Object.entries(entity)) {
-        if (!pattern.test(key)) continue;
-        if (
-            typeof value === 'number' ||
-            (typeof value === 'string' && value.trim() !== '')
-        ) {
-            return value;
-        }
-    }
-    return undefined;
+	// Pattern fallback keeps identity extraction resilient when schema-selected fields vary.
+	for (const [key, value] of Object.entries(entity)) {
+		if (!pattern.test(key)) continue;
+		if (typeof value === 'number' || (typeof value === 'string' && value.trim() !== '')) {
+			return value;
+		}
+	}
+	return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -65,46 +59,141 @@ function getFieldValueByKeyPattern(
 // ---------------------------------------------------------------------------
 
 export interface ResolvedLabel {
-    field: string;
-    from: string | number;
-    to: string | number;
+	field: string;
+	from: string | number;
+	to: string | number;
 }
 
 export function toResolvedLabels(resolutions?: LabelResolution[]): ResolvedLabel[] {
-    return (resolutions ?? []).map(({ field, from, to }) => ({ field, from, to }));
+	return (resolutions ?? []).map(({ field, from, to }) => ({ field, from, to }));
 }
 
 export interface ListPaginationState {
-    hasMore: boolean;
-    nextOffset?: number;
-    totalAvailable?: number;
-    notes?: string[];
+	hasMore: boolean;
+	nextOffset?: number;
+	totalAvailable?: number;
+	notes?: string[];
+	continuation?: ListContinuationPointer | null;
+	isTruncated?: boolean;
+	truncationReason?: string;
+	serverCap: number;
+	clientCap: number;
+}
+
+export interface ListContinuationPointer {
+	hasMore: boolean;
+	nextOffset?: number;
+}
+
+export interface ListContinuationContract {
+	continuation: ListContinuationPointer | null;
+	isTruncated: boolean;
+	truncationReason?: string;
+	serverCap: number;
+	clientCap: number;
+}
+
+export interface ListContinuationComputation {
+	currentOffset: number;
+	recordsReturned: number;
+	recordsMatched: number;
+	requestedLimit: number;
+	returnAll: boolean;
+	recencyActive: boolean;
+	maxQueryLimit: number;
+	serverCap: number;
+	clientCap: number;
+	serverCapReached: boolean;
+}
+
+export function computeListContinuation(
+	input: ListContinuationComputation,
+): ListContinuationContract {
+	const {
+		currentOffset,
+		recordsReturned,
+		recordsMatched,
+		requestedLimit,
+		returnAll,
+		recencyActive,
+		maxQueryLimit,
+		serverCap,
+		clientCap,
+		serverCapReached,
+	} = input;
+	const isTruncated = recordsMatched > recordsReturned || serverCapReached;
+	let continuation: ListContinuationPointer | null = null;
+	let truncationReason: string | undefined;
+
+	if (returnAll) {
+		if (serverCapReached) {
+			truncationReason = recencyActive
+				? `returnAll requested, but recency fetch is capped at ${serverCap} records. Retry with narrower recency or explicit since/until windows to fetch the full set.`
+				: `returnAll requested, but server fetch is capped at ${serverCap} records. Retry with narrower filters to fetch all matching records.`;
+		} else if (recordsMatched > recordsReturned) {
+			truncationReason = `Fetched all matching records; response payload is capped at ${clientCap} records. Narrow filters or requested fields to inspect a smaller subset.`;
+		}
+		return {
+			continuation,
+			isTruncated,
+			truncationReason,
+			serverCap,
+			clientCap,
+		};
+	}
+
+	if (recordsMatched > recordsReturned) {
+		const truncatedNextOffset = currentOffset + clientCap;
+		if (truncatedNextOffset < maxQueryLimit) {
+			continuation = { hasMore: true, nextOffset: truncatedNextOffset };
+		}
+	} else if (!returnAll && !recencyActive && recordsReturned > 0) {
+		const candidateNext = currentOffset + recordsReturned;
+		if (recordsReturned >= requestedLimit && candidateNext < maxQueryLimit) {
+			continuation = { hasMore: true, nextOffset: candidateNext };
+		}
+	}
+
+	if (isTruncated && !truncationReason) {
+		if (recordsMatched > recordsReturned) {
+			truncationReason = continuation?.hasMore
+				? `Response payload capped at ${clientCap} records. Continue with the provided nextOffset.`
+				: `Response payload capped at ${clientCap} records and offset pagination cap (${maxQueryLimit}) was reached. Narrow filters to continue.`;
+		} else if (serverCapReached) {
+			truncationReason = `Server-side fetch cap (${serverCap}) was reached. Narrow filters or split the request into smaller windows.`;
+		}
+	}
+
+	return {
+		continuation,
+		isTruncated,
+		truncationReason,
+		serverCap,
+		clientCap,
+	};
 }
 
 // ---------------------------------------------------------------------------
 // Identity string builder (internal)
 // ---------------------------------------------------------------------------
 
-function buildIdentityString(
-    resource: string,
-    entity: Record<string, unknown>,
-): string {
-    const profile = getAiIdentityProfile(resource);
-    const humanId =
-        getFieldValue(entity, profile.humanIdentifierFields ?? []) ??
-        getFieldValueByKeyPattern(entity, /Number$|Code$|Reference$/i);
-    const titleVal =
-        getFieldValue(entity, profile.titleLikeFields ?? []) ??
-        getFieldValueByKeyPattern(entity, /Name$|Title$|Subject$|DisplayName$/i);
-    const id = entity.id ?? entity.itemId;
-    const parts: string[] = [];
-    if (humanId !== undefined) parts.push(String(humanId));
-    if (titleVal !== undefined) parts.push(String(titleVal));
-    const descriptor = parts.join(' — ');
-    if (descriptor && id !== undefined) return `${descriptor} (ID: ${id})`;
-    if (descriptor) return descriptor;
-    if (id !== undefined) return `(ID: ${id})`;
-    return '';
+function buildIdentityString(resource: string, entity: Record<string, unknown>): string {
+	const profile = getAiIdentityProfile(resource);
+	const humanId =
+		getFieldValue(entity, profile.humanIdentifierFields ?? []) ??
+		getFieldValueByKeyPattern(entity, /Number$|Code$|Reference$/i);
+	const titleVal =
+		getFieldValue(entity, profile.titleLikeFields ?? []) ??
+		getFieldValueByKeyPattern(entity, /Name$|Title$|Subject$|DisplayName$/i);
+	const id = entity.id ?? entity.itemId;
+	const parts: string[] = [];
+	if (humanId !== undefined) parts.push(String(humanId));
+	if (titleVal !== undefined) parts.push(String(titleVal));
+	const descriptor = parts.join(' — ');
+	if (descriptor && id !== undefined) return `${descriptor} (ID: ${id})`;
+	if (descriptor) return descriptor;
+	if (id !== undefined) return `(ID: ${id})`;
+	return '';
 }
 
 // ---------------------------------------------------------------------------
@@ -112,41 +201,44 @@ function buildIdentityString(
 // ---------------------------------------------------------------------------
 
 export function buildListResponse(
-    resource: string,
-    operation: string,
-    records: Record<string, unknown>[],
-    pagination: ListPaginationState,
-    context: ToolResponseContext = {},
+	resource: string,
+	operation: string,
+	records: Record<string, unknown>[],
+	pagination: ListPaginationState,
+	context: ToolResponseContext = {},
 ): Record<string, unknown> {
-    const count = records.length;
-    let terminationSignal: string;
-    if (pagination.totalAvailable !== undefined) {
-        terminationSignal = `truncated — ${pagination.totalAvailable} total matched, limit reached. Use narrower filters`;
-    } else if (pagination.hasMore) {
-        terminationSignal = `more available. Use nextOffset: ${pagination.nextOffset} to continue`;
-    } else {
-        terminationSignal = 'complete set, no further calls needed';
-    }
-    const opPrefix =
-        operation === 'getPosted' ? 'posted '
-        : operation === 'getUnposted' ? 'unposted '
-        : '';
-    const summary = `Found ${count} ${opPrefix}${resource} records — ${terminationSignal}.`;
-    const response: Record<string, unknown> = {
-        summary,
-        resource,
-        operation: `${resource}.${operation}`,
-        records,
-        returnedCount: count,
-        hasMore: pagination.hasMore,
-        resolvedLabels: toResolvedLabels(context.resolutions),
-        pendingConfirmations: context.pendingConfirmations ?? [],
-        warnings: context.resolutionWarnings ?? [],
-    };
-    if (pagination.nextOffset !== undefined) response.nextOffset = pagination.nextOffset;
-    if (pagination.totalAvailable !== undefined) response.totalAvailable = pagination.totalAvailable;
-    if (pagination.notes && pagination.notes.length > 0) response.notes = pagination.notes;
-    return response;
+	const count = records.length;
+	let terminationSignal: string;
+	if (pagination.totalAvailable !== undefined) {
+		terminationSignal = `truncated — ${pagination.totalAvailable} total matched, limit reached. Use narrower filters`;
+	} else if (pagination.hasMore) {
+		terminationSignal = `more available. Use nextOffset: ${pagination.nextOffset} to continue`;
+	} else {
+		terminationSignal = 'complete set, no further calls needed';
+	}
+	const opPrefix =
+		operation === 'getPosted' ? 'posted ' : operation === 'getUnposted' ? 'unposted ' : '';
+	const summary = `Found ${count} ${opPrefix}${resource} records — ${terminationSignal}.`;
+	const response: Record<string, unknown> = {
+		summary,
+		resource,
+		operation: `${resource}.${operation}`,
+		records,
+		returnedCount: count,
+		hasMore: pagination.hasMore,
+		continuation: pagination.continuation ?? null,
+		isTruncated: pagination.isTruncated ?? false,
+		truncationReason: pagination.truncationReason ?? null,
+		serverCap: pagination.serverCap,
+		clientCap: pagination.clientCap,
+		resolvedLabels: toResolvedLabels(context.resolutions),
+		pendingConfirmations: context.pendingConfirmations ?? [],
+		warnings: context.resolutionWarnings ?? [],
+	};
+	if (pagination.nextOffset !== undefined) response.nextOffset = pagination.nextOffset;
+	if (pagination.totalAvailable !== undefined) response.totalAvailable = pagination.totalAvailable;
+	if (pagination.notes && pagination.notes.length > 0) response.notes = pagination.notes;
+	return response;
 }
 
 /**
@@ -154,26 +246,26 @@ export function buildListResponse(
  * @param verb  Verb used in summary: "Retrieved" (default) | "Authenticated as"
  */
 export function buildItemResponse(
-    resource: string,
-    operation: string,
-    record: Record<string, unknown>,
-    options: { verb?: string } = {},
-    context: ToolResponseContext = {},
+	resource: string,
+	operation: string,
+	record: Record<string, unknown>,
+	options: { verb?: string } = {},
+	context: ToolResponseContext = {},
 ): Record<string, unknown> {
-    const verb = options.verb ?? 'Retrieved';
-    const identity = buildIdentityString(resource, record);
-    const summary = identity
-        ? `${verb} ${resource} ${identity}.`
-        : `${verb} ${resource} (ID: ${record.id ?? 'unknown'}).`;
-    return {
-        summary,
-        resource,
-        operation: `${resource}.${operation}`,
-        record,
-        resolvedLabels: toResolvedLabels(context.resolutions),
-        pendingConfirmations: context.pendingConfirmations ?? [],
-        warnings: context.resolutionWarnings ?? [],
-    };
+	const verb = options.verb ?? 'Retrieved';
+	const identity = buildIdentityString(resource, record);
+	const summary = identity
+		? `${verb} ${resource} ${identity}.`
+		: `${verb} ${resource} (ID: ${record.id ?? 'unknown'}).`;
+	return {
+		summary,
+		resource,
+		operation: `${resource}.${operation}`,
+		record,
+		resolvedLabels: toResolvedLabels(context.resolutions),
+		pendingConfirmations: context.pendingConfirmations ?? [],
+		warnings: context.resolutionWarnings ?? [],
+	};
 }
 
 /**
@@ -183,241 +275,251 @@ export function buildItemResponse(
  * that return no entity (e.g. some update variants).
  */
 export function buildMutationResponse(
-    resource: string,
-    operation: string,
-    id: number | string,
-    record?: Record<string, unknown>,
-    context: ToolResponseContext = {},
+	resource: string,
+	operation: string,
+	id: number | string,
+	record?: Record<string, unknown>,
+	context: ToolResponseContext = {},
 ): Record<string, unknown> {
-    const opVerb =
-        operation === 'create' ? 'Created'
-        : operation === 'update' ? 'Updated'
-        : operation === 'approve' ? 'Approved'
-        : operation === 'reject' ? 'Rejected'
-        : operation === 'post' ? 'Posted'
-        : operation === 'moveToCompany' ? 'Moved to company for'
-        : operation === 'moveConfigurationItem' ? 'Moved configuration item for'
-        : operation === 'transferOwnership' ? 'Transferred ownership for'
-        : operation.endsWith('e')
-            ? operation.charAt(0).toUpperCase() + operation.slice(1) + 'd'
-            : operation.charAt(0).toUpperCase() + operation.slice(1) + 'ed';
-    const identity = record ? buildIdentityString(resource, record) : '';
-    const summary = identity
-        ? `${opVerb} ${resource} ${identity} successfully.`
-        : `${opVerb} ${resource} (ID: ${id}) successfully.`;
-    const response: Record<string, unknown> = {
-        summary,
-        resource,
-        operation: `${resource}.${operation}`,
-        id,
-        resolvedLabels: toResolvedLabels(context.resolutions),
-        pendingConfirmations: context.pendingConfirmations ?? [],
-        warnings: context.resolutionWarnings ?? [],
-    };
-    if (record) response.record = record;
-    return response;
+	const opVerb =
+		operation === 'create'
+			? 'Created'
+			: operation === 'update'
+				? 'Updated'
+				: operation === 'approve'
+					? 'Approved'
+					: operation === 'reject'
+						? 'Rejected'
+						: operation === 'post'
+							? 'Posted'
+							: operation === 'moveToCompany'
+								? 'Moved to company for'
+								: operation === 'moveConfigurationItem'
+									? 'Moved configuration item for'
+									: operation === 'transferOwnership'
+										? 'Transferred ownership for'
+										: operation.endsWith('e')
+											? operation.charAt(0).toUpperCase() + operation.slice(1) + 'd'
+											: operation.charAt(0).toUpperCase() + operation.slice(1) + 'ed';
+	const identity = record ? buildIdentityString(resource, record) : '';
+	const summary = identity
+		? `${opVerb} ${resource} ${identity} successfully.`
+		: `${opVerb} ${resource} (ID: ${id}) successfully.`;
+	const response: Record<string, unknown> = {
+		summary,
+		resource,
+		operation: `${resource}.${operation}`,
+		id,
+		resolvedLabels: toResolvedLabels(context.resolutions),
+		pendingConfirmations: context.pendingConfirmations ?? [],
+		warnings: context.resolutionWarnings ?? [],
+	};
+	if (record) response.record = record;
+	return response;
 }
 
 /** Flat response for delete (no entity returned). */
 export function buildDeleteResponse(
-    resource: string,
-    operation: string,
-    id: number | string,
-    context: ToolResponseContext = {},
+	resource: string,
+	operation: string,
+	id: number | string,
+	context: ToolResponseContext = {},
 ): Record<string, unknown> {
-    return {
-        summary: `Deleted ${resource} (ID: ${id}) successfully.`,
-        resource,
-        operation: `${resource}.${operation}`,
-        id,
-        resolvedLabels: toResolvedLabels(context.resolutions),
-        pendingConfirmations: context.pendingConfirmations ?? [],
-        warnings: context.resolutionWarnings ?? [],
-    };
+	return {
+		summary: `Deleted ${resource} (ID: ${id}) successfully.`,
+		resource,
+		operation: `${resource}.${operation}`,
+		id,
+		resolvedLabels: toResolvedLabels(context.resolutions),
+		pendingConfirmations: context.pendingConfirmations ?? [],
+		warnings: context.resolutionWarnings ?? [],
+	};
 }
 
 export function buildCountResponse(
-    resource: string,
-    operation: string,
-    matchCount: number,
+	resource: string,
+	operation: string,
+	matchCount: number,
 ): Record<string, unknown> {
-    return {
-        summary: `${matchCount} ${resource} records match the filter.`,
-        resource,
-        operation: `${resource}.${operation}`,
-        matchCount,
-        warnings: [],
-    };
+	return {
+		summary: `${matchCount} ${resource} records match the filter.`,
+		resource,
+		operation: `${resource}.${operation}`,
+		matchCount,
+		warnings: [],
+	};
 }
 
 export function buildCompoundResponse(
-    resource: string,
-    operation: string,
-    compoundData: {
-        outcome: string;
-        id?: number | string;
-        existingId?: number | string;
-        record?: Record<string, unknown>;
-        matchedDedupFields?: string[];
-        fieldsUpdated?: Record<string, unknown>;
-        fieldsCompared?: Record<string, unknown>;
-        context?: Record<string, unknown>;
-    },
-    context: ToolResponseContext = {},
+	resource: string,
+	operation: string,
+	compoundData: {
+		outcome: string;
+		id?: number | string;
+		existingId?: number | string;
+		record?: Record<string, unknown>;
+		matchedDedupFields?: string[];
+		fieldsUpdated?: Record<string, unknown>;
+		fieldsCompared?: Record<string, unknown>;
+		context?: Record<string, unknown>;
+	},
+	context: ToolResponseContext = {},
 ): Record<string, unknown> {
-    const { outcome, id, existingId, record, matchedDedupFields, fieldsUpdated, fieldsCompared } = compoundData;
-    const canonicalId = id ?? existingId;
-    let summary: string;
-    if (outcome === 'created') {
-        summary = `${resource} created (ID: ${canonicalId}).`;
-    } else if (outcome === 'skipped') {
-        summary = `${resource} already exists (skipped). Existing ID: ${canonicalId}.`;
-    } else if (outcome === 'updated') {
-        const count = fieldsUpdated ? Object.keys(fieldsUpdated).length : 0;
-        summary = `${resource} updated (ID: ${canonicalId}). ${count} field${count !== 1 ? 's' : ''} changed.`;
-    } else {
-        summary = `${resource} could not be processed — ${outcome}${canonicalId !== undefined ? ` (ID: ${canonicalId})` : ''}.`;
-    }
-    const response: Record<string, unknown> = {
-        summary,
-        resource,
-        operation: `${resource}.${operation}`,
-        outcome,
-        resolvedLabels: toResolvedLabels(context.resolutions),
-        pendingConfirmations: context.pendingConfirmations ?? [],
-        warnings: context.resolutionWarnings ?? [],
-    };
-    if (canonicalId !== undefined) response.id = canonicalId;
-    if (record) response.record = record;
-    if (matchedDedupFields !== undefined) response.matchedDedupFields = matchedDedupFields;
-    if (fieldsCompared !== undefined) response.fieldsCompared = fieldsCompared;
-    if (fieldsUpdated !== undefined) response.fieldsUpdated = fieldsUpdated;
-    return response;
+	const { outcome, id, existingId, record, matchedDedupFields, fieldsUpdated, fieldsCompared } =
+		compoundData;
+	const canonicalId = id ?? existingId;
+	let summary: string;
+	if (outcome === 'created') {
+		summary = `${resource} created (ID: ${canonicalId}).`;
+	} else if (outcome === 'skipped') {
+		summary = `${resource} already exists (skipped). Existing ID: ${canonicalId}.`;
+	} else if (outcome === 'updated') {
+		const count = fieldsUpdated ? Object.keys(fieldsUpdated).length : 0;
+		summary = `${resource} updated (ID: ${canonicalId}). ${count} field${count !== 1 ? 's' : ''} changed.`;
+	} else {
+		summary = `${resource} could not be processed — ${outcome}${canonicalId !== undefined ? ` (ID: ${canonicalId})` : ''}.`;
+	}
+	const response: Record<string, unknown> = {
+		summary,
+		resource,
+		operation: `${resource}.${operation}`,
+		outcome,
+		resolvedLabels: toResolvedLabels(context.resolutions),
+		pendingConfirmations: context.pendingConfirmations ?? [],
+		warnings: context.resolutionWarnings ?? [],
+	};
+	if (canonicalId !== undefined) response.id = canonicalId;
+	if (record) response.record = record;
+	if (matchedDedupFields !== undefined) response.matchedDedupFields = matchedDedupFields;
+	if (fieldsCompared !== undefined) response.fieldsCompared = fieldsCompared;
+	if (fieldsUpdated !== undefined) response.fieldsUpdated = fieldsUpdated;
+	return response;
 }
 
 type MetadataPayload =
-    | { kind: 'describeFields'; fields: FieldMeta[]; mode: string }
-    | { kind: 'listPicklistValues'; fieldId: string; picklistValues: unknown[] }
-    | { kind: 'describeOperation'; operationDoc: unknown; targetOperation: string };
+	| { kind: 'describeFields'; fields: FieldMeta[]; mode: string }
+	| { kind: 'listPicklistValues'; fieldId: string; picklistValues: unknown[] }
+	| { kind: 'describeOperation'; operationDoc: unknown; targetOperation: string };
 
 export function buildMetadataResponse(
-    resource: string,
-    operation: string,
-    payload: MetadataPayload,
+	resource: string,
+	operation: string,
+	payload: MetadataPayload,
 ): Record<string, unknown> {
-    if (payload.kind === 'describeFields') {
-        const { fields, mode } = payload;
-        const requiredFields = fields.filter((f) => f.required);
-        const requiredSummary = requiredFields
-            .slice(0, 5)
-            .map((f) => {
-                if (f.isReference && f.referencesEntity) return `${f.id} (ref→${f.referencesEntity})`;
-                if (f.isPickList) return `${f.id} (picklist)`;
-                return `${f.id} (${f.type ?? 'unknown'})`;
-            })
-            .join(', ');
-        const overflow = requiredFields.length > 5 ? ` (+${requiredFields.length - 5} more)` : '';
-        const summary = requiredFields.length > 0
-            ? `${resource} has ${fields.length} fields. Required for ${mode}: ${requiredSummary}${overflow}.`
-            : `${resource} has ${fields.length} fields. No required fields for ${mode}.`;
-        return {
-            summary,
-            resource,
-            operation: `${resource}.${operation}`,
-            fields,
-            warnings: [],
-        };
-    }
+	if (payload.kind === 'describeFields') {
+		const { fields, mode } = payload;
+		const requiredFields = fields.filter((f) => f.required);
+		const requiredSummary = requiredFields
+			.slice(0, 5)
+			.map((f) => {
+				if (f.isReference && f.referencesEntity) return `${f.id} (ref→${f.referencesEntity})`;
+				if (f.isPickList) return `${f.id} (picklist)`;
+				return `${f.id} (${f.type ?? 'unknown'})`;
+			})
+			.join(', ');
+		const overflow = requiredFields.length > 5 ? ` (+${requiredFields.length - 5} more)` : '';
+		const summary =
+			requiredFields.length > 0
+				? `${resource} has ${fields.length} fields. Required for ${mode}: ${requiredSummary}${overflow}.`
+				: `${resource} has ${fields.length} fields. No required fields for ${mode}.`;
+		return {
+			summary,
+			resource,
+			operation: `${resource}.${operation}`,
+			fields,
+			warnings: [],
+		};
+	}
 
-    if (payload.kind === 'listPicklistValues') {
-        const { fieldId, picklistValues } = payload;
-        const activeCount = (picklistValues as Array<{ isActive?: boolean }>).filter(
-            (v) => v.isActive !== false,
-        ).length;
-        return {
-            summary: `Field '${fieldId}' has ${activeCount} active picklist values.`,
-            resource,
-            operation: `${resource}.${operation}`,
-            picklistValues,
-            warnings: [],
-        };
-    }
+	if (payload.kind === 'listPicklistValues') {
+		const { fieldId, picklistValues } = payload;
+		const activeCount = (picklistValues as Array<{ isActive?: boolean }>).filter(
+			(v) => v.isActive !== false,
+		).length;
+		return {
+			summary: `Field '${fieldId}' has ${activeCount} active picklist values.`,
+			resource,
+			operation: `${resource}.${operation}`,
+			picklistValues,
+			warnings: [],
+		};
+	}
 
-    // kind === 'describeOperation'
-    const { operationDoc, targetOperation } = payload;
-    const purpose =
-        operationDoc &&
-        typeof operationDoc === 'object' &&
-        'purpose' in operationDoc &&
-        typeof (operationDoc as Record<string, unknown>).purpose === 'string'
-            ? (operationDoc as Record<string, unknown>).purpose as string
-            : `performs ${targetOperation}.`;
-    const purposeText = purpose.endsWith('.') ? purpose : `${purpose}.`;
-    return {
-        summary: `Operation '${targetOperation}' on ${resource}: ${purposeText}`,
-        resource,
-        operation: `${resource}.${operation}`,
-        operationDoc,
-        warnings: [],
-    };
+	// kind === 'describeOperation'
+	const { operationDoc, targetOperation } = payload;
+	const purpose =
+		operationDoc &&
+		typeof operationDoc === 'object' &&
+		'purpose' in operationDoc &&
+		typeof (operationDoc as Record<string, unknown>).purpose === 'string'
+			? ((operationDoc as Record<string, unknown>).purpose as string)
+			: `performs ${targetOperation}.`;
+	const purposeText = purpose.endsWith('.') ? purpose : `${purpose}.`;
+	return {
+		summary: `Operation '${targetOperation}' on ${resource}: ${purposeText}`,
+		resource,
+		operation: `${resource}.${operation}`,
+		operationDoc,
+		warnings: [],
+	};
 }
 
 export function buildSlaHealthCheckResponse(
-    resource: string,
-    operation: string,
-    record: Record<string, unknown>,
-    context: ToolResponseContext = {},
+	resource: string,
+	operation: string,
+	record: Record<string, unknown>,
+	context: ToolResponseContext = {},
 ): Record<string, unknown> {
-    const ticket = record.ticket as Record<string, unknown> | undefined;
-    const ticketNumber = ticket?.ticketNumber as string | undefined;
-    const wallClockHours =
-        typeof record.wallClockRemainingHours === 'number'
-            ? record.wallClockRemainingHours.toFixed(1)
-            : undefined;
-    const isBreached = record.isBreached === true;
-    const ticketRef =
-        ticketNumber ?? (ticket?.id !== undefined ? `ticket ID: ${ticket.id}` : 'unknown ticket');
-    const parts: string[] = [];
-    if (wallClockHours !== undefined) parts.push(`${wallClockHours}h remaining`);
-    parts.push(isBreached ? 'BREACHED' : 'not breached');
-    const summary = `SLA health check for ${ticketRef}: ${parts.join(', ')}.`;
-    return {
-        summary,
-        resource,
-        operation: `${resource}.${operation}`,
-        record,
-        resolvedLabels: toResolvedLabels(context.resolutions),
-        pendingConfirmations: context.pendingConfirmations ?? [],
-        warnings: context.resolutionWarnings ?? [],
-    };
+	const ticket = record.ticket as Record<string, unknown> | undefined;
+	const ticketNumber = ticket?.ticketNumber as string | undefined;
+	const wallClockHours =
+		typeof record.wallClockRemainingHours === 'number'
+			? record.wallClockRemainingHours.toFixed(1)
+			: undefined;
+	const isBreached = record.isBreached === true;
+	const ticketRef =
+		ticketNumber ?? (ticket?.id !== undefined ? `ticket ID: ${ticket.id}` : 'unknown ticket');
+	const parts: string[] = [];
+	if (wallClockHours !== undefined) parts.push(`${wallClockHours}h remaining`);
+	parts.push(isBreached ? 'BREACHED' : 'not breached');
+	const summary = `SLA health check for ${ticketRef}: ${parts.join(', ')}.`;
+	return {
+		summary,
+		resource,
+		operation: `${resource}.${operation}`,
+		record,
+		resolvedLabels: toResolvedLabels(context.resolutions),
+		pendingConfirmations: context.pendingConfirmations ?? [],
+		warnings: context.resolutionWarnings ?? [],
+	};
 }
 
 export function buildTicketSummaryResponse(
-    resource: string,
-    operation: string,
-    record: Record<string, unknown>,
-    context: ToolResponseContext = {},
+	resource: string,
+	operation: string,
+	record: Record<string, unknown>,
+	context: ToolResponseContext = {},
 ): Record<string, unknown> {
-    const core = record.core as Record<string, unknown> | undefined;
-    const computed = record.computed as Record<string, unknown> | undefined;
-    const ticketNumber = core?.ticketNumber as string | undefined;
-    const title = core?.title as string | undefined;
-    const ageHours =
-        typeof computed?.ageHours === 'number' ? computed.ageHours.toFixed(1) : undefined;
-    const isBreached = computed?.isOverdue === true;
-    const identityParts: string[] = [];
-    if (ticketNumber) identityParts.push(ticketNumber);
-    if (title) identityParts.push(`— ${title}`);
-    const detailParts: string[] = [];
-    if (ageHours !== undefined) detailParts.push(`Age: ${ageHours}h`);
-    detailParts.push(isBreached ? 'SLA: breached' : 'SLA: not breached');
-    const identityStr = identityParts.join(' ') || 'Ticket';
-    const summary = `${identityStr} (${detailParts.join(', ')}).`;
-    return {
-        summary,
-        resource,
-        operation: `${resource}.${operation}`,
-        ticketSummary: record,
-        warnings: context.resolutionWarnings ?? [],
-    };
+	const core = record.core as Record<string, unknown> | undefined;
+	const computed = record.computed as Record<string, unknown> | undefined;
+	const ticketNumber = core?.ticketNumber as string | undefined;
+	const title = core?.title as string | undefined;
+	const ageHours =
+		typeof computed?.ageHours === 'number' ? computed.ageHours.toFixed(1) : undefined;
+	const isBreached = computed?.isOverdue === true;
+	const identityParts: string[] = [];
+	if (ticketNumber) identityParts.push(ticketNumber);
+	if (title) identityParts.push(`— ${title}`);
+	const detailParts: string[] = [];
+	if (ageHours !== undefined) detailParts.push(`Age: ${ageHours}h`);
+	detailParts.push(isBreached ? 'SLA: breached' : 'SLA: not breached');
+	const identityStr = identityParts.join(' ') || 'Ticket';
+	const summary = `${identityStr} (${detailParts.join(', ')}).`;
+	return {
+		summary,
+		resource,
+		operation: `${resource}.${operation}`,
+		ticketSummary: record,
+		warnings: context.resolutionWarnings ?? [],
+	};
 }

--- a/nodes/Autotask/ai-tools/tool-executor.ts
+++ b/nodes/Autotask/ai-tools/tool-executor.ts
@@ -55,10 +55,7 @@ import {
 	traceResponse,
 	traceToolCall,
 } from './debug-trace';
-import {
-	buildWriteResolutionBlocker,
-	summariseResolutionState,
-} from './write-guard';
+import { buildWriteResolutionBlocker, summariseResolutionState } from './write-guard';
 import {
 	COMPOUND_REGISTRY,
 	COMPOUND_PARENT_NOT_FOUND_OUTCOMES,
@@ -225,7 +222,6 @@ const N8N_METADATA_FIELDS = new Set([
 
 /** Key prefixes injected by n8n that must be stripped regardless of suffix */
 const N8N_METADATA_PREFIXES = ['Prompt__'];
-
 
 /** Extract the canonical created-entity numeric ID from a compound creator result. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -582,9 +578,9 @@ export async function executeAiTool(
 			recencyFilters: summariseFilters(recencyResult.filters),
 			recencyDateRange: recencyResult.isActive
 				? {
-					from: recencyResult.filters.find((f) => f.op === 'gte')?.value,
-					to: recencyResult.filters.find((f) => f.op === 'lte')?.value,
-				  }
+						from: recencyResult.filters.find((f) => f.op === 'gte')?.value,
+						to: recencyResult.filters.find((f) => f.op === 'lte')?.value,
+					}
 				: undefined,
 			filtersJsonUsed: Boolean(params.filtersJson),
 			combinedStrategy: params.filtersJson
@@ -624,13 +620,14 @@ export async function executeAiTool(
 	const supportsOffsetPagination = ['getMany', 'getPosted', 'getUnposted'].includes(
 		effectiveOperation,
 	);
-	const queryLimit = recencyResult.isActive
-		? RECENCY_OVER_REQUEST_LIMIT
-		: effectiveOffset > 0 && supportsOffsetPagination
-			? Math.min(effectiveOffset + effectiveLimit, MAX_QUERY_LIMIT)
-			: params.returnAll === true
-				? MAX_QUERY_LIMIT
-				: effectiveLimit;
+	const queryLimit =
+		recencyResult.isActive && params.returnAll !== true
+			? RECENCY_OVER_REQUEST_LIMIT
+			: effectiveOffset > 0 && supportsOffsetPagination
+				? Math.min(effectiveOffset + effectiveLimit, MAX_QUERY_LIMIT)
+				: params.returnAll === true
+					? undefined
+					: effectiveLimit;
 	traceFilterBuild({
 		phase: 'pagination-plan',
 		resource,
@@ -948,7 +945,10 @@ export async function executeAiTool(
 				}
 				// Always apply bounded query limits for list/count style operations.
 				// Note: offset is applied client-side only (slice after fetch), not sent to API.
-				if (['getMany', 'getPosted', 'getUnposted', 'count'].includes(effectiveOperation)) {
+				if (
+					['getMany', 'getPosted', 'getUnposted', 'count'].includes(effectiveOperation) &&
+					queryLimit !== undefined
+				) {
 					data.limit = queryLimit;
 				}
 				if (effectiveOperation === 'searchByDomain') {
@@ -985,7 +985,7 @@ export async function executeAiTool(
 			case 'returnAll':
 				return params.returnAll === true;
 			case 'maxRecords':
-				return params.returnAll === true
+				return params.returnAll === true || queryLimit === undefined
 					? undefined // executeScopedQuery handles full pagination internally; MaxRecords is ignored
 					: queryLimit;
 			case 'bodyJson':
@@ -1086,8 +1086,8 @@ export async function executeAiTool(
 				if (process.env.N8N_AI_TOOL_STRICT_PARAMS === '1') {
 					console.warn(
 						`[AutotaskAiTools] Unmapped getNodeParameter key "${name}" ` +
-						`for ${resource}.${effectiveOperation} — returning fallbackValue. ` +
-						`Add an explicit case to the override switch in tool-executor.ts.`,
+							`for ${resource}.${effectiveOperation} — returning fallbackValue. ` +
+							`Add an explicit case to the override switch in tool-executor.ts.`,
 					);
 				}
 				return fallbackValue;
@@ -1186,11 +1186,16 @@ export async function executeAiTool(
 
 				return attachCorrelation(
 					JSON.stringify(
-						buildCompoundResponse(resource, 'createIfNotExists', compoundData as Parameters<typeof buildCompoundResponse>[2], {
-							resolutions: labelResolutions,
-							resolutionWarnings: allWarnings,
-							pendingConfirmations: labelPendingConfirmations,
-						}),
+						buildCompoundResponse(
+							resource,
+							'createIfNotExists',
+							compoundData as Parameters<typeof buildCompoundResponse>[2],
+							{
+								resolutions: labelResolutions,
+								resolutionWarnings: allWarnings,
+								pendingConfirmations: labelPendingConfirmations,
+							},
+						),
 					),
 					correlationId,
 				);
@@ -1254,6 +1259,7 @@ export async function executeAiTool(
 			recencyNote: recencyResult.note ?? recencyOffsetNote,
 			recencyWindowLimited:
 				recencyResult.isActive &&
+				params.returnAll !== true &&
 				supportsListResponse &&
 				fetchedRecords.length >= RECENCY_OVER_REQUEST_LIMIT,
 			resolutions: allResolutions.length > 0 ? allResolutions : undefined,
@@ -1262,6 +1268,14 @@ export async function executeAiTool(
 				allPendingConfirmations.length > 0 ? allPendingConfirmations : undefined,
 			effectiveOffset: recencyResult.isActive ? 0 : effectiveOffset,
 			readFields,
+			serverCap: queryLimit ?? MAX_QUERY_LIMIT,
+			clientCap: 100,
+			serverCapReached: Boolean(
+				supportsListResponse &&
+				queryLimit !== undefined &&
+				recencyResult.isActive &&
+				fetchedRecords.length >= queryLimit,
+			),
 		};
 
 		// Apply Change Info Field aliases to ticket read results.


### PR DESCRIPTION
### Motivation

- Improve pagination semantics and client guidance for list-style operations by computing an explicit continuation pointer and truncation reasons.
- Make the executor aware of server/client fetch caps and propagate that to response builders so callers know when results are capped by server limits or client payload caps.
- Ensure `returnAll` and recency windows are handled consistently so callers and downstream pagination logic can act on a precise continuation contract.

### Description

- Introduced `computeListContinuation` and new types `ListContinuationPointer`, `ListContinuationContract`, and related inputs to centralize continuation/truncation computation.
- Extended `ListPaginationState` and `buildListResponse` to include `continuation`, `isTruncated`, `truncationReason`, `serverCap`, and `clientCap` in list responses and adjusted `searchByDomain` to return the same metadata shape.
- Updated `dispatchOperationResponse` to call `computeListContinuation`, include continuation metadata in list responses, and use the new pagination contract to populate notes and warnings.
- Adjusted `tool-executor` pagination logic to compute `queryLimit` more precisely (respecting `returnAll` and recency behavior), to omit `limit` when scoped/full-pagination handling is expected, and to populate `responseContext` with `serverCap`, `clientCap`, and `serverCapReached` flags used by the continuation computation.

### Testing

- Performed a TypeScript build check with `tsc --noEmit` to validate typings and compilation, which completed successfully.
- Executed the repository unit test suite with `npm test`, and all tests passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db20d424288320aebea47a4f00b751)