### PR TITLE
feat(ai-tools): automatic response enrichment for ticketID/taskID references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the n8n-nodes-autotask project will be documented in this
 
 ## [2.10.0] — 2026-04-19
 
+### Added
+
+- **AI tools — automatic ID enrichment of response records**: Records returned by AI tool operations are now automatically enriched with human-readable fields when they contain `ticketID` or `taskID`. Records with `ticketID` gain `ticketNumber` and `ticketTitle`; records with `taskID` gain `taskTitle`, `taskProjectNumber`, and `taskProjectName`. Enrichment applies to all `records[]` and `record{}` response shapes including compound (`createIfNotExists`) results. Single insertion point in `tool-executor.ts`: `enrichResponseJson()` is called between `dispatchOperationResponse` and `attachCorrelation` on the main happy-path, and between `buildCompoundResponse` and `attachCorrelation` on the compound path. Failure-safe — outer try/catch returns the original JSON on any panic.
+- **Module-level in-memory enrichment cache** (1800 s TTL) with in-flight request coalescing via `Map<string, Promise<...>>` — no CacheService dependency. Shared across all tool invocations in the same process.
+- **`EntityValueHelper.getValuesByIds()` optional `includeFields` parameter**: Callers can now pass a list of field names to restrict which fields the Autotask API returns, reducing response payload size. Used by the enrichment engine to fetch only the required fields per entity type.
+
+> ⚠️ **Behavioural note:** List and single-record operation responses will now include additional fields (`ticketNumber`, `ticketTitle`, `taskTitle`, `taskProjectNumber`, `taskProjectName`) when records reference tickets or tasks. LLM prompts or downstream automations that depend on the **absence** of these fields should be reviewed.
+
 ### Changed
 
 - **AI tools — typed-reference auto-resolution for ticket and project references**: Any reference field whose `referencesEntity` is `ticket` or `project` now auto-resolves human-readable identifiers on both write and filter paths. Ticket numbers matching `T{YYYYMMDD}.{seq4}` (e.g. `T20240615.0674`) resolve via a single `Tickets/query { ticketNumber eq }` lookup. Project numbers resolve via `Projects/query { projectNumber eq }`. When a human-readable string doesn't match the number format, an optional companion field (`ticketLookupField: 'title' | 'description'` or `projectLookupField: 'projectName' | 'description'`) switches the lookup to a `contains` search on the chosen field. Eliminates the previous fall-through to `EntityValueHelper`, which fetched the full entity list and rarely matched on non-numeric label fields. Registry-driven via `helpers/typed-reference/` — adding Contract, Company, etc. in future releases is a one-entry change.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Key AI Tools capabilities:
 - **Offset pagination**: List operations accept an `offset` parameter for paginating through results (up to 100 records). Responses include `hasMore` and `nextOffset` for continuation.
 - **Impersonation name resolution**: The `impersonationResourceId` parameter accepts a name or email in addition to numeric IDs.
 - **Idempotent creation**: `createIfNotExists` operations (see below) provide find-or-create semantics with configurable dedup fields.
+- **Automatic response enrichment**: Records that reference a ticket (via `ticketID`) or task (via `taskID`) are automatically enriched with human-readable fields (`ticketNumber`, `ticketTitle`, `taskTitle`, `taskProjectNumber`, `taskProjectName`). Enrichment is transparent — it requires no configuration and applies to all list, get, and compound responses.
 
 ### Supported Resources
 

--- a/nodes/Autotask/ai-tools/tool-executor.ts
+++ b/nodes/Autotask/ai-tools/tool-executor.ts
@@ -62,6 +62,7 @@ import {
 	COMPOUND_PARENT_NOT_FOUND_OUTCOMES,
 } from '../constants/compound-registry';
 import { validateOperationContract, hasProvidedValue, type OperationContractViolation } from './operation-contracts';
+import { enrichResponseJson } from '../helpers/enrichment';
 
 export interface ToolExecutorParams {
 	resource: string;
@@ -1309,21 +1310,20 @@ export async function executeAiTool(
 					compoundData.fieldsCompared = compoundResult.fieldsCompared;
 				if (compoundContext !== undefined) compoundData.context = compoundContext;
 
-				return attachCorrelation(
-					JSON.stringify(
-						buildCompoundResponse(
-							resource,
-							'createIfNotExists',
-							compoundData as Parameters<typeof buildCompoundResponse>[2],
-							{
-								resolutions: labelResolutions,
-								resolutionWarnings: allWarnings,
-								pendingConfirmations: labelPendingConfirmations,
-							},
-						),
+				const compoundJson = JSON.stringify(
+					buildCompoundResponse(
+						resource,
+						'createIfNotExists',
+						compoundData as Parameters<typeof buildCompoundResponse>[2],
+						{
+							resolutions: labelResolutions,
+							resolutionWarnings: allWarnings,
+							pendingConfirmations: labelPendingConfirmations,
+						},
 					),
-					correlationId,
 				);
+				const enrichedCompoundJson = await enrichResponseJson(compoundJson, context);
+				return attachCorrelation(enrichedCompoundJson, correlationId);
 			}
 		}
 
@@ -1440,7 +1440,8 @@ export async function executeAiTool(
 				noResultsClassification: records.length === 0 ? 'empty' : 'non-empty',
 			},
 		});
-		return attachCorrelation(formattedResponse, correlationId);
+		const enrichedResponse = await enrichResponseJson(formattedResponse, context);
+		return attachCorrelation(enrichedResponse, correlationId);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		traceError({

--- a/nodes/Autotask/helpers/enrichment.ts
+++ b/nodes/Autotask/helpers/enrichment.ts
@@ -1,0 +1,317 @@
+import type { IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
+import { QUERY_LIMITS } from '../constants/operations';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type OutputFieldSpec = string | ((record: Record<string, unknown>) => unknown);
+
+interface HopConfig {
+	entityName: string;
+	fetchFields: string[];
+	outputFields: Record<string, OutputFieldSpec>;
+}
+
+interface EnrichmentConfig extends HopConfig {
+	nextHop?: HopConfig & { idField: string };
+}
+
+// ---------------------------------------------------------------------------
+// Module-level caches
+// ---------------------------------------------------------------------------
+
+const ENRICHMENT_TTL_MS = 1_800_000;
+
+interface EnrichmentCacheEntry {
+	fields: Record<string, unknown>;
+	expiresAt: number;
+}
+
+/** Cache of output fields keyed by `${entityName}:${id}` */
+const enrichmentCache = new Map<string, EnrichmentCacheEntry>();
+
+/** Cache of raw source records keyed by `raw:${entityName}:${id}` — used for nextHop idField lookup */
+const rawCache = new Map<string, EnrichmentCacheEntry>();
+
+const inFlightMap = new Map<string, Promise<Record<string, unknown>[]>>();
+
+// ---------------------------------------------------------------------------
+// Enrichment registry
+// ---------------------------------------------------------------------------
+
+const ENRICHMENT_REGISTRY: Record<string, EnrichmentConfig> = {
+	ticketID: {
+		entityName: 'Ticket',
+		fetchFields: ['id', 'ticketNumber', 'title'],
+		outputFields: { ticketNumber: 'ticketNumber', ticketTitle: 'title' },
+	},
+	taskID: {
+		entityName: 'Task',
+		fetchFields: ['id', 'title', 'projectID'],
+		outputFields: { taskTitle: 'title' },
+		nextHop: {
+			entityName: 'Project',
+			idField: 'projectID',
+			fetchFields: ['id', 'projectNumber', 'projectName'],
+			outputFields: { taskProjectNumber: 'projectNumber', taskProjectName: 'projectName' },
+		},
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getCachedEntry(
+	cache: Map<string, EnrichmentCacheEntry>,
+	key: string,
+): Record<string, unknown> | undefined {
+	const entry = cache.get(key);
+	if (!entry) return undefined;
+	if (Date.now() > entry.expiresAt) {
+		cache.delete(key);
+		return undefined;
+	}
+	return entry.fields;
+}
+
+function applyOutputFields(
+	sourceRecord: Record<string, unknown>,
+	outputFields: Record<string, OutputFieldSpec>,
+): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+	for (const [outKey, spec] of Object.entries(outputFields)) {
+		if (typeof spec === 'string') {
+			result[outKey] = sourceRecord[spec];
+		} else {
+			result[outKey] = spec(sourceRecord);
+		}
+	}
+	return result;
+}
+
+/**
+ * Fetches enrichment fields for a batch of IDs using EntityValueHelper.getValuesByIds().
+ * Returns a Map<id, outputFields> of resolved output fields.
+ * Also populates rawCache so callers can look up source-record fields (e.g. nextHop idField).
+ */
+async function fetchEntityFields(
+	entityName: string,
+	ids: number[],
+	fetchFields: string[],
+	outputFields: Record<string, OutputFieldSpec>,
+	context: IExecuteFunctions | ILoadOptionsFunctions,
+	warnings: string[],
+	MAX_IN_CLAUSE: number,
+): Promise<Map<number, Record<string, unknown>>> {
+	const resultMap = new Map<number, Record<string, unknown>>();
+
+	// Check cache for each id
+	const uncachedIds: number[] = [];
+	for (const id of ids) {
+		const cached = getCachedEntry(enrichmentCache, `${entityName}:${id}`);
+		if (cached !== undefined) {
+			resultMap.set(id, cached);
+		} else {
+			uncachedIds.push(id);
+		}
+	}
+
+	if (uncachedIds.length === 0) {
+		return resultMap;
+	}
+
+	// Truncate if over limit
+	if (uncachedIds.length > MAX_IN_CLAUSE) {
+		warnings.push(
+			`Enrichment truncated: ${entityName} has ${uncachedIds.length} unique IDs, limit is ${MAX_IN_CLAUSE} — first ${MAX_IN_CLAUSE} enriched`,
+		);
+		uncachedIds.splice(MAX_IN_CLAUSE);
+	}
+
+	const batchKey = `batch:${entityName}:${[...uncachedIds].sort((a, b) => a - b).join(',')}`;
+
+	if (!inFlightMap.has(batchKey)) {
+		const promise = (async () => {
+			const { EntityValueHelper } = await import('./entity-values/value-helper');
+			const helper = new EntityValueHelper(
+				context as unknown as ILoadOptionsFunctions,
+				entityName,
+			);
+			return (await helper.getValuesByIds(uncachedIds, fetchFields)) as Record<string, unknown>[];
+		})().finally(() => inFlightMap.delete(batchKey));
+		inFlightMap.set(batchKey, promise);
+	}
+
+	let rawResults: Record<string, unknown>[];
+	try {
+		rawResults = (await inFlightMap.get(batchKey)) ?? [];
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		warnings.push(
+			`Enrichment failed for ${entityName} IDs [${uncachedIds.join(', ')}]: ${msg} — enriched fields omitted`,
+		);
+		return resultMap;
+	}
+
+	const expiresAt = Date.now() + ENRICHMENT_TTL_MS;
+
+	for (const rawResult of rawResults) {
+		const id = rawResult['id'] as number;
+		if (id == null) continue;
+
+		// Cache the raw source record (for nextHop idField lookups)
+		rawCache.set(`raw:${entityName}:${id}`, { fields: rawResult, expiresAt });
+
+		// Compute and cache output fields
+		const fields = applyOutputFields(rawResult, outputFields);
+		enrichmentCache.set(`${entityName}:${id}`, { fields, expiresAt });
+
+		resultMap.set(id, fields);
+	}
+
+	return resultMap;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function enrichResponseJson(
+	responseJson: string,
+	context: IExecuteFunctions | ILoadOptionsFunctions,
+): Promise<string> {
+	try {
+		const parsed: Record<string, unknown> = JSON.parse(responseJson);
+
+		// Skip error responses
+		if (parsed['error'] === true) {
+			return responseJson;
+		}
+
+		// Detect shape.
+		// NOTE: `items` references the arrays/objects owned by `parsed` directly. Field injection
+		// below mutates those records in place. If any exception is thrown mid-mutation and is
+		// caught by the outer try/catch, the original (un-stringified) `responseJson` is returned —
+		// so partial mutations on the parsed object are never observed by the caller. Safe but
+		// worth being explicit about.
+		let items: Record<string, unknown>[] | null = null;
+
+		if (Array.isArray(parsed['records'])) {
+			items = parsed['records'] as Record<string, unknown>[];
+		} else if (
+			parsed['record'] !== undefined &&
+			parsed['record'] !== null &&
+			typeof parsed['record'] === 'object' &&
+			!Array.isArray(parsed['record'])
+		) {
+			items = [parsed['record'] as Record<string, unknown>];
+		}
+
+		// If no enrichable shape (count, metadata, ticketSummary, etc.) return as-is
+		if (items === null) {
+			return responseJson;
+		}
+
+		const warnings: string[] = [];
+
+		for (const [fieldKey, config] of Object.entries(ENRICHMENT_REGISTRY)) {
+			// Collect unique non-null, non-zero IDs from items
+			const idSet = new Set<number>();
+			for (const item of items) {
+				const v = item[fieldKey];
+				if (typeof v === 'number' && v > 0) {
+					idSet.add(v);
+				}
+			}
+
+			if (idSet.size === 0) continue;
+
+			const uniqueIds = Array.from(idSet);
+
+			// Fetch first-hop entity fields
+			const firstHopMap = await fetchEntityFields(
+				config.entityName,
+				uniqueIds,
+				config.fetchFields,
+				config.outputFields,
+				context,
+				warnings,
+				QUERY_LIMITS.MAX_IN_CLAUSE_VALUES,
+			);
+
+			// Handle optional second hop
+			let nextHopMap: Map<number, Record<string, unknown>> | null = null;
+			if (config.nextHop) {
+				const { nextHop } = config;
+				// Collect unique next-hop IDs by reading raw source records from rawCache
+				const nextHopIdSet = new Set<number>();
+				for (const id of uniqueIds) {
+					const rawRecord = getCachedEntry(rawCache, `raw:${config.entityName}:${id}`);
+					if (rawRecord) {
+						const nextIdRaw = rawRecord[nextHop.idField];
+						if (typeof nextIdRaw === 'number' && nextIdRaw > 0) {
+							nextHopIdSet.add(nextIdRaw);
+						}
+					}
+				}
+
+				if (nextHopIdSet.size > 0) {
+					nextHopMap = await fetchEntityFields(
+						nextHop.entityName,
+						Array.from(nextHopIdSet),
+						nextHop.fetchFields,
+						nextHop.outputFields,
+						context,
+						warnings,
+						QUERY_LIMITS.MAX_IN_CLAUSE_VALUES,
+					);
+				}
+			}
+
+			// Inject enriched fields into each item
+			for (const item of items) {
+				const v = item[fieldKey];
+				if (typeof v !== 'number' || v <= 0) continue;
+
+				// Inject first-hop output fields
+				const firstHopFields = firstHopMap.get(v);
+				if (firstHopFields) {
+					for (const [k, val] of Object.entries(firstHopFields)) {
+						if (!(k in item)) {
+							item[k] = val;
+						}
+					}
+				}
+
+				// Inject next-hop output fields
+				if (nextHopMap && config.nextHop) {
+					const rawRecord = getCachedEntry(rawCache, `raw:${config.entityName}:${v}`);
+					if (rawRecord) {
+						const nextId = rawRecord[config.nextHop.idField];
+						if (typeof nextId === 'number' && nextId > 0) {
+							const nextHopFields = nextHopMap.get(nextId);
+							if (nextHopFields) {
+								for (const [k, val] of Object.entries(nextHopFields)) {
+									if (!(k in item)) {
+										item[k] = val;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if (warnings.length > 0) {
+			// Response builders always initialise `warnings: []`, so this array is guaranteed to exist.
+			(parsed['warnings'] as unknown[]).push(...warnings);
+		}
+
+		return JSON.stringify(parsed);
+	} catch {
+		return responseJson;
+	}
+}

--- a/nodes/Autotask/helpers/entity-values/value-helper.ts
+++ b/nodes/Autotask/helpers/entity-values/value-helper.ts
@@ -208,8 +208,13 @@ export class EntityValueHelper<T extends IAutotaskEntity> {
 	 * Retrieve entities by their IDs.
 	 *
 	 * @param ids An array of entity IDs to retrieve.
+	 * @param includeFields Optional list of fields to restrict the API response to.
+	 *                     When provided, the resulting `IncludeFields` is the union of these
+	 *                     fields, the entity's required display fields, and `id`. This lets
+	 *                     callers (e.g. response enrichment) minimise bandwidth while still
+	 *                     guaranteeing the fields they need are returned by the API.
 	 */
-	public async getValuesByIds(ids: (string | number)[]): Promise<T[]> {
+	public async getValuesByIds(ids: (string | number)[], includeFields?: string[]): Promise<T[]> {
 		if (!ids || ids.length === 0) {
 			return [];
 		}
@@ -225,6 +230,20 @@ export class EntityValueHelper<T extends IAutotaskEntity> {
 					},
 				],
 			};
+
+			// When the caller specifies includeFields, build an explicit IncludeFields that
+			// merges them with required display fields. GetManyOperation.executeQuery honours
+			// an explicit caller-supplied IncludeFields even under isPicklistQuery mode.
+			if (includeFields && includeFields.length > 0) {
+				const merged = new Set<string>(['id']);
+				for (const field of this.getRequiredDisplayFields()) {
+					merged.add(field);
+				}
+				for (const field of includeFields) {
+					if (field) merged.add(field);
+				}
+				query.IncludeFields = Array.from(merged);
+			}
 
 			console.debug(`Loading ${ids.length} reference entities for ${this.entityType} by ID`);
 

--- a/nodes/Autotask/operations/base/get-many.ts
+++ b/nodes/Autotask/operations/base/get-many.ts
@@ -304,17 +304,20 @@ export class GetManyOperation<T extends IAutotaskEntity> {
 					queryBody.MaxRecords = filters.MaxRecords;
 				}
 
-				// Check if this is a picklist query
-				if (this.options?.isPicklistQuery) {
-					// For picklist queries, don't specify IncludeFields to get all fields
-					// This avoids issues with incorrect fields being included
+				// Honour caller-supplied IncludeFields first — even for picklist queries.
+				// Callers (e.g. enrichment) that pass an explicit IncludeFields list know
+				// exactly which fields they need and have already merged in required display fields.
+				if (filters.IncludeFields && filters.IncludeFields.length > 0) {
+					queryBody.IncludeFields = filters.IncludeFields;
+					console.debug(`[GetManyOperation] Using caller-supplied IncludeFields with ${filters.IncludeFields.length} fields for ${this.entityType} query`);
+				} else if (this.options?.isPicklistQuery) {
+					// For picklist queries without explicit IncludeFields, don't specify it so
+					// the API returns all fields. This avoids issues with incorrect fields being included.
 					console.debug(`[GetManyOperation] Picklist query detected for ${this.entityType} - not using IncludeFields`);
-				} else {
+				} else if (includeFields.length > 0) {
 					// For regular queries, add IncludeFields if there are specific fields to include
-					if (includeFields.length > 0) {
-						queryBody.IncludeFields = includeFields;
-						console.debug(`[GetManyOperation] Using IncludeFields with ${includeFields.length} fields for query`);
-					}
+					queryBody.IncludeFields = includeFields;
+					console.debug(`[GetManyOperation] Using IncludeFields with ${includeFields.length} fields for query`);
 				}
 
 				const response = await autotaskApiRequest.call(


### PR DESCRIPTION
## Summary

- Adds `enrichResponseJson()` in `helpers/enrichment.ts` — transparently enriches AI tool responses with human-readable fields (`ticketNumber`, `ticketTitle`, `taskTitle`, `taskProjectNumber`, `taskProjectName`) when records contain `ticketID` or `taskID`
- Single insertion point pattern: called at two places in `tool-executor.ts` (main happy-path between `dispatchOperationResponse` and `attachCorrelation`; compound path between `buildCompoundResponse` and `attachCorrelation`)
- Module-level in-memory cache (1800s TTL) with in-flight request coalescing via `Map<string, Promise<...>>` — no CacheService dependency
- `EntityValueHelper.getValuesByIds()` gains optional `includeFields` parameter to minimise API payload size
- `GetManyOperation` updated to honour caller-supplied `IncludeFields` even under `isPicklistQuery` mode

## Test plan

- [ ] Verify `getMany` response for a resource with `ticketID` fields (e.g. timeEntry) includes `ticketNumber` and `ticketTitle`
- [ ] Verify `getMany` response for a resource with `taskID` fields includes `taskTitle`, `taskProjectNumber`, `taskProjectName`
- [ ] Verify `createIfNotExists` compound responses are also enriched
- [ ] Verify responses without `ticketID`/`taskID` pass through unchanged
- [ ] Verify enrichment failure (e.g. bad ticket ID) returns original JSON without error
- [ ] Verify `pnpm build` exits 0

> ⚠️ **Behavioural note:** List and single-record responses will now include additional fields when records reference tickets or tasks. LLM prompts or downstream automations that depend on the **absence** of these fields should be reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)