### PR TITLE
Classify unresolved IDs in reference arrays and block execution with INVALID_FILTER_CONSTRAINT

### DIFF
--- a/nodes/Autotask/ai-tools/filter-builder.ts
+++ b/nodes/Autotask/ai-tools/filter-builder.ts
@@ -22,6 +22,10 @@ export interface FilterResolutionResult {
     warnings: string[];
     pendingConfirmations: PendingLabelConfirmation[];
     unresolvedIdLikeFilters: ToolFilter[];
+    unresolvedIdLikeFilterDetails: Array<{
+        field: string;
+        unresolvedElements: Array<string | number | boolean>;
+    }>;
 }
 
 interface ToolExecutorFilterParams {
@@ -232,15 +236,38 @@ export async function resolveAndClassifyFilters(
         }),
     );
 
+    const unresolvedIdLikeFilterDetails: Array<{
+        field: string;
+        unresolvedElements: Array<string | number | boolean>;
+    }> = [];
     const unresolvedIdLikeFilters = filters.filter((filter) => {
-        if (typeof filter.value !== 'string') return false;
-        if (filter.value.trim() === '') return false;
-        if (isLikelyId(filter.value)) return false;
-        return isLikelyReferenceIdFilterField(filter.field, resource, readFields);
+        if (!isLikelyReferenceIdFilterField(filter.field, resource, readFields)) return false;
+
+        const unresolvedElements: Array<string | number | boolean> = [];
+        if (typeof filter.value === 'string') {
+            if (filter.value.trim() !== '' && !isLikelyId(filter.value)) {
+                unresolvedElements.push(filter.value);
+            }
+        } else if (Array.isArray(filter.value) && (filter.op === 'in' || filter.op === 'notIn')) {
+            for (const element of filter.value) {
+                if (typeof element !== 'string') continue;
+                if (element.trim() === '') continue;
+                if (!isLikelyId(element)) unresolvedElements.push(element);
+            }
+        }
+
+        if (unresolvedElements.length === 0) return false;
+        unresolvedIdLikeFilterDetails.push({
+            field: filter.field,
+            unresolvedElements: Array.from(new Set(unresolvedElements)),
+        });
+        return true;
     });
-    for (const unresolved of unresolvedIdLikeFilters) {
+    for (const unresolved of unresolvedIdLikeFilterDetails) {
         allWarnings.push(
-            `Unresolved ID-like filter '${unresolved.field}' has non-numeric value '${String(unresolved.value)}'.`,
+            `Unresolved ID-like filter '${unresolved.field}' has non-numeric value(s): ${unresolved.unresolvedElements
+                .map((value) => `'${String(value)}'`)
+                .join(', ')}.`,
         );
     }
 
@@ -250,5 +277,6 @@ export async function resolveAndClassifyFilters(
         warnings: allWarnings,
         pendingConfirmations: allPendingConfirmations,
         unresolvedIdLikeFilters,
+        unresolvedIdLikeFilterDetails,
     };
 }

--- a/nodes/Autotask/ai-tools/tool-executor.ts
+++ b/nodes/Autotask/ai-tools/tool-executor.ts
@@ -344,6 +344,7 @@ export async function executeAiTool(
 		warnings: filterWarnings,
 		pendingConfirmations: filterPendingConfirmations,
 		unresolvedIdLikeFilters,
+		unresolvedIdLikeFilterDetails,
 	} = await resolveAndClassifyFilters(context, resource, filters, readFields);
 	traceLabelResolution({
 		phase: 'filter-resolution',
@@ -354,6 +355,7 @@ export async function executeAiTool(
 			attempted: filters.length > 0,
 			unresolvedIdLikeFilterCount: unresolvedIdLikeFilters.length,
 			unresolvedIdLikeFilterFields: unresolvedIdLikeFilters.map((filter) => filter.field),
+			unresolvedIdLikeFilterDetails,
 			...summariseResolutionState(filterResolutions, filterWarnings, filterPendingConfirmations),
 			...(AI_TOOL_DEBUG_VERBOSE ? { filterSnapshot: redactForVerbose(filters) } : {}),
 		},
@@ -662,8 +664,11 @@ export async function executeAiTool(
 	}
 
 	if (unresolvedIdLikeFilters.length > 0) {
-		const unresolvedSummary = unresolvedIdLikeFilters
-			.map((filter) => `${filter.field}='${String(filter.value)}'`)
+		const unresolvedSummary = unresolvedIdLikeFilterDetails
+			.map(
+				(detail) =>
+					`${detail.field}=[${detail.unresolvedElements.map((value) => `'${String(value)}'`).join(', ')}]`,
+			)
 			.join(', ');
 		const hasPendingCandidates = filterPendingConfirmations.length > 0;
 		const pendingSummary = filterPendingConfirmations.map((entry) => {
@@ -688,6 +693,7 @@ export async function executeAiTool(
 						: `Use autotask_resource with operation 'getMany' (or the relevant entity tool) to resolve names to numeric IDs, then retry autotask_${resource} with numeric ID filter values.`,
 					{
 						unresolvedFilters: unresolvedIdLikeFilters,
+						unresolvedFilterDetails: unresolvedIdLikeFilterDetails,
 						...(hasPendingCandidates
 							? {
 									pendingConfirmations: filterPendingConfirmations,


### PR DESCRIPTION
### Motivation

- Detect and surface unresolved non-numeric reference values in filters, including elements inside `in`/`notIn` arrays on reference-like fields, so callers/agents can disambiguate before an API call is made.
- Provide a structured payload that callers (agents) can use to choose the correct numeric IDs while preserving the existing pending-confirmation payload for retry flows.

### Description

- Add `unresolvedIdLikeFilterDetails` to `FilterResolutionResult` as an array of `{ field, unresolvedElements }` to return structured unresolved information from `resolveAndClassifyFilters` in `filter-builder.ts`.
- Extend unresolved classification in `resolveAndClassifyFilters` to collect unresolved string elements from both scalar reference-like filters and `in`/`notIn` arrays, deduplicate elements, and emit warnings listing the unresolved values.
- Wire the new `unresolvedIdLikeFilterDetails` into `tool-executor.ts` tracing and error handling, format a readable unresolved summary, and include `unresolvedFilterDetails` in the `INVALID_FILTER_CONSTRAINT` error payload while keeping legacy `unresolvedIdLikeFilters` and `pendingConfirmations` in the response for agent disambiguation and retry.
- Use `ERROR_TYPES.INVALID_FILTER_CONSTRAINT` to block execution when unresolved reference values are present so no API call proceeds with ambiguous non-numeric IDs.

### Testing

- Ran TypeScript type-checking with `pnpm -s typecheck`, which completed successfully.
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db275fb43c8320b662749a578954d0)