### PR TITLE
refactor(ai-tools): centralize operation metadata and routing

### DIFF
--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -18,6 +18,11 @@ import {
 	buildUnifiedDescriptionTemplate,
 	injectDescriptionReferenceUtc,
 } from './ai-tools/description-builders';
+import {
+	SUPPORTED_TOOL_OPERATIONS,
+	getOperationMetadata,
+	isWriteOperation,
+} from './ai-tools/operation-metadata';
 import { RuntimeDynamicStructuredTool, runtimeZod, getLazyLogWrapper } from './ai-tools/runtime';
 import { getRuntimeSchemaBuilders } from './ai-tools/schema-generator';
 import { isNodeResourceImpersonationSupported } from './helpers/impersonation';
@@ -33,39 +38,6 @@ import {
 	traceToolBuild,
 } from './ai-tools/debug-trace';
 
-const WRITE_OPERATIONS = [
-	'create',
-	'createIfNotExists',
-	'moveToCompany',
-	'moveConfigurationItem',
-	'transferOwnership',
-	'update',
-	'approve',
-	'reject',
-	'delete',
-];
-const SUPPORTED_TOOL_OPERATIONS = [
-	'get',
-	'getMany',
-	'searchByDomain',
-	'getPosted',
-	'getUnposted',
-	'getByResource',
-	'getByYear',
-	'count',
-	'create',
-	'moveToCompany',
-	'moveConfigurationItem',
-	'transferOwnership',
-	'update',
-	'delete',
-	'whoAmI',
-	'slaHealthCheck',
-	'summary',
-	'createIfNotExists',
-	'approve',
-	'reject',
-];
 const EXCLUDED_RESOURCES = ['aiHelper', 'apiThreshold'];
 const TOOL_BUILD_CACHE_TTL_MS = 90_000;
 const METADATA_CACHE_TTL_MS = 90_000;
@@ -383,7 +355,7 @@ export class AutotaskAiTools implements INodeType {
 		}
 
 		const effectiveOps = operations.filter(
-			(op) => !WRITE_OPERATIONS.includes(op) || allowWriteOperations,
+			(op) => !isWriteOperation(op) || allowWriteOperations,
 		);
 		if (effectiveOps.length === 0) {
 			throw new NodeOperationError(
@@ -539,7 +511,7 @@ export class AutotaskAiTools implements INodeType {
 			func: async (rawParams: Record<string, unknown>) => {
 				const operation = rawParams.operation as string;
 				if (!operation || !allAllowedOps.includes(operation)) {
-					if (operation && WRITE_OPERATIONS.includes(operation) && !allowWriteOperations) {
+					if (operation && isWriteOperation(operation) && !allowWriteOperations) {
 						return JSON.stringify(
 							wrapError(
 								resource,
@@ -616,7 +588,7 @@ export class AutotaskAiTools implements INodeType {
 
 		// Pick the first permitted operation as the default for test execution
 		const effectiveOps = operations.filter(
-			(op) => !WRITE_OPERATIONS.includes(op) || allowWriteOperations,
+			(op) => !isWriteOperation(op) || allowWriteOperations,
 		);
 		if (effectiveOps.length === 0) {
 			throw new NodeOperationError(
@@ -747,7 +719,7 @@ export class AutotaskAiTools implements INodeType {
 
 			const requestedOp = (item.json.operation as string) || effectiveOps[0];
 			if (requestedOp && !allAllowedOps.includes(requestedOp)) {
-				if (WRITE_OPERATIONS.includes(requestedOp) && !allowWriteOperations) {
+				if (isWriteOperation(requestedOp) && !allowWriteOperations) {
 					response.push({
 						json: {
 							...wrapError(
@@ -871,34 +843,12 @@ async function getToolResourceOperations(
 	const ops = getResourceOperations(resource);
 	const options: INodePropertyOptions[] = [];
 
-	const opLabels: Record<string, string> = {
-		get: 'Get by ID',
-		whoAmI: 'Who am I',
-		getMany: 'Get many (with filters)',
-		searchByDomain: 'Search by domain',
-		slaHealthCheck: 'SLA health check',
-		summary: 'Ticket summary',
-		getPosted: 'Get posted time entries',
-		getUnposted: 'Get unposted time entries',
-		count: 'Count',
-		create: 'Create',
-		moveToCompany: 'Move contact to company',
-		moveConfigurationItem: 'Move configuration item (clone to company)',
-		transferOwnership: 'Transfer ownership',
-		update: 'Update',
-		delete: 'Delete',
-		createIfNotExists: 'Create If Not Exists (idempotent)',
-		getByResource: 'Get by resource',
-		getByYear: 'Get by resource and year',
-		approve: 'Approve time off request',
-		reject: 'Reject time off request',
-	};
-
 	for (const op of ops) {
 		if (!SUPPORTED_TOOL_OPERATIONS.includes(op)) continue;
-		if (WRITE_OPERATIONS.includes(op) && !allowWriteOperations) continue;
+		if (isWriteOperation(op) && !allowWriteOperations) continue;
+		const metadata = getOperationMetadata(op);
 		options.push({
-			name: opLabels[op] ?? op,
+			name: metadata?.label ?? op,
 			value: op,
 			description: `${op} operation`,
 		});

--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -480,7 +480,9 @@ export function buildUnifiedDescriptionTemplate(
 			? `operation '${op}': ${metadata.docsFragment}`
 			: `operation '${op}': Perform ${op} on ${resourceLabel}.`;
 
-		if (op === 'create') {
+		if (op === 'whoAmI') {
+			summary = `operation '${op}': Resolve the authenticated ${resourceLabel} record.`;
+		} else if (op === 'create') {
 			summary = `operation '${op}': ${metadata?.docsFragment ?? 'Create a new record.'} ${buildRequiredFieldsSummary(writeFields)} Populate every optional field for which you already have data — do not omit known information. Supports name-based resolution for picklist/reference fields.`;
 		} else if (op === 'update') {
 			if (resource === 'resourceTimeOffAdditional') {

--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -3,6 +3,7 @@ import { getEntityMetadata } from '../constants/entities';
 import { getAiIdentityHint } from '../constants/ai-identity';
 import { AI_TOOL_DEBUG_VERBOSE, redactForVerbose, traceDescriptionBuild } from './debug-trace';
 import { getOperationContractRuleText } from './operation-contracts';
+import { getOperationMetadata, isWriteOperation } from './operation-metadata';
 
 export const DESCRIPTION_REFERENCE_PLACEHOLDER = '__REFERENCE_UTC__';
 
@@ -445,18 +446,7 @@ export function buildUnifiedDescriptionTemplate(
 			supportsImpersonation,
 		},
 	});
-	const hasWriteOps = operations.some(
-		(op) =>
-			op === 'create' ||
-			op === 'update' ||
-			op === 'delete' ||
-			op === 'createIfNotExists' ||
-			op === 'approve' ||
-			op === 'reject' ||
-			op === 'moveToCompany' ||
-			op === 'moveConfigurationItem' ||
-			op === 'transferOwnership',
-	);
+	const hasWriteOps = operations.some((op) => isWriteOperation(op));
 	const allOps = [
 		...new Set([...operations, 'describeFields', 'listPicklistValues', 'describeOperation']),
 	];
@@ -485,77 +475,23 @@ export function buildUnifiedDescriptionTemplate(
 	);
 
 	for (const op of operations) {
-		let summary: string;
-		switch (op) {
-			case 'get':
-				summary = `operation '${op}': Retrieve a single record by numeric 'id'.`;
-				break;
-			case 'whoAmI':
-				summary = `operation '${op}': Resolve the authenticated ${resourceLabel} record.`;
-				break;
-			case 'getMany':
-				summary =
-					`operation '${op}': Search records with up to two filters (AND/OR via filter_logic). Use filter_field/filter_value. Supports name-based resolution for reference/picklist filter values. ` +
-					listDateTimeFieldHint(readFields);
-				break;
-			case 'count':
-				summary = `operation '${op}': Count records matching optional filters.`;
-				break;
-			case 'searchByDomain':
-				summary = `operation '${op}': Search companies by domain string.`;
-				break;
-			case 'slaHealthCheck':
-				summary = `operation '${op}': Run SLA health check for a ticket using 'id' or 'ticketNumber'.`;
-				break;
-			case 'summary':
-				summary = `operation '${op}': Get a compact ticket summary ('id' or 'ticketNumber' required). Computed values, child counts, relationships.`;
-				break;
-			case 'getPosted':
-				summary = `operation '${op}': Get posted time entries with optional filters.`;
-				break;
-			case 'getUnposted':
-				summary = `operation '${op}': Get unposted time entries with optional filters.`;
-				break;
-			case 'create': {
-				summary = `operation '${op}': Create a new record. ${buildRequiredFieldsSummary(writeFields)} Populate every optional field for which you already have data — do not omit known information. Supports name-based resolution for picklist/reference fields.`;
-				break;
+		const metadata = getOperationMetadata(op);
+		let summary = metadata
+			? `operation '${op}': ${metadata.docsFragment}`
+			: `operation '${op}': Perform ${op} on ${resourceLabel}.`;
+
+		if (op === 'create') {
+			summary = `operation '${op}': ${metadata?.docsFragment ?? 'Create a new record.'} ${buildRequiredFieldsSummary(writeFields)} Populate every optional field for which you already have data — do not omit known information. Supports name-based resolution for picklist/reference fields.`;
+		} else if (op === 'update') {
+			if (resource === 'resourceTimeOffAdditional') {
+				summary = `operation '${op}': Update time-off additional quotas for a resource. Provide 'resourceID' (name or numeric ID, auto-resolved) and the fields to change (annual/additional hours per category). Supports name-based resolution.`;
+			} else {
+				summary = `operation '${op}': ${metadata?.docsFragment ?? "Update a record by numeric 'id'."} Supports name-based resolution for picklist/reference fields.`;
 			}
-			case 'update':
-				if (resource === 'resourceTimeOffAdditional') {
-					summary = `operation '${op}': Update time-off additional quotas for a resource. Provide 'resourceID' (name or numeric ID, auto-resolved) and the fields to change (annual/additional hours per category). Supports name-based resolution.`;
-				} else {
-					summary = `operation '${op}': Update a record by numeric 'id'. Provide only fields to change. Supports name-based resolution for picklist/reference fields.`;
-				}
-				break;
-			case 'delete':
-				summary = `operation '${op}': Delete a record by numeric 'id'.`;
-				break;
-			case 'moveToCompany':
-				summary = `operation '${op}': Move a contact to another company.`;
-				break;
-			case 'moveConfigurationItem':
-				summary = `operation '${op}': Clone a configuration item to a different company.`;
-				break;
-			case 'transferOwnership':
-				summary = `operation '${op}': Transfer ownership from source resource to destination resource.`;
-				break;
-			case 'createIfNotExists':
-				summary = buildCreateIfNotExistsDescription(resource);
-				break;
-			case 'getByResource':
-				summary = `operation '${op}': Get record(s) for a specific resource. Provide 'resourceID' as a name or numeric ID (auto-resolved). Use for operations that are scoped to a parent resource rather than queried by their own ID.`;
-				break;
-			case 'getByYear':
-				summary = `operation '${op}': Get the time-off balance for a specific calendar year. Provide 'resourceID' (name or numeric ID, auto-resolved) and 'year' as an integer (e.g. 2024).`;
-				break;
-			case 'approve':
-				summary = `operation '${op}': Approve a pending time off request by numeric 'id'. Changes the request status to approved.`;
-				break;
-			case 'reject':
-				summary = `operation '${op}': Reject a pending time off request by numeric 'id'. Provide an optional 'rejectReason' string to record the reason for rejection.`;
-				break;
-			default:
-				summary = `operation '${op}': Perform ${op} on ${resourceLabel}.`;
+		} else if (op === 'createIfNotExists') {
+			summary = `operation '${op}': ${buildCreateIfNotExistsDescription(resource)}`;
+		} else if (op === 'getMany') {
+			summary = `operation '${op}': ${metadata?.docsFragment ?? ''} ${listDateTimeFieldHint(readFields)}`;
 		}
 		sections.push(summary);
 	}

--- a/nodes/Autotask/ai-tools/operation-handlers/operation-dispatch.ts
+++ b/nodes/Autotask/ai-tools/operation-handlers/operation-dispatch.ts
@@ -13,6 +13,7 @@ import {
 	type ListPaginationState,
 } from '../response-builder';
 import { MAX_QUERY_LIMIT, getEffectiveLimit } from '../tool-executor';
+import { getOperationMetadata } from '../operation-metadata';
 
 const MAX_RESPONSE_RECORDS = 100;
 
@@ -52,6 +53,7 @@ export function dispatchOperationResponse(
 	context: ToolResponseContext = {},
 ): string {
 	const firstRecord = records[0] ?? null;
+	const responseKind = getOperationMetadata(operation)?.responseKind;
 
 	const extractId = (record: Record<string, unknown> | null): number | string | null => {
 		if (!record) return null;
@@ -172,6 +174,164 @@ export function dispatchOperationResponse(
 		}
 	};
 
+	if (responseKind === 'list' && operation !== 'searchByDomain') {
+		const hasFilters = !!(
+			params.filter_field ||
+			params.filter_field_2 ||
+			params.filtersJson ||
+			params.recency ||
+			params.since ||
+			params.until
+		);
+		if (hasFilters && records.length === 0) {
+			const filtersUsed: Record<string, unknown> = {};
+			if (params.filter_field) {
+				filtersUsed.filter_field = params.filter_field;
+				filtersUsed.filter_op = params.filter_op;
+				filtersUsed.filter_value = params.filter_value;
+			}
+			if (params.filter_field_2) {
+				filtersUsed.filter_field_2 = params.filter_field_2;
+				filtersUsed.filter_op_2 = params.filter_op_2;
+				filtersUsed.filter_value_2 = params.filter_value_2;
+			}
+			if (params.filter_logic && params.filter_logic !== 'and') {
+				filtersUsed.filter_logic = params.filter_logic;
+			}
+			if (params.filtersJson) filtersUsed.filtersJson = params.filtersJson;
+			if (params.recency) filtersUsed.recency = params.recency;
+			if (params.since) filtersUsed.since = params.since;
+			if (params.until) filtersUsed.until = params.until;
+
+			const usedFilterFields = new Set<string>(
+				[
+					typeof params.filter_field === 'string' ? params.filter_field : '',
+					typeof params.filter_field_2 === 'string' ? params.filter_field_2 : '',
+				]
+					.map((f) => f.trim().toLowerCase())
+					.filter((f) => f !== ''),
+			);
+			const alternativeFilterFields = (context.readFields ?? [])
+				.filter(
+					(f) =>
+						!f.udf &&
+						typeof f.type === 'string' &&
+						f.type.toLowerCase() === 'string' &&
+						!usedFilterFields.has(f.id.toLowerCase()),
+				)
+				.map((f) => f.id)
+				.slice(0, 10);
+
+			const contextFields: Record<string, unknown> = { filtersUsed };
+			if (alternativeFilterFields.length > 0) {
+				contextFields.alternativeFilterFields = alternativeFilterFields;
+			}
+			const unresolvedFilterWarnings = context.resolutionWarnings ?? [];
+			if (unresolvedFilterWarnings.length > 0) {
+				contextFields.filterResolutionWarnings = unresolvedFilterWarnings;
+			}
+			return JSON.stringify(
+				wrapError(
+					resource,
+					operation,
+					ERROR_TYPES.NO_RESULTS_FOUND,
+					`No ${resource} records matched the supplied filters.`,
+					`Definitive negative — do not retry with the same filters. Broaden or change filter_field/filter_value and retry.`,
+					contextFields,
+				),
+			);
+		}
+
+		const total = records.length;
+		const truncated = total > MAX_RESPONSE_RECORDS;
+		const items = truncated ? records.slice(0, MAX_RESPONSE_RECORDS) : records;
+		const currentOffset = context.effectiveOffset ?? 0;
+		let totalAvailable: number | undefined;
+		const continuationContract = computeListContinuation({
+			currentOffset,
+			recordsReturned: items.length,
+			recordsMatched: total,
+			requestedLimit: getEffectiveLimit(params.limit),
+			returnAll: params.returnAll === true,
+			recencyActive: context.recencyActive === true,
+			maxQueryLimit: MAX_QUERY_LIMIT,
+			serverCap: context.serverCap ?? MAX_QUERY_LIMIT,
+			clientCap: context.clientCap ?? MAX_RESPONSE_RECORDS,
+			serverCapReached:
+				context.serverCapReached === true || context.recencyWindowLimited === true,
+		});
+		const hasMore = continuationContract.continuation?.hasMore === true;
+		const nextOffset = continuationContract.continuation?.nextOffset;
+
+		if (truncated) totalAvailable = total;
+
+		const notes: string[] = [];
+		if (context.recencyNote) notes.push(context.recencyNote);
+		if (continuationContract.truncationReason) {
+			notes.push(continuationContract.truncationReason);
+		}
+		if (truncated) {
+			if (params.returnAll) {
+				notes.push(
+					`Fetched all ${total} matching records via returnAll; showing first ${MAX_RESPONSE_RECORDS} in this response. ` +
+						`Use 'fields' to reduce payload size, or narrow filters to reduce match count.`,
+				);
+			} else {
+				notes.push(
+					hasMore
+						? `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Use offset=${nextOffset} to see the next page, or use a narrower filter.`
+						: `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Offset pagination limit (${MAX_QUERY_LIMIT}) reached — use narrower filters to access more records.`,
+				);
+			}
+		}
+
+		const listWarnings: string[] = [...(context.resolutionWarnings ?? [])];
+		if (context.recencyWindowLimited) {
+			listWarnings.push(
+				'500 records were returned for the current recency window. Narrow recency, or provide since/until, to ensure the newest records are included.',
+			);
+		}
+
+		const pagination: ListPaginationState = {
+			hasMore,
+			...(nextOffset !== undefined ? { nextOffset } : {}),
+			...(totalAvailable !== undefined ? { totalAvailable } : {}),
+			...(notes.length > 0 ? { notes } : {}),
+			continuation: continuationContract.continuation,
+			isTruncated: continuationContract.isTruncated,
+			truncationReason: continuationContract.truncationReason,
+			serverCap: continuationContract.serverCap,
+			clientCap: continuationContract.clientCap,
+		};
+
+		const listContext: ToolResponseContext = {
+			...context,
+			resolutionWarnings: listWarnings,
+		};
+
+		return JSON.stringify(buildListResponse(resource, operation, items, pagination, listContext));
+	}
+
+	if (responseKind === 'mutation') {
+		const validation = validateMutationSuccess(operation, firstRecord);
+		if (!validation.ok) {
+			return JSON.stringify(
+				wrapError(
+					resource,
+					operation,
+					validation.errorType ?? ERROR_TYPES.API_ERROR,
+					validation.message ?? `${resource}.${operation} failed validation.`,
+					validation.hint ?? `Retry autotask_${resource} with operation '${operation}'.`,
+					validation.context,
+				),
+			);
+		}
+
+		return JSON.stringify(
+			buildMutationResponse(resource, operation, validation.id ?? 'unknown', firstRecord ?? undefined, context),
+		);
+	}
+
 	switch (operation) {
 		case 'get': {
 			if (
@@ -192,146 +352,6 @@ export function dispatchOperationResponse(
 				);
 			}
 			return JSON.stringify(buildItemResponse(resource, operation, firstRecord, {}, context));
-		}
-
-		case 'getMany':
-		case 'getPosted':
-		case 'getUnposted': {
-			const hasFilters = !!(
-				params.filter_field ||
-				params.filter_field_2 ||
-				params.filtersJson ||
-				params.recency ||
-				params.since ||
-				params.until
-			);
-			if (hasFilters && records.length === 0) {
-				const filtersUsed: Record<string, unknown> = {};
-				if (params.filter_field) {
-					filtersUsed.filter_field = params.filter_field;
-					filtersUsed.filter_op = params.filter_op;
-					filtersUsed.filter_value = params.filter_value;
-				}
-				if (params.filter_field_2) {
-					filtersUsed.filter_field_2 = params.filter_field_2;
-					filtersUsed.filter_op_2 = params.filter_op_2;
-					filtersUsed.filter_value_2 = params.filter_value_2;
-				}
-				if (params.filter_logic && params.filter_logic !== 'and') {
-					filtersUsed.filter_logic = params.filter_logic;
-				}
-				if (params.filtersJson) filtersUsed.filtersJson = params.filtersJson;
-				if (params.recency) filtersUsed.recency = params.recency;
-				if (params.since) filtersUsed.since = params.since;
-				if (params.until) filtersUsed.until = params.until;
-
-				const usedFilterFields = new Set<string>(
-					[
-						typeof params.filter_field === 'string' ? params.filter_field : '',
-						typeof params.filter_field_2 === 'string' ? params.filter_field_2 : '',
-					]
-						.map((f) => f.trim().toLowerCase())
-						.filter((f) => f !== ''),
-				);
-				const alternativeFilterFields = (context.readFields ?? [])
-					.filter(
-						(f) =>
-							!f.udf &&
-							typeof f.type === 'string' &&
-							f.type.toLowerCase() === 'string' &&
-							!usedFilterFields.has(f.id.toLowerCase()),
-					)
-					.map((f) => f.id)
-					.slice(0, 10);
-
-				const contextFields: Record<string, unknown> = { filtersUsed };
-				if (alternativeFilterFields.length > 0) {
-					contextFields.alternativeFilterFields = alternativeFilterFields;
-				}
-				const unresolvedFilterWarnings = context.resolutionWarnings ?? [];
-				if (unresolvedFilterWarnings.length > 0) {
-					contextFields.filterResolutionWarnings = unresolvedFilterWarnings;
-				}
-				return JSON.stringify(
-					wrapError(
-						resource,
-						operation,
-						ERROR_TYPES.NO_RESULTS_FOUND,
-						`No ${resource} records matched the supplied filters.`,
-						`Definitive negative — do not retry with the same filters. Broaden or change filter_field/filter_value and retry.`,
-						contextFields,
-					),
-				);
-			}
-
-			const total = records.length;
-			const truncated = total > MAX_RESPONSE_RECORDS;
-			const items = truncated ? records.slice(0, MAX_RESPONSE_RECORDS) : records;
-			const currentOffset = context.effectiveOffset ?? 0;
-			let totalAvailable: number | undefined;
-			const continuationContract = computeListContinuation({
-				currentOffset,
-				recordsReturned: items.length,
-				recordsMatched: total,
-				requestedLimit: getEffectiveLimit(params.limit),
-				returnAll: params.returnAll === true,
-				recencyActive: context.recencyActive === true,
-				maxQueryLimit: MAX_QUERY_LIMIT,
-				serverCap: context.serverCap ?? MAX_QUERY_LIMIT,
-				clientCap: context.clientCap ?? MAX_RESPONSE_RECORDS,
-				serverCapReached:
-					context.serverCapReached === true || context.recencyWindowLimited === true,
-			});
-			const hasMore = continuationContract.continuation?.hasMore === true;
-			const nextOffset = continuationContract.continuation?.nextOffset;
-
-			if (truncated) totalAvailable = total;
-
-			const notes: string[] = [];
-			if (context.recencyNote) notes.push(context.recencyNote);
-			if (continuationContract.truncationReason) {
-				notes.push(continuationContract.truncationReason);
-			}
-			if (truncated) {
-				if (params.returnAll) {
-					notes.push(
-						`Fetched all ${total} matching records via returnAll; showing first ${MAX_RESPONSE_RECORDS} in this response. ` +
-							`Use 'fields' to reduce payload size, or narrow filters to reduce match count.`,
-					);
-				} else {
-					notes.push(
-						hasMore
-							? `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Use offset=${nextOffset} to see the next page, or use a narrower filter.`
-							: `Showing first ${MAX_RESPONSE_RECORDS} of ${total} records. Offset pagination limit (${MAX_QUERY_LIMIT}) reached — use narrower filters to access more records.`,
-					);
-				}
-			}
-
-			const listWarnings: string[] = [...(context.resolutionWarnings ?? [])];
-			if (context.recencyWindowLimited) {
-				listWarnings.push(
-					'500 records were returned for the current recency window. Narrow recency, or provide since/until, to ensure the newest records are included.',
-				);
-			}
-
-			const pagination: ListPaginationState = {
-				hasMore,
-				...(nextOffset !== undefined ? { nextOffset } : {}),
-				...(totalAvailable !== undefined ? { totalAvailable } : {}),
-				...(notes.length > 0 ? { notes } : {}),
-				continuation: continuationContract.continuation,
-				isTruncated: continuationContract.isTruncated,
-				truncationReason: continuationContract.truncationReason,
-				serverCap: continuationContract.serverCap,
-				clientCap: continuationContract.clientCap,
-			};
-
-			const listContext: ToolResponseContext = {
-				...context,
-				resolutionWarnings: listWarnings,
-			};
-
-			return JSON.stringify(buildListResponse(resource, operation, items, pagination, listContext));
 		}
 
 		case 'whoAmI': {
@@ -413,37 +433,6 @@ export function dispatchOperationResponse(
 				);
 			}
 			return JSON.stringify(buildTicketSummaryResponse(resource, operation, firstRecord, context));
-		}
-
-		case 'moveConfigurationItem':
-		case 'moveToCompany':
-		case 'approve':
-		case 'reject':
-		case 'transferOwnership':
-		case 'create':
-		case 'update': {
-			const validation = validateMutationSuccess(operation, firstRecord);
-			if (!validation.ok) {
-				return JSON.stringify(
-					wrapError(
-						resource,
-						operation,
-						validation.errorType ?? ERROR_TYPES.API_ERROR,
-						validation.message ?? `${resource}.${operation} failed validation.`,
-						validation.hint ?? `Retry autotask_${resource} with operation '${operation}'.`,
-					),
-				);
-			}
-
-			return JSON.stringify(
-				buildMutationResponse(
-					resource,
-					operation,
-					validation.id ?? 'unknown',
-					firstRecord ?? undefined,
-					context,
-				),
-			);
 		}
 
 		case 'delete': {

--- a/nodes/Autotask/ai-tools/operation-handlers/operation-dispatch.ts
+++ b/nodes/Autotask/ai-tools/operation-handlers/operation-dispatch.ts
@@ -98,7 +98,7 @@ export function dispatchOperationResponse(
 						return { ok: true, id: fallbackId };
 					}
 				}
-				if (record === null) {
+				if (record === null || record === undefined) {
 					return {
 						ok: false,
 						errorType: ERROR_TYPES.ENTITY_NOT_FOUND,
@@ -322,7 +322,6 @@ export function dispatchOperationResponse(
 					validation.errorType ?? ERROR_TYPES.API_ERROR,
 					validation.message ?? `${resource}.${operation} failed validation.`,
 					validation.hint ?? `Retry autotask_${resource} with operation '${operation}'.`,
-					validation.context,
 				),
 			);
 		}

--- a/nodes/Autotask/ai-tools/operation-metadata.ts
+++ b/nodes/Autotask/ai-tools/operation-metadata.ts
@@ -40,7 +40,7 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		supportsFilters: true,
 		responseKind: 'list',
 		docsFragment:
-			'Search records with up to two filters (AND/OR via filter_logic). Supports name-based resolution for reference/picklist filter values.',
+			'Search records with up to two filters (AND/OR via filter_logic). Use filter_field/filter_value. Supports name-based resolution for reference/picklist filter values.',
 	},
 	{
 		name: 'getPosted',
@@ -146,7 +146,7 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		supportsFilters: false,
 		responseKind: 'summary',
 		docsFragment:
-			"Get a compact ticket summary ('id' or 'ticketNumber' required), including computed values and optional child counts.",
+			"Get a compact ticket summary ('id' or 'ticketNumber' required). Computed values, child counts, relationships.",
 	},
 	{
 		name: 'getByResource',
@@ -155,7 +155,7 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		supportsFilters: false,
 		responseKind: 'item',
 		docsFragment:
-			"Get record(s) for a specific resource using 'resourceID' (name or numeric ID, auto-resolved).",
+			"Get record(s) for a specific resource. Provide 'resourceID' as a name or numeric ID (auto-resolved). Use for operations that are scoped to a parent resource rather than queried by their own ID.",
 	},
 	{
 		name: 'getByYear',
@@ -164,7 +164,7 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		supportsFilters: false,
 		responseKind: 'item',
 		docsFragment:
-			"Get the time-off balance for a specific calendar year using 'resourceID' and 'year'.",
+			"Get the time-off balance for a specific calendar year. Provide 'resourceID' (name or numeric ID, auto-resolved) and 'year' as an integer (e.g. 2024).",
 	},
 	{
 		name: 'approve',

--- a/nodes/Autotask/ai-tools/operation-metadata.ts
+++ b/nodes/Autotask/ai-tools/operation-metadata.ts
@@ -1,0 +1,204 @@
+export type OperationResponseKind =
+	| 'item'
+	| 'list'
+	| 'mutation'
+	| 'delete'
+	| 'count'
+	| 'slaHealthCheck'
+	| 'summary';
+
+export interface OperationMetadata {
+	name: string;
+	isWrite: boolean;
+	label: string;
+	supportsFilters: boolean;
+	responseKind: OperationResponseKind;
+	docsFragment: string;
+}
+
+const OPERATION_METADATA_LIST: OperationMetadata[] = [
+	{
+		name: 'get',
+		isWrite: false,
+		label: 'Get by ID',
+		supportsFilters: false,
+		responseKind: 'item',
+		docsFragment: "Retrieve a single record by numeric 'id'.",
+	},
+	{
+		name: 'whoAmI',
+		isWrite: false,
+		label: 'Who am I',
+		supportsFilters: false,
+		responseKind: 'item',
+		docsFragment: 'Resolve the authenticated resource record.',
+	},
+	{
+		name: 'getMany',
+		isWrite: false,
+		label: 'Get many (with filters)',
+		supportsFilters: true,
+		responseKind: 'list',
+		docsFragment:
+			'Search records with up to two filters (AND/OR via filter_logic). Supports name-based resolution for reference/picklist filter values.',
+	},
+	{
+		name: 'getPosted',
+		isWrite: false,
+		label: 'Get posted time entries',
+		supportsFilters: true,
+		responseKind: 'list',
+		docsFragment: 'Get posted time entries with optional filters.',
+	},
+	{
+		name: 'getUnposted',
+		isWrite: false,
+		label: 'Get unposted time entries',
+		supportsFilters: true,
+		responseKind: 'list',
+		docsFragment: 'Get unposted time entries with optional filters.',
+	},
+	{
+		name: 'searchByDomain',
+		isWrite: false,
+		label: 'Search by domain',
+		supportsFilters: false,
+		responseKind: 'list',
+		docsFragment: 'Search companies by domain string.',
+	},
+	{
+		name: 'count',
+		isWrite: false,
+		label: 'Count',
+		supportsFilters: true,
+		responseKind: 'count',
+		docsFragment: 'Count records matching optional filters.',
+	},
+	{
+		name: 'create',
+		isWrite: true,
+		label: 'Create',
+		supportsFilters: false,
+		responseKind: 'mutation',
+		docsFragment: 'Create a new record.',
+	},
+	{
+		name: 'createIfNotExists',
+		isWrite: true,
+		label: 'Create If Not Exists (idempotent)',
+		supportsFilters: false,
+		responseKind: 'mutation',
+		docsFragment:
+			'Idempotent create using dedup fields, with outcomes: created, skipped, updated, or not_found variants.',
+	},
+	{
+		name: 'update',
+		isWrite: true,
+		label: 'Update',
+		supportsFilters: false,
+		responseKind: 'mutation',
+		docsFragment: "Update a record by numeric 'id'. Provide only fields to change.",
+	},
+	{
+		name: 'delete',
+		isWrite: true,
+		label: 'Delete',
+		supportsFilters: false,
+		responseKind: 'delete',
+		docsFragment: "Delete a record by numeric 'id'.",
+	},
+	{
+		name: 'moveToCompany',
+		isWrite: true,
+		label: 'Move contact to company',
+		supportsFilters: false,
+		responseKind: 'mutation',
+		docsFragment: 'Move a contact to another company.',
+	},
+	{
+		name: 'moveConfigurationItem',
+		isWrite: true,
+		label: 'Move configuration item (clone to company)',
+		supportsFilters: false,
+		responseKind: 'mutation',
+		docsFragment: 'Clone a configuration item to a different company.',
+	},
+	{
+		name: 'transferOwnership',
+		isWrite: true,
+		label: 'Transfer ownership',
+		supportsFilters: false,
+		responseKind: 'mutation',
+		docsFragment: 'Transfer ownership from source resource to destination resource.',
+	},
+	{
+		name: 'slaHealthCheck',
+		isWrite: false,
+		label: 'SLA health check',
+		supportsFilters: false,
+		responseKind: 'slaHealthCheck',
+		docsFragment: "Run SLA health check for a ticket using 'id' or 'ticketNumber'.",
+	},
+	{
+		name: 'summary',
+		isWrite: false,
+		label: 'Ticket summary',
+		supportsFilters: false,
+		responseKind: 'summary',
+		docsFragment:
+			"Get a compact ticket summary ('id' or 'ticketNumber' required), including computed values and optional child counts.",
+	},
+	{
+		name: 'getByResource',
+		isWrite: false,
+		label: 'Get by resource',
+		supportsFilters: false,
+		responseKind: 'item',
+		docsFragment:
+			"Get record(s) for a specific resource using 'resourceID' (name or numeric ID, auto-resolved).",
+	},
+	{
+		name: 'getByYear',
+		isWrite: false,
+		label: 'Get by resource and year',
+		supportsFilters: false,
+		responseKind: 'item',
+		docsFragment:
+			"Get the time-off balance for a specific calendar year using 'resourceID' and 'year'.",
+	},
+	{
+		name: 'approve',
+		isWrite: true,
+		label: 'Approve time off request',
+		supportsFilters: false,
+		responseKind: 'mutation',
+		docsFragment: "Approve a pending time off request by numeric 'id'.",
+	},
+	{
+		name: 'reject',
+		isWrite: true,
+		label: 'Reject time off request',
+		supportsFilters: false,
+		responseKind: 'mutation',
+		docsFragment:
+			"Reject a pending time off request by numeric 'id', with optional rejectReason.",
+	},
+];
+
+export const OPERATION_METADATA: Readonly<Record<string, OperationMetadata>> = Object.freeze(
+	Object.fromEntries(OPERATION_METADATA_LIST.map((operation) => [operation.name, operation])),
+);
+
+export const SUPPORTED_TOOL_OPERATIONS = OPERATION_METADATA_LIST.map((operation) => operation.name);
+
+export const WRITE_OPERATIONS = OPERATION_METADATA_LIST
+	.filter((operation) => operation.isWrite)
+	.map((operation) => operation.name);
+
+export function getOperationMetadata(operation: string): OperationMetadata | undefined {
+	return OPERATION_METADATA[operation];
+}
+
+export function isWriteOperation(operation: string): boolean {
+	return OPERATION_METADATA[operation]?.isWrite === true;
+}

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -3,7 +3,6 @@ import { FilterOperators } from '../constants/filters';
 import type { RuntimeZod } from './runtime';
 import { IDENTIFIER_PAIR_OPERATIONS } from '../constants/resource-operations';
 import { safeKeys, summariseFields, traceSchemaBuild } from './debug-trace';
-import { validateOperationContract } from './operation-contracts';
 import { getOperationMetadata, isWriteOperation } from './operation-metadata';
 
 /** Maximum number of picklist values to inline in a field description */

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -3,6 +3,8 @@ import { FilterOperators } from '../constants/filters';
 import type { RuntimeZod } from './runtime';
 import { IDENTIFIER_PAIR_OPERATIONS } from '../constants/resource-operations';
 import { safeKeys, summariseFields, traceSchemaBuild } from './debug-trace';
+import { validateOperationContract } from './operation-contracts';
+import { getOperationMetadata, isWriteOperation } from './operation-metadata';
 
 /** Maximum number of picklist values to inline in a field description */
 const MAX_INLINE_PICKLIST_VALUES = 8;
@@ -164,6 +166,9 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		readFields: FieldMeta[],
 		writeFields: FieldMeta[],
 	) {
+		const operationMetadata = operations
+			.map((operation) => getOperationMetadata(operation))
+			.filter((metadata): metadata is NonNullable<typeof metadata> => metadata !== undefined);
 		const isReadOnlyOpsSet = writeFields.length === 0;
 		if (isReadOnlyOpsSet) {
 			const cacheKey = getReadOnlySchemaCacheKey(resource, operations, readFields);
@@ -184,11 +189,9 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			summary: {
 				operations,
 				hasListFamilyOps: operations.some((op) =>
-					['getMany', 'count', 'getPosted', 'getUnposted'].includes(op),
+					getOperationMetadata(op)?.supportsFilters === true,
 				),
-				hasWriteFamilyOps: operations.some((op) =>
-					['create', 'createIfNotExists', 'update', 'delete'].includes(op),
-				),
+				hasWriteFamilyOps: operations.some((op) => isWriteOperation(op)),
 				hasIdentifierPairOps: Boolean(IDENTIFIER_PAIR_OPERATIONS[resource]),
 				readFields: summariseFields(readFields),
 				writeFields: summariseFields(writeFields),
@@ -200,14 +203,10 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const shape: Record<string, any> = {};
 
-		const hasGetFamily = operations.some((op) =>
-			['get', 'whoAmI', 'getMany', 'count', 'getPosted', 'getUnposted', 'searchByDomain'].includes(
-				op,
-			),
+		const hasGetFamily = operationMetadata.some((metadata) =>
+			['item', 'list', 'count'].includes(metadata.responseKind),
 		);
-		const hasListFamily = operations.some((op) =>
-			['getMany', 'count', 'getPosted', 'getUnposted'].includes(op),
-		);
+		const hasListFamily = operationMetadata.some((metadata) => metadata.supportsFilters);
 		const hasGetOrDelete = operations.some((op) => ['get', 'delete'].includes(op));
 		const hasUpdate = operations.includes('update');
 		const hasCreate = operations.includes('create');


### PR DESCRIPTION
### Motivation

- Reduce duplication and hardcoded operation lists across AI-tooling code by centralizing operation metadata. 
- Make write-gating, labels, schema shape toggles, and response routing consistent and easier to maintain. 
- Prepare the codebase for easier future changes to operation behaviour and descriptions by exposing a single source of truth.

### Description

- Add a new `operation-metadata` module (`nodes/Autotask/ai-tools/operation-metadata.ts`) that defines each tool operation's metadata (`name`, `isWrite`, `label`, `supportsFilters`, `responseKind`, `docsFragment`) and exports helpers such as `SUPPORTED_TOOL_OPERATIONS`, `getOperationMetadata`, and `isWriteOperation`.
- Update `AutotaskAiTools.node.ts` to consume the centralized metadata for supported-operation validation, write-operation gating, and load-options labels, removing duplicated local arrays and maps and using `SUPPORTED_TOOL_OPERATIONS` and `isWriteOperation` instead.
- Refactor `ai-tools/schema-generator.ts` to derive read/list/write behavior from operation metadata (`supportsFilters`, `responseKind`, `isWrite`) when building the unified runtime schema instead of relying on hardcoded operation name arrays.
- Refactor `ai-tools/description-builders.ts` to use `getOperationMetadata(...).docsFragment` and centralized write detection (`isWriteOperation`) for operation summaries while preserving operation-specific enrichments (e.g. `create`, `update`, `getMany`).
- Refactor `ai-tools/operation-handlers/operation-dispatch.ts` to route list and mutation responses by `responseKind` from metadata (retaining existing special-case handling like `searchByDomain`, `slaHealthCheck`, and `summary`).

### Testing

- Ran type checks with `npm run -s typecheck`, which completed successfully. 
- Ran linter with `npm run -s lint`, which reported existing repository lint violations (14 errors) unrelated to the refactor and did not pass; the refactor does not introduce new lint failures beyond existing rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db29c333a083208994f5d0e6acedf0)