### PR TITLE
feat(company): add searchByIdentity ranked resolution operation

### DIFF
--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -69,7 +69,9 @@ interface ArtifactCacheEntry {
 
 /** Minimal interface for calling safeParse on a Zod schema without importing zod types. */
 interface ZodSafeParseable {
-	safeParse(input: unknown):
+	safeParse(
+		input: unknown,
+	):
 		| { success: true; data: Record<string, unknown> }
 		| { success: false; error: { message: string } };
 }
@@ -101,7 +103,10 @@ function getArtifactCacheKey(
 	return `${credentialIdentity}|${resource}|ops:${getOpsSignature(effectiveOps)}|allowWrite:${allowWriteOperations ? '1' : '0'}|imp:${supportsImpersonation ? '1' : '0'}|meta:${metadataHash}`;
 }
 
-function getCachedEntry<T extends { expiresAt: number }>(cache: Map<string, T>, key: string): T | undefined {
+function getCachedEntry<T extends { expiresAt: number }>(
+	cache: Map<string, T>,
+	key: string,
+): T | undefined {
 	const hit = cache.get(key);
 	if (!hit) return undefined;
 	if (hit.expiresAt <= Date.now()) {
@@ -128,7 +133,10 @@ function getReferenceUtcNow(): string {
 	return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
 }
 
-function getMetadataNeeds(operations: string[]): { needsReadFields: boolean; needsWriteFields: boolean } {
+function getMetadataNeeds(operations: string[]): {
+	needsReadFields: boolean;
+	needsWriteFields: boolean;
+} {
 	const needsReadFields = operations.some((op) =>
 		[
 			'get',
@@ -137,6 +145,7 @@ function getMetadataNeeds(operations: string[]): { needsReadFields: boolean; nee
 			'getUnposted',
 			'count',
 			'whoAmI',
+			'searchByIdentity',
 			'searchByDomain',
 			'getByResource',
 			'getByYear',
@@ -149,7 +158,9 @@ function getMetadataNeeds(operations: string[]): { needsReadFields: boolean; nee
 			'searchByKeyword',
 		].includes(op),
 	);
-	const needsWriteFields = operations.some((op) => ['create', 'createIfNotExists', 'update'].includes(op));
+	const needsWriteFields = operations.some((op) =>
+		['create', 'createIfNotExists', 'update'].includes(op),
+	);
 	return { needsReadFields, needsWriteFields };
 }
 
@@ -187,7 +198,12 @@ async function resolveMetadataForTool(
 	const { needsReadFields, needsWriteFields } = getMetadataNeeds(operations);
 
 	if (credentialIdentity !== null) {
-		const cacheKey = getMetadataCacheKey(credentialIdentity, resource, needsReadFields, needsWriteFields);
+		const cacheKey = getMetadataCacheKey(
+			credentialIdentity,
+			resource,
+			needsReadFields,
+			needsWriteFields,
+		);
 		const cached = getCachedEntry(metadataCache, cacheKey);
 		if (cached) {
 			return {
@@ -393,9 +409,7 @@ export class AutotaskAiTools implements INodeType {
 			);
 		}
 
-		const effectiveOps = operations.filter(
-			(op) => !isWriteOperation(op) || allowWriteOperations,
-		);
+		const effectiveOps = operations.filter((op) => !isWriteOperation(op) || allowWriteOperations);
 		if (effectiveOps.length === 0) {
 			throw new NodeOperationError(
 				this.getNode(),
@@ -448,16 +462,20 @@ export class AutotaskAiTools implements INodeType {
 			});
 		}
 
-		const cachedArtifact = credentialIdentity !== null
-			? getCachedEntry(artifactCache, getArtifactCacheKey(
-				credentialIdentity,
-				resource,
-				effectiveOps,
-				allowWriteOperations,
-				supportsImpersonation,
-				metadata.metadataHash,
-			))
-			: undefined;
+		const cachedArtifact =
+			credentialIdentity !== null
+				? getCachedEntry(
+						artifactCache,
+						getArtifactCacheKey(
+							credentialIdentity,
+							resource,
+							effectiveOps,
+							allowWriteOperations,
+							supportsImpersonation,
+							metadata.metadataHash,
+						),
+					)
+				: undefined;
 
 		let schema: unknown;
 		let descriptionTemplate: string;
@@ -476,7 +494,12 @@ export class AutotaskAiTools implements INodeType {
 			});
 		} else {
 			const schemaBuildStart = Date.now();
-			schema = buildUnifiedSchema(resource, effectiveOps, metadata.readFields, metadata.writeFields);
+			schema = buildUnifiedSchema(
+				resource,
+				effectiveOps,
+				metadata.readFields,
+				metadata.writeFields,
+			);
 			schemaBuildDurationMs = Date.now() - schemaBuildStart;
 
 			const descriptionBuildStart = Date.now();
@@ -626,9 +649,7 @@ export class AutotaskAiTools implements INodeType {
 		}
 
 		// Pick the first permitted operation as the default for test execution
-		const effectiveOps = operations.filter(
-			(op) => !isWriteOperation(op) || allowWriteOperations,
-		);
+		const effectiveOps = operations.filter((op) => !isWriteOperation(op) || allowWriteOperations);
 		if (effectiveOps.length === 0) {
 			throw new NodeOperationError(
 				this.getNode(),
@@ -695,16 +716,20 @@ export class AutotaskAiTools implements INodeType {
 		const supportsImpersonation = isNodeResourceImpersonationSupported(resource);
 		let zodSchema: ZodSafeParseable;
 		{
-			const cachedArtifact = credentialIdentity !== null
-				? getCachedEntry(artifactCache, getArtifactCacheKey(
-					credentialIdentity,
-					resource,
-					effectiveOps,
-					allowWriteOperations,
-					supportsImpersonation,
-					metadata.metadataHash,
-				))
-				: undefined;
+			const cachedArtifact =
+				credentialIdentity !== null
+					? getCachedEntry(
+							artifactCache,
+							getArtifactCacheKey(
+								credentialIdentity,
+								resource,
+								effectiveOps,
+								allowWriteOperations,
+								supportsImpersonation,
+								metadata.metadataHash,
+							),
+						)
+					: undefined;
 			if (cachedArtifact) {
 				zodSchema = cachedArtifact.schema as ZodSafeParseable;
 			} else {
@@ -712,7 +737,10 @@ export class AutotaskAiTools implements INodeType {
 				// Build the schema on demand and cache it for subsequent calls.
 				const { buildUnifiedSchema } = getRuntimeSchemaBuilders(runtimeZod);
 				const schema = buildUnifiedSchema(
-					resource, effectiveOps, metadata.readFields, metadata.writeFields,
+					resource,
+					effectiveOps,
+					metadata.readFields,
+					metadata.writeFields,
 				);
 				zodSchema = schema as ZodSafeParseable;
 				if (credentialIdentity !== null) {
@@ -726,7 +754,12 @@ export class AutotaskAiTools implements INodeType {
 						supportsImpersonation,
 					);
 					const allAllowedOpsCold = [
-						...new Set([...effectiveOps, 'describeFields', 'listPicklistValues', 'describeOperation']),
+						...new Set([
+							...effectiveOps,
+							'describeFields',
+							'listPicklistValues',
+							'describeOperation',
+						]),
 					];
 					setCachedEntry(
 						artifactCache,
@@ -813,18 +846,21 @@ export class AutotaskAiTools implements INodeType {
 					// This is defense in depth: Zod catches type errors; the contract
 					// check catches semantic/required-field violations that produce
 					// a clearer, more actionable error message for the LLM.
-					const contractViolations: OperationContractViolation[] =
-						validateOperationContract(resource, operation, normalisedJson);
+					const contractViolations: OperationContractViolation[] = validateOperationContract(
+						resource,
+						operation,
+						normalisedJson,
+					);
 					const zodMessage = parseResult.error.message;
-					const contractMessage = contractViolations
-						.map((v) => v.message)
-						.join(' ');
-					const combinedSummary = contractViolations.length > 0
-						? `${contractMessage} (Zod details: ${zodMessage})`
-						: `Input validation failed: ${zodMessage}`;
-					const nextAction = contractViolations.length > 0
-						? `Call autotask_${resource} with operation '${operation}' and supply the missing/correct fields: ${contractMessage}`
-						: `Check parameter names and types. Use autotask_${resource} with operation 'describeFields' to see valid fields.`;
+					const contractMessage = contractViolations.map((v) => v.message).join(' ');
+					const combinedSummary =
+						contractViolations.length > 0
+							? `${contractMessage} (Zod details: ${zodMessage})`
+							: `Input validation failed: ${zodMessage}`;
+					const nextAction =
+						contractViolations.length > 0
+							? `Call autotask_${resource} with operation '${operation}' and supply the missing/correct fields: ${contractMessage}`
+							: `Check parameter names and types. Use autotask_${resource} with operation 'describeFields' to see valid fields.`;
 					response.push({
 						json: {
 							...wrapError(

--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -123,7 +123,7 @@ function setDescriptionTemplateCache(key: string, value: string): void {
 
 /** Rule for getMany/count/getPosted/getUnposted: how recency and since/until interact. */
 const RECENCY_VS_SINCE_UNTIL_RULE =
-	"Temporal filter decision tree:\n- \"recent/latest/last N days/today/this week\" → recency param (e.g. last_7d). recency = LOWER BOUND (records newer than cutoff).\n- \"since date X / after date X\" → use since= param. since is a LOWER BOUND (records >= timestamp).\n- \"fixed range e.g. Q1 2026\" → since= + until=.\n- \"older than N days / before date X / stale / not touched since X\" → filter_field with filter_op='lt' on a date field (createDate, lastActivityDate, dueDateTime). 'lt' = UPPER BOUND. Do NOT use since/until for upper-bound queries.\n- Combination (between A and B) → two filter triplets: filter_op='gt' for inner bound + filter_op='lt' for outer bound on same field. ";
+	'Temporal filter decision tree:\n- "recent/latest/last N days/today/this week" → recency param (e.g. last_7d). recency = LOWER BOUND (records newer than cutoff).\n- "since date X / after date X" → use since= param. since is a LOWER BOUND (records >= timestamp).\n- "fixed range e.g. Q1 2026" → since= + until=.\n- "older than N days / before date X / stale / not touched since X" → filter_field with filter_op=\'lt\' on a date field (createDate, lastActivityDate, dueDateTime). \'lt\' = UPPER BOUND. Do NOT use since/until for upper-bound queries.\n- Combination (between A and B) → two filter triplets: filter_op=\'gt\' for inner bound + filter_op=\'lt\' for outer bound on same field. ';
 
 /** Warning shared by list-family builders and LIST_ADVANCED_NOTES about API ordering. */
 const ASCENDING_ID_WARNING =
@@ -303,12 +303,23 @@ export function buildUnpostedTimeEntriesDescription(
 
 export function buildCompanySearchByDomainDescription(resourceName: string): string {
 	return (
-		'Search companies by domain using website-style fields. ' +
+		'Legacy company domain search using website-style fields (preferred AI operation: searchByIdentity). ' +
 		'Input can be a bare domain or full URL; the tool normalises it to a domain fragment (for example autotask.net). ' +
 		'IMPORTANT: Autotask typically stores company websites as full URLs (for example https://www.autotask.net/), so exact operator matches can fail on bare domain input. ' +
 		'To avoid false negatives, eq/like semantics are handled safely for website matching. ' +
 		'When searchContactEmails is true (default), if no company website matches exist, the tool searches Contact.emailAddress by domain and resolves the most common canonical company name from companyID references. ' +
 		"Use the 'fields' parameter to limit which company fields are returned per result (comma-separated); omit to receive the full company entity. matchedField and matchedValue are always included to indicate which website field matched and its value. " +
+		describeFieldsHint(resourceName)
+	);
+}
+
+export function buildCompanySearchByIdentityDescription(resourceName: string): string {
+	return (
+		'Preferred AI company resolution operation. Accepts companyName, email, and website/domain, then ranks candidates by confidence. ' +
+		'Domain is normalised from website first, then email; domain matching is attempted first (company website fields, then contact-email fallback). ' +
+		'If domain signals are weak or absent, companyName contains matching is executed and merged into a confidence-ranked candidate list. ' +
+		'Use this operation as first choice for company lookup when identity hints may be incomplete or noisy. ' +
+		"Use the 'fields' parameter to limit returned company fields; omit for full records. " +
 		describeFieldsHint(resourceName)
 	);
 }
@@ -345,7 +356,7 @@ export function buildGetFullDetailDescription(resource: string): string {
 			"Supply EITHER numeric 'id' OR 'ticketNumber' (e.g. T20240615.0123). " +
 			"Response includes all ticket fields, 'slaStatus' (breached/compliant/paused/no_sla/unknown), " +
 			"'slaBreachDateTime' (resolvedDueDateTime), and 'summaryText' (plain-English one-liner). " +
-			"Use this instead of calling get + slaHealthCheck separately when you need both ticket data and SLA status. " +
+			'Use this instead of calling get + slaHealthCheck separately when you need both ticket data and SLA status. ' +
 			describeFieldsHint(resource)
 		);
 	}
@@ -421,7 +432,7 @@ export function buildCountByPeriodDescription(resource: string): string {
 	return (
 		`Count ${recordsLabel} created within a named time period. Required: 'period' (e.g. 'this_month', 'last_quarter'). ` +
 		`Optional: ${optionalHint}. ` +
-		"Returns matchCount plus the period date bounds used."
+		'Returns matchCount plus the period date bounds used.'
 	);
 }
 
@@ -453,12 +464,12 @@ export function buildGetByAgeDescription(resource: string): string {
 
 export function buildTicketSearchByKeywordDescription(_resource: string): string {
 	return (
-		"Cross-entity full-text search for tickets by keyword. " +
+		'Cross-entity full-text search for tickets by keyword. ' +
 		"Required: 'keyword' (case-insensitive contains-match). " +
 		"Always searches ticket 'title' and 'description'. " +
 		"Optional: 'includeNotes'=true to also search TicketNotes.description; 'includeTimeEntries'=true to also search TimeEntries.summaryNotes. " +
 		"Each returned ticket gets a 'matchedIn' array (e.g. ['title','notes']) indicating which sources matched. " +
-		"Per-stage cap: 200 records. " +
+		'Per-stage cap: 200 records. ' +
 		"Use 'recency', 'since', or 'until' to constrain by date (applied post-merge to merged results; use 'recency_field' to specify which date field). " +
 		"Use 'returnAll' for the full deduplicated result set."
 	);
@@ -720,7 +731,7 @@ const LIST_ADVANCED_NOTES = [
 const SEARCH_BY_KEYWORD_NOTES: readonly string[] = [
 	"Use 'limit' (default 10) or 'returnAll=true' to control result count from the merged set.",
 	"Use 'recency', 'since', or 'until' to filter by creation date — applied post-merge, not per-stage.",
-	"Per-stage cap is 200 records. If a stage hits the cap, set includeNotes/includeTimeEntries=false or narrow the keyword.",
+	'Per-stage cap is 200 records. If a stage hits the cap, set includeNotes/includeTimeEntries=false or narrow the keyword.',
 ];
 
 /** Static parameter map for read and metadata operations */
@@ -864,6 +875,36 @@ const READ_OP_PARAMS: Record<string, { required: OperationParam[]; optional: Ope
 				field: 'searchContactEmails',
 				type: 'boolean',
 				description: 'Fall back to contact email search if no website match (default true).',
+			},
+			{
+				field: 'fields',
+				type: 'string',
+				description: 'Comma-separated company field names to return.',
+			},
+		],
+	},
+	searchByIdentity: {
+		required: [],
+		optional: [
+			{
+				field: 'companyName',
+				type: 'string',
+				description: 'Optional company name signal (contains match).',
+			},
+			{
+				field: 'email',
+				type: 'string',
+				description: 'Optional email signal used to infer domain.',
+			},
+			{
+				field: 'website',
+				type: 'string',
+				description: 'Optional website/domain signal used for primary match.',
+			},
+			{
+				field: 'limit',
+				type: 'number',
+				description: 'Max ranked candidates to return (1-100, default 25).',
 			},
 			{
 				field: 'fields',
@@ -1120,13 +1161,11 @@ function buildWriteParams(
 			},
 		);
 	}
-	optional.push(
-		{
-			field: 'impersonationResourceId',
-			type: 'number | string',
-			description: 'Resource ID or name for write attribution (auto-resolved).',
-		},
-	);
+	optional.push({
+		field: 'impersonationResourceId',
+		type: 'number | string',
+		description: 'Resource ID or name for write attribution (auto-resolved).',
+	});
 	return { required, optional };
 }
 
@@ -1158,6 +1197,8 @@ function getOperationPurpose(
 			return buildUnpostedTimeEntriesDescription(resource);
 		case 'searchByDomain':
 			return buildCompanySearchByDomainDescription(resource);
+		case 'searchByIdentity':
+			return buildCompanySearchByIdentityDescription(resource);
 		case 'slaHealthCheck':
 			return buildTicketSlaHealthCheckDescription(resource);
 		case 'summary':

--- a/nodes/Autotask/ai-tools/field-validator.ts
+++ b/nodes/Autotask/ai-tools/field-validator.ts
@@ -3,165 +3,162 @@ import type { FlatErrorResponse } from './error-formatter';
 import { formatFieldError, formatIdError, formatRequiredFieldsError } from './error-formatter';
 
 interface ValidationSuccess {
-    valid: true;
+	valid: true;
 }
 
 interface ValidationFailure {
-    valid: false;
-    error: FlatErrorResponse;
+	valid: false;
+	error: FlatErrorResponse;
 }
 
 export type ValidationResult = ValidationSuccess | ValidationFailure;
 
 function sampleValidFields(fields: FieldMeta[], limit = 20): string[] {
-    return fields.slice(0, limit).map((field) => field.id);
+	return fields.slice(0, limit).map((field) => field.id);
 }
 
 function isEmptyValue(value: unknown): boolean {
-    return value === undefined || value === null || value === '';
+	return value === undefined || value === null || value === '';
 }
 
 function getFieldValueCaseInsensitive(
-    fieldValues: Record<string, unknown>,
-    fieldId: string,
+	fieldValues: Record<string, unknown>,
+	fieldId: string,
 ): unknown {
-    const matchKey = Object.keys(fieldValues).find(
-        (key) => key.toLowerCase() === fieldId.toLowerCase(),
-    );
-    return matchKey ? fieldValues[matchKey] : undefined;
+	const matchKey = Object.keys(fieldValues).find(
+		(key) => key.toLowerCase() === fieldId.toLowerCase(),
+	);
+	return matchKey ? fieldValues[matchKey] : undefined;
 }
 
 export function validateReadFields(
-    selectedColumns: string[],
-    readFields: FieldMeta[],
-    resource: string,
-    operation: string,
+	selectedColumns: string[],
+	readFields: FieldMeta[],
+	resource: string,
+	operation: string,
 ): ValidationResult {
-    if (!selectedColumns.length || !readFields.length) {
-        return { valid: true };
-    }
+	if (!selectedColumns.length || !readFields.length) {
+		return { valid: true };
+	}
 
-    const readFieldSet = new Set(readFields.map((field) => field.id.toLowerCase()));
-    const invalidFields = selectedColumns.filter(
-        (field) => !readFieldSet.has(field.toLowerCase()),
-    );
+	const readFieldSet = new Set(readFields.map((field) => field.id.toLowerCase()));
+	const invalidFields = selectedColumns.filter((field) => !readFieldSet.has(field.toLowerCase()));
 
-    if (!invalidFields.length) {
-        return { valid: true };
-    }
+	if (!invalidFields.length) {
+		return { valid: true };
+	}
 
-    return {
-        valid: false,
-        error: formatFieldError(
-            'INVALID_FIELDS',
-            resource,
-            operation,
-            invalidFields,
-            sampleValidFields(readFields),
-        ),
-    };
+	return {
+		valid: false,
+		error: formatFieldError(
+			'INVALID_FIELDS',
+			resource,
+			operation,
+			invalidFields,
+			sampleValidFields(readFields),
+		),
+	};
 }
 
 export function validateWriteFields(
-    fieldValues: Record<string, unknown>,
-    writeFields: FieldMeta[],
-    resource: string,
-    operation: string,
+	fieldValues: Record<string, unknown>,
+	writeFields: FieldMeta[],
+	resource: string,
+	operation: string,
 ): ValidationResult {
-    if (!writeFields.length) {
-        return { valid: true };
-    }
+	if (!writeFields.length) {
+		return { valid: true };
+	}
 
-    const writeFieldSet = new Set(writeFields.map((field) => field.id.toLowerCase()));
-    const providedFields = Object.keys(fieldValues);
+	const writeFieldSet = new Set(writeFields.map((field) => field.id.toLowerCase()));
+	const providedFields = Object.keys(fieldValues);
 
-    const invalidFields = providedFields.filter(
-        (field) => !writeFieldSet.has(field.toLowerCase()),
-    );
+	const invalidFields = providedFields.filter((field) => !writeFieldSet.has(field.toLowerCase()));
 
-    if (invalidFields.length > 0) {
-        return {
-            valid: false,
-            error: formatFieldError(
-                'INVALID_WRITE_FIELDS',
-                resource,
-                operation,
-                invalidFields,
-                sampleValidFields(writeFields),
-            ),
-        };
-    }
+	if (invalidFields.length > 0) {
+		return {
+			valid: false,
+			error: formatFieldError(
+				'INVALID_WRITE_FIELDS',
+				resource,
+				operation,
+				invalidFields,
+				sampleValidFields(writeFields),
+			),
+		};
+	}
 
-    if (operation === 'create' || operation === 'createIfNotExists') {
-        const missingRequiredFields = writeFields
-            .filter((field) => field.required)
-            .map((field) => field.id)
-            .filter((fieldId) => isEmptyValue(getFieldValueCaseInsensitive(fieldValues, fieldId)));
+	if (operation === 'create' || operation === 'createIfNotExists') {
+		const missingRequiredFields = writeFields
+			.filter((field) => field.required)
+			.map((field) => field.id)
+			.filter((fieldId) => isEmptyValue(getFieldValueCaseInsensitive(fieldValues, fieldId)));
 
-        if (missingRequiredFields.length > 0) {
-            return {
-                valid: false,
-                error: formatRequiredFieldsError(resource, operation, missingRequiredFields),
-            };
-        }
-    }
+		if (missingRequiredFields.length > 0) {
+			return {
+				valid: false,
+				error: formatRequiredFieldsError(resource, operation, missingRequiredFields),
+			};
+		}
+	}
 
-    return { valid: true };
+	return { valid: true };
 }
 
 export function validateEntityId(
-    idValue: string | number | undefined,
-    resource: string,
-    operation: string,
+	idValue: string | number | undefined,
+	resource: string,
+	operation: string,
 ): ValidationResult {
-    const noIdOperations = [
-        'getMany',
-        'searchByDomain',
-        'getPosted',
-        'getUnposted',
-        'count',
-        'create',
-        'createIfNotExists',
-        'moveToCompany',
-        'moveConfigurationItem',
-        'transferOwnership',
-        'whoAmI',
-        'slaHealthCheck',
-        'summary',
-        'getByResource',
-        'getByYear',
-        'getByCompanyAndStatus',
-        'getUnassigned',
-        'getBySLAStatus',
-        'getFullDetail',
-        'countByPeriod',
-        'getByAge',
-        'searchByKeyword',
-    ];
-    if (noIdOperations.includes(operation)) {
-        return { valid: true };
-    }
+	const noIdOperations = [
+		'getMany',
+		'searchByIdentity',
+		'searchByDomain',
+		'getPosted',
+		'getUnposted',
+		'count',
+		'create',
+		'createIfNotExists',
+		'moveToCompany',
+		'moveConfigurationItem',
+		'transferOwnership',
+		'whoAmI',
+		'slaHealthCheck',
+		'summary',
+		'getByResource',
+		'getByYear',
+		'getByCompanyAndStatus',
+		'getUnassigned',
+		'getBySLAStatus',
+		'getFullDetail',
+		'countByPeriod',
+		'getByAge',
+		'searchByKeyword',
+	];
+	if (noIdOperations.includes(operation)) {
+		return { valid: true };
+	}
 
-    // resourceTimeOffAdditional.update uses resourceID from fieldsToMap as the path parameter
-    // (PATCH Resources/{resourceID}/TimeOffAdditional) — there is no separate entity-level ID
-    if (resource === 'resourceTimeOffAdditional' && operation === 'update') {
-        return { valid: true };
-    }
+	// resourceTimeOffAdditional.update uses resourceID from fieldsToMap as the path parameter
+	// (PATCH Resources/{resourceID}/TimeOffAdditional) — there is no separate entity-level ID
+	if (resource === 'resourceTimeOffAdditional' && operation === 'update') {
+		return { valid: true };
+	}
 
-    if (idValue === undefined || idValue === '') {
-        return {
-            valid: false,
-            error: formatIdError(resource, operation),
-        };
-    }
+	if (idValue === undefined || idValue === '') {
+		return {
+			valid: false,
+			error: formatIdError(resource, operation),
+		};
+	}
 
-    const idString = String(idValue).trim();
-    if (!/^\d+$/.test(idString)) {
-        return {
-            valid: false,
-            error: formatIdError(resource, operation),
-        };
-    }
+	const idString = String(idValue).trim();
+	if (!/^\d+$/.test(idString)) {
+		return {
+			valid: false,
+			error: formatIdError(resource, operation),
+		};
+	}
 
-    return { valid: true };
+	return { valid: true };
 }

--- a/nodes/Autotask/ai-tools/operation-handlers/operation-dispatch.ts
+++ b/nodes/Autotask/ai-tools/operation-handlers/operation-dispatch.ts
@@ -184,7 +184,7 @@ export function dispatchOperationResponse(
 		}
 	};
 
-	if (responseKind === 'list' && operation !== 'searchByDomain') {
+	if (responseKind === 'list' && !['searchByDomain', 'searchByIdentity'].includes(operation)) {
 		const hasFilters = !!(
 			params.filter_field ||
 			params.filter_field_2 ||
@@ -246,8 +246,10 @@ export function dispatchOperationResponse(
 				['filter_field', 'filter_op'],
 				['filter_field_2', 'filter_op_2'],
 			] as const) {
-				const field = typeof params[fieldKey] === 'string' ? (params[fieldKey] as string).trim() : '';
-				const op = typeof params[opKey] === 'string' ? (params[opKey] as string).toLowerCase() : 'eq';
+				const field =
+					typeof params[fieldKey] === 'string' ? (params[fieldKey] as string).trim() : '';
+				const op =
+					typeof params[opKey] === 'string' ? (params[opKey] as string).toLowerCase() : 'eq';
 				const val = params[fieldKey === 'filter_field' ? 'filter_value' : 'filter_value_2'];
 				if (!field || typeof val !== 'string' || (op !== 'eq' && op !== 'equals')) continue;
 				const fieldMeta = (context.readFields ?? []).find(
@@ -287,8 +289,7 @@ export function dispatchOperationResponse(
 			maxQueryLimit: MAX_QUERY_LIMIT,
 			serverCap: context.serverCap ?? MAX_QUERY_LIMIT,
 			clientCap: context.clientCap ?? MAX_RESPONSE_RECORDS,
-			serverCapReached:
-				context.serverCapReached === true || context.recencyWindowLimited === true,
+			serverCapReached: context.serverCapReached === true || context.recencyWindowLimited === true,
 		});
 		const hasMore = continuationContract.continuation?.hasMore === true;
 		const nextOffset = continuationContract.continuation?.nextOffset;
@@ -297,7 +298,8 @@ export function dispatchOperationResponse(
 
 		// Count-injection override: executor-supplied total takes precedence over fetched-count heuristic.
 		// When the sequential/parallel count query succeeded, its result is the authoritative totalAvailable.
-		const injectedTotal = (context as ToolResponseContext & { injectedTotalAvailable?: number }).injectedTotalAvailable;
+		const injectedTotal = (context as ToolResponseContext & { injectedTotalAvailable?: number })
+			.injectedTotalAvailable;
 		if (injectedTotal !== undefined) {
 			totalAvailable = injectedTotal;
 		}
@@ -359,10 +361,16 @@ export function dispatchOperationResponse(
 			typeof firstRecord.item === 'object' &&
 			!Array.isArray(firstRecord.item)
 				? (firstRecord.item as Record<string, unknown>)
-				: firstRecord ?? undefined;
+				: (firstRecord ?? undefined);
 
 		return JSON.stringify(
-			buildMutationResponse(resource, operation, validation.id ?? 'unknown', mutationRecord, context),
+			buildMutationResponse(
+				resource,
+				operation,
+				validation.id ?? 'unknown',
+				mutationRecord,
+				context,
+			),
 		);
 	}
 
@@ -421,6 +429,37 @@ export function dispatchOperationResponse(
 			const resolvedLabels = toResolvedLabels(context.resolutions);
 			return JSON.stringify({
 				summary: `Found ${records.length} ${resource} records — complete set, no further calls needed.`,
+				resource,
+				operation: `${resource}.${operation}`,
+				records,
+				returnedCount: records.length,
+				hasMore: false,
+				continuation: null,
+				isTruncated: false,
+				truncationReason: null,
+				serverCap: MAX_QUERY_LIMIT,
+				clientCap: MAX_RESPONSE_RECORDS,
+				resolvedLabels,
+				pendingConfirmations: context.pendingConfirmations ?? [],
+				warnings: context.resolutionWarnings ?? [],
+			});
+		}
+
+		case 'searchByIdentity': {
+			if (records.length === 0) {
+				return JSON.stringify(
+					wrapError(
+						resource,
+						operation,
+						ERROR_TYPES.NO_RESULTS_FOUND,
+						`No ${resource} found matching the supplied identity signals.`,
+						`Retry with additional hints (companyName, email, website), or use autotask_${resource} with operation 'getMany' with a filter.`,
+					),
+				);
+			}
+			const resolvedLabels = toResolvedLabels(context.resolutions);
+			return JSON.stringify({
+				summary: `Found ${records.length} ranked ${resource} candidates — complete set, no further calls needed.`,
 				resource,
 				operation: `${resource}.${operation}`,
 				records,

--- a/nodes/Autotask/ai-tools/operation-metadata.ts
+++ b/nodes/Autotask/ai-tools/operation-metadata.ts
@@ -59,12 +59,21 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		docsFragment: 'Get unposted time entries with optional filters.',
 	},
 	{
+		name: 'searchByIdentity',
+		isWrite: false,
+		label: 'Search by identity',
+		supportsFilters: false,
+		responseKind: 'list',
+		docsFragment:
+			'Preferred AI company resolution using companyName/email/website with ranked confidence.',
+	},
+	{
 		name: 'searchByDomain',
 		isWrite: false,
 		label: 'Search by domain',
 		supportsFilters: false,
 		responseKind: 'list',
-		docsFragment: 'Search companies by domain string.',
+		docsFragment: 'Legacy company domain search (prefer searchByIdentity for AI).',
 	},
 	{
 		name: 'count',
@@ -172,7 +181,8 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		label: 'Get by company and status',
 		supportsFilters: true,
 		responseKind: 'list',
-		docsFragment: "Filter records by company (required, auto-resolved) and optionally by status or priority.",
+		docsFragment:
+			'Filter records by company (required, auto-resolved) and optionally by status or priority.',
 	},
 	{
 		name: 'getUnassigned',
@@ -180,7 +190,8 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		label: 'Get unassigned open records',
 		supportsFilters: true,
 		responseKind: 'list',
-		docsFragment: "Return open, unassigned records (assigned resource absent, status not terminal).",
+		docsFragment:
+			'Return open, unassigned records (assigned resource absent, status not terminal).',
 	},
 	{
 		name: 'getBySLAStatus',
@@ -188,7 +199,8 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		label: 'Get by SLA status',
 		supportsFilters: true,
 		responseKind: 'list',
-		docsFragment: "Filter tickets by SLA state: breached, at_risk (within atRiskWindowHours of deadline), or compliant.",
+		docsFragment:
+			'Filter tickets by SLA state: breached, at_risk (within atRiskWindowHours of deadline), or compliant.',
 	},
 	{
 		name: 'getFullDetail',
@@ -196,7 +208,8 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		label: 'Get full detail',
 		supportsFilters: false,
 		responseKind: 'item',
-		docsFragment: "Get a record's fields plus a summary in one call (tickets also include SLA status). Requires 'id' (tickets also accept 'ticketNumber').",
+		docsFragment:
+			"Get a record's fields plus a summary in one call (tickets also include SLA status). Requires 'id' (tickets also accept 'ticketNumber').",
 	},
 	{
 		name: 'countByPeriod',
@@ -204,7 +217,8 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		label: 'Count by period',
 		supportsFilters: false,
 		responseKind: 'count',
-		docsFragment: "Count records created within a named period (today, this_month, last_quarter, etc.). Optional: company, status, priority.",
+		docsFragment:
+			'Count records created within a named period (today, this_month, last_quarter, etc.). Optional: company, status, priority.',
 	},
 	{
 		name: 'getByAge',
@@ -212,7 +226,8 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		label: 'Get by age',
 		supportsFilters: true,
 		responseKind: 'list',
-		docsFragment: "Return records created more than N days ago. Required: olderThanDays (positive integer). Optional: status, company, priority.",
+		docsFragment:
+			'Return records created more than N days ago. Required: olderThanDays (positive integer). Optional: status, company, priority.',
 	},
 	{
 		name: 'searchByKeyword',
@@ -237,8 +252,7 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		label: 'Reject time off request',
 		supportsFilters: false,
 		responseKind: 'mutation',
-		docsFragment:
-			"Reject a pending time off request by numeric 'id', with optional rejectReason.",
+		docsFragment: "Reject a pending time off request by numeric 'id', with optional rejectReason.",
 	},
 ];
 
@@ -248,9 +262,9 @@ export const OPERATION_METADATA: Readonly<Record<string, OperationMetadata>> = O
 
 export const SUPPORTED_TOOL_OPERATIONS = OPERATION_METADATA_LIST.map((operation) => operation.name);
 
-export const WRITE_OPERATIONS = OPERATION_METADATA_LIST
-	.filter((operation) => operation.isWrite)
-	.map((operation) => operation.name);
+export const WRITE_OPERATIONS = OPERATION_METADATA_LIST.filter(
+	(operation) => operation.isWrite,
+).map((operation) => operation.name);
 
 export function getOperationMetadata(operation: string): OperationMetadata | undefined {
 	return OPERATION_METADATA[operation];

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -18,8 +18,7 @@ const IMPERSONATION_RESOURCE_ID_DESCRIBE =
 	'Resource ID, name, or email to impersonate for write attribution (auto-resolved).';
 
 /** Shared proceedWithoutImpersonationIfDenied description — used at all 5 schema insertion sites. */
-const IMPERSONATION_PROCEED_DESCRIBE =
-	'If impersonation denied, retry without it (default true).';
+const IMPERSONATION_PROCEED_DESCRIBE = 'If impersonation denied, retry without it (default true).';
 
 function getSchemaFieldSignature(fields: FieldMeta[]): string {
 	return fields
@@ -37,7 +36,11 @@ function getSchemaFieldSignature(fields: FieldMeta[]): string {
 		.join('|');
 }
 
-function getReadOnlySchemaCacheKey(resource: string, operations: string[], readFields: FieldMeta[]): string {
+function getReadOnlySchemaCacheKey(
+	resource: string,
+	operations: string[],
+	readFields: FieldMeta[],
+): string {
 	const opSig = [...operations].sort().join(',');
 	return `${resource}|${opSig}|${getSchemaFieldSignature(readFields)}`;
 }
@@ -213,8 +216,8 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			resource,
 			summary: {
 				operations,
-				hasListFamilyOps: operations.some((op) =>
-					getOperationMetadata(op)?.supportsFilters === true,
+				hasListFamilyOps: operations.some(
+					(op) => getOperationMetadata(op)?.supportsFilters === true,
 				),
 				hasWriteFamilyOps: operations.some((op) => isWriteOperation(op)),
 				hasIdentifierPairOps: Boolean(IDENTIFIER_PAIR_OPERATIONS[resource]),
@@ -246,9 +249,8 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			: [];
 		const hasIdPairOps = idPairOps.length > 0;
 		const hasGetFullDetail = operations.includes('getFullDetail');
-		const fullDetailUsesIdPair = hasGetFullDetail
-			&& !!idPairConfig
-			&& idPairConfig.operations.includes('getFullDetail');
+		const fullDetailUsesIdPair =
+			hasGetFullDetail && !!idPairConfig && idPairConfig.operations.includes('getFullDetail');
 		const hasGetFullDetailIdOnly = hasGetFullDetail && !fullDetailUsesIdPair;
 
 		// operation — required enum
@@ -256,6 +258,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		// not here. Runtime enforcement is via operation-contracts.ts xorGroups.
 		const operationDesc = `Operation to perform. One of: ${allOps.join(', ')}`;
 		shape.operation = rz.enum(allOps).describe(operationDesc);
+		const hasSearchByIdentity = operations.includes('searchByIdentity');
 		const hasSearchByDomain = operations.includes('searchByDomain');
 		const hasMoveConfigItem = operations.includes('moveConfigurationItem');
 		const hasMoveToCompany = operations.includes('moveToCompany');
@@ -266,7 +269,14 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		const hasGetByYear = operations.includes('getByYear');
 
 		// id — used by get, delete, update, identifier-pair ops (e.g. slaHealthCheck, summary), approve, reject, getFullDetail (id-only mode)
-		if (hasGet || hasDeleteOp || hasUpdate || hasIdPairOps || hasApproveOrReject || hasGetFullDetailIdOnly) {
+		if (
+			hasGet ||
+			hasDeleteOp ||
+			hasUpdate ||
+			hasIdPairOps ||
+			hasApproveOrReject ||
+			hasGetFullDetailIdOnly
+		) {
 			const strictIdOps: string[] = [];
 			if (hasGet) strictIdOps.push('get');
 			if (hasDeleteOp) strictIdOps.push('delete');
@@ -288,9 +298,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.resourceID = rz
 				.union([rz.number(), rz.string()])
 				.nullish()
-				.describe(
-					'Resource ID or name (auto-resolved). Required for getByResource and getByYear.',
-				);
+				.describe('Resource ID or name (auto-resolved). Required for getByResource and getByYear.');
 		}
 
 		// year — used by getByYear
@@ -311,9 +319,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.rejectReasonPolicy = rz
 				.enum(['optional', 'mandatory'])
 				.nullish()
-				.describe(
-					"Reject-reason policy for reject operation. 'mandatory' requires rejectReason.",
-				);
+				.describe("Reject-reason policy for reject operation. 'mandatory' requires rejectReason.");
 		}
 
 		// fields — column selection
@@ -337,9 +343,15 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					? rz
 							.enum(fieldNames as [string, ...string[]])
 							.nullish()
-							.describe("Field to filter on. For 'older than' / upper-bound date queries, use a date field (createDate, lastActivityDate, dueDateTime) with filter_op='lt'.")
+							.describe(
+								"Field to filter on. For 'older than' / upper-bound date queries, use a date field (createDate, lastActivityDate, dueDateTime) with filter_op='lt'.",
+							)
 					: rz.string().nullish().describe(filterFieldDesc);
-			shape.filter_op = rFilterOpEnum.nullish().describe("Filter operator. Use 'notExist' for unassigned/empty/null fields (no filter_value needed). Use 'exist' for populated fields. Other operators: eq (equals), noteq (not equals), gt/gte/lt/lte (numeric/date comparisons), contains/beginsWith/endsWith (text), in/notIn (array of values).");
+			shape.filter_op = rFilterOpEnum
+				.nullish()
+				.describe(
+					"Filter operator. Use 'notExist' for unassigned/empty/null fields (no filter_value needed). Use 'exist' for populated fields. Other operators: eq (equals), noteq (not equals), gt/gte/lt/lte (numeric/date comparisons), contains/beginsWith/endsWith (text), in/notIn (array of values).",
+				);
 			shape.filter_value = rFilterValueSchema.nullish();
 			shape.filter_field_2 = rz
 				.string()
@@ -352,9 +364,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.filter_logic = rz
 				.enum(['and', 'or'])
 				.nullish()
-				.describe(
-					"Combiner between the two filter pairs: 'and' (default) or 'or'.",
-				);
+				.describe("Combiner between the two filter pairs: 'and' (default) or 'or'.");
 			shape.limit = rz
 				.number()
 				.int()
@@ -391,10 +401,11 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.until = rz
 				.string()
 				.nullish()
+				.describe('Range end (ISO-8601). Requires since or recency.');
+			shape.filtersJson = rz
+				.string()
+				.nullish()
 				.describe(
-					'Range end (ISO-8601). Requires since or recency.',
-				);
-			shape.filtersJson = rz.string().nullish().describe(
 					'JSON IFilterCondition array. No label resolution — use numeric IDs (call listPicklistValues for picklist IDs). Mutually exclusive with filter_field. Dates UTC.',
 				);
 			shape.returnAll = rz
@@ -406,9 +417,30 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.outputMode = rz
 				.enum(['idsAndLabels', 'rawIds'])
 				.nullish()
-				.describe(
-					"'idsAndLabels' (default, enriched with labels) or 'rawIds' (lighter).",
-				);
+				.describe("'idsAndLabels' (default, enriched with labels) or 'rawIds' (lighter).");
+		}
+
+		// searchByIdentity fields
+		if (hasSearchByIdentity) {
+			shape.companyName = rz
+				.string()
+				.nullish()
+				.describe('Optional company name for contains matching and ranking.');
+			shape.email = rz
+				.string()
+				.nullish()
+				.describe('Optional email used to infer domain for matching.');
+			shape.website = rz
+				.string()
+				.nullish()
+				.describe('Optional website/domain used for primary domain matching.');
+			shape.limit = rz
+				.number()
+				.int()
+				.min(1)
+				.max(100)
+				.nullish()
+				.describe('Max results (1-100, default 25).');
 		}
 
 		// searchByDomain fields
@@ -426,6 +458,13 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.boolean()
 				.nullish()
 				.describe('When true (default), fall back to contact email search if no website match.');
+			shape.limit = rz
+				.number()
+				.int()
+				.min(1)
+				.max(100)
+				.nullish()
+				.describe('Max results (1-100, default 25).');
 		}
 
 		// slaHealthCheck fields
@@ -491,14 +530,18 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				shape.slaStatus = rz
 					.enum(['breached', 'at_risk', 'compliant'])
 					.nullish()
-					.describe("Required for getBySLAStatus: 'breached' (SLA missed), 'at_risk' (within atRiskWindowHours of deadline), or 'compliant' (SLA met).");
+					.describe(
+						"Required for getBySLAStatus: 'breached' (SLA missed), 'at_risk' (within atRiskWindowHours of deadline), or 'compliant' (SLA met).",
+					);
 			}
 			if (!shape.atRiskWindowHours) {
 				shape.atRiskWindowHours = rz
 					.number()
 					.positive()
 					.nullish()
-					.describe('Hours before resolvedDueDateTime to consider a ticket at-risk (default 4). Only applies when slaStatus=at_risk.');
+					.describe(
+						'Hours before resolvedDueDateTime to consider a ticket at-risk (default 4). Only applies when slaStatus=at_risk.',
+					);
 			}
 			if (!shape.company) {
 				shape.company = rz
@@ -513,7 +556,17 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		if (hasCountByPeriod) {
 			if (!shape.period) {
 				shape.period = rz
-					.enum(['today', 'this_week', 'last_7d', 'this_month', 'last_month', 'this_quarter', 'last_quarter', 'last_30d', 'last_90d'])
+					.enum([
+						'today',
+						'this_week',
+						'last_7d',
+						'this_month',
+						'last_month',
+						'this_quarter',
+						'last_quarter',
+						'last_30d',
+						'last_90d',
+					])
 					.nullish()
 					.describe('Required for countByPeriod: named period preset for createDate range.');
 			}
@@ -546,11 +599,25 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					.int()
 					.positive()
 					.nullish()
-					.describe('Required for getByAge: return records older than N days (e.g. 30 for records created more than 30 days ago). Positive integer.');
+					.describe(
+						'Required for getByAge: return records older than N days (e.g. 30 for records created more than 30 days ago). Positive integer.',
+					);
 			}
-			if (!shape.company) shape.company = rz.union([rz.number(), rz.string()]).nullish().describe('Company name or companyID (auto-resolved).');
-			if (!shape.status) shape.status = rz.union([rz.number(), rz.string()]).nullish().describe('Status picklist label or ID (optional).');
-			if (RESOURCES_WITH_PRIORITY.has(resource) && !shape.priority) shape.priority = rz.union([rz.number(), rz.string()]).nullish().describe('Priority picklist label or ID (optional).');
+			if (!shape.company)
+				shape.company = rz
+					.union([rz.number(), rz.string()])
+					.nullish()
+					.describe('Company name or companyID (auto-resolved).');
+			if (!shape.status)
+				shape.status = rz
+					.union([rz.number(), rz.string()])
+					.nullish()
+					.describe('Status picklist label or ID (optional).');
+			if (RESOURCES_WITH_PRIORITY.has(resource) && !shape.priority)
+				shape.priority = rz
+					.union([rz.number(), rz.string()])
+					.nullish()
+					.describe('Priority picklist label or ID (optional).');
 		}
 
 		// searchByKeyword fields
@@ -961,7 +1028,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					.boolean()
 					.nullish()
 					.describe(
-						"If true, error on duplicate instead of returning outcome: skipped. Default false.",
+						'If true, error on duplicate instead of returning outcome: skipped. Default false.',
 					);
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
@@ -984,32 +1051,19 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			);
 
 		// listPicklistValues fields
-		shape.fieldId = rz
-			.string()
-			.nullish()
-			.describe(
-				'Field ID. Required for listPicklistValues.',
-			);
-		shape.query = rz
-			.string()
-			.nullish()
-			.describe('Search term to filter picklist values.');
+		shape.fieldId = rz.string().nullish().describe('Field ID. Required for listPicklistValues.');
+		shape.query = rz.string().nullish().describe('Search term to filter picklist values.');
 		if (!shape.limit) {
 			shape.limit = rz
 				.number()
 				.nullish()
 				.describe('Max results (used by listPicklistValues for pagination, default 50).');
 		}
-		shape.page = rz
-			.number()
-			.nullish()
-			.describe('Page for listPicklistValues (default 1).');
+		shape.page = rz.number().nullish().describe('Page for listPicklistValues (default 1).');
 		shape.targetOperation = rz
 			.string()
 			.nullish()
-			.describe(
-				"For describeOperation: the operation name to document (e.g. 'create').",
-			);
+			.describe("For describeOperation: the operation name to document (e.g. 'create').");
 
 		// Typed-reference companion fields (ticketLookupField, projectLookupField, …).
 		// Emitted outside the hasCreate||hasUpdate block so they are available on
@@ -1017,9 +1071,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		const allFields = [...writeFields, ...readFields];
 		for (const strategy of Object.values(TYPED_REFERENCE_STRATEGIES)) {
 			const hasMatchingField = allFields.some(
-				(f) =>
-					f.isReference &&
-					f.referencesEntity?.toLowerCase() === strategy.entityType,
+				(f) => f.isReference && f.referencesEntity?.toLowerCase() === strategy.entityType,
 			);
 			if (!hasMatchingField) continue;
 			if (strategy.companionFieldName in shape) continue; // de-dup guard
@@ -1028,8 +1080,8 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.nullish()
 				.describe(
 					`Search field for ${strategy.entityType} lookup when ${strategy.entityType}ID is a non-numeric label. ` +
-					`E.g. set to '${strategy.searchableFields[0]}' to find by name. ` +
-					`Not needed when supplying a ${strategy.entityType} number (${strategy.exampleValue}).`,
+						`E.g. set to '${strategy.searchableFields[0]}' to find by name. ` +
+						`Not needed when supplying a ${strategy.entityType} number (${strategy.exampleValue}).`,
 				);
 		}
 

--- a/nodes/Autotask/ai-tools/tool-executor.ts
+++ b/nodes/Autotask/ai-tools/tool-executor.ts
@@ -76,7 +76,11 @@ import {
 	COMPOUND_REGISTRY,
 	COMPOUND_PARENT_NOT_FOUND_OUTCOMES,
 } from '../constants/compound-registry';
-import { validateOperationContract, hasProvidedValue, type OperationContractViolation } from './operation-contracts';
+import {
+	validateOperationContract,
+	hasProvidedValue,
+	type OperationContractViolation,
+} from './operation-contracts';
 import { enrichResponseJson } from '../helpers/enrichment';
 import { autotaskApiRequest } from '../helpers/http';
 
@@ -162,9 +166,13 @@ const RESOURCE_CONVENIENCE_CONFIG: Record<string, ResourceConvenienceConfig> = {
 		supportsSLA: false,
 		getFullDetailMode: 'simple',
 		childCountEntities: [
-			{ queryEndpoint: 'TaskNotes/query',              parentField: 'taskID',    key: 'notes' },
-			{ queryEndpoint: 'TaskSecondaryResources/query', parentField: 'taskID',    key: 'secondaryResources' },
-			{ queryEndpoint: 'TimeEntries/query',            parentField: 'taskID',    key: 'timeEntries' },
+			{ queryEndpoint: 'TaskNotes/query', parentField: 'taskID', key: 'notes' },
+			{
+				queryEndpoint: 'TaskSecondaryResources/query',
+				parentField: 'taskID',
+				key: 'secondaryResources',
+			},
+			{ queryEndpoint: 'TimeEntries/query', parentField: 'taskID', key: 'timeEntries' },
 		],
 	},
 	project: {
@@ -179,10 +187,10 @@ const RESOURCE_CONVENIENCE_CONFIG: Record<string, ResourceConvenienceConfig> = {
 		supportsSLA: false,
 		getFullDetailMode: 'simple',
 		childCountEntities: [
-			{ queryEndpoint: 'ProjectNotes/query',   parentField: 'projectID', key: 'notes' },
+			{ queryEndpoint: 'ProjectNotes/query', parentField: 'projectID', key: 'notes' },
 			{ queryEndpoint: 'ProjectCharges/query', parentField: 'projectID', key: 'charges' },
-			{ queryEndpoint: 'Tasks/query',          parentField: 'projectID', key: 'tasks' },
-			{ queryEndpoint: 'Phases/query',         parentField: 'projectID', key: 'phases' },
+			{ queryEndpoint: 'Tasks/query', parentField: 'projectID', key: 'tasks' },
+			{ queryEndpoint: 'Phases/query', parentField: 'projectID', key: 'phases' },
 		],
 	},
 };
@@ -197,34 +205,26 @@ export async function resolveCompanyToProjectIdFilter(
 	operationName: string,
 	callerResource: string,
 ): Promise<
-	| { filter: ToolFilter; warning?: string }
-	| { empty: true }
-	| { error: FlatErrorResponse }
+	{ filter: ToolFilter; warning?: string } | { empty: true } | { error: FlatErrorResponse }
 > {
 	let companyId: number;
 	const raw = String(companyRaw).trim();
 	if (/^\d+$/.test(raw)) {
 		companyId = Number(raw);
 	} else {
-		const companyLookup = await autotaskApiRequest.call(
-			context, 'POST', 'Companies/query',
-			{
-				filter: [{ field: 'companyName', op: 'eq', value: raw }],
-				MaxRecords: 1,
-			} as IDataObject,
-		) as { items?: IAutotaskEntity[] };
+		const companyLookup = (await autotaskApiRequest.call(context, 'POST', 'Companies/query', {
+			filter: [{ field: 'companyName', op: 'eq', value: raw }],
+			MaxRecords: 1,
+		} as IDataObject)) as { items?: IAutotaskEntity[] };
 		const matches = Array.isArray(companyLookup.items) ? companyLookup.items : [];
 		if (matches.length === 0) {
 			// Try partial match to provide suggestions
 			try {
-				const partialLookup = await autotaskApiRequest.call(
-					context, 'POST', 'Companies/query',
-					{
-						filter: [{ field: 'companyName', op: 'contains', value: raw }],
-						MaxRecords: 5,
-						IncludeFields: ['id', 'companyName'],
-					} as IDataObject,
-				) as { items?: IAutotaskEntity[] };
+				const partialLookup = (await autotaskApiRequest.call(context, 'POST', 'Companies/query', {
+					filter: [{ field: 'companyName', op: 'contains', value: raw }],
+					MaxRecords: 5,
+					IncludeFields: ['id', 'companyName'],
+				} as IDataObject)) as { items?: IAutotaskEntity[] };
 				const partialMatches = Array.isArray(partialLookup.items) ? partialLookup.items : [];
 				const candidates = partialMatches.map((c) => ({
 					id: c.id as string | number,
@@ -256,14 +256,11 @@ export async function resolveCompanyToProjectIdFilter(
 		companyId = Number(matches[0].id);
 	}
 
-	const projectsResp = await autotaskApiRequest.call(
-		context, 'POST', 'Projects/query',
-		{
-			filter: [{ field: 'companyID', op: 'eq', value: companyId }],
-			MaxRecords: 500,
-			IncludeFields: ['id'],
-		} as IDataObject,
-	) as { items?: IAutotaskEntity[] };
+	const projectsResp = (await autotaskApiRequest.call(context, 'POST', 'Projects/query', {
+		filter: [{ field: 'companyID', op: 'eq', value: companyId }],
+		MaxRecords: 500,
+		IncludeFields: ['id'],
+	} as IDataObject)) as { items?: IAutotaskEntity[] };
 	const projectIds = (Array.isArray(projectsResp.items) ? projectsResp.items : [])
 		.map((p) => Number(p.id))
 		.filter((n) => Number.isFinite(n));
@@ -274,9 +271,10 @@ export async function resolveCompanyToProjectIdFilter(
 
 	return {
 		filter: { field: 'projectID', op: 'in', value: projectIds } as ToolFilter,
-		warning: projectIds.length >= 500
-			? `Company expanded to 500+ projects — task results may be incomplete. Narrow the search by date or status.`
-			: undefined,
+		warning:
+			projectIds.length >= 500
+				? `Company expanded to 500+ projects — task results may be incomplete. Narrow the search by date or status.`
+				: undefined,
 	};
 }
 
@@ -373,6 +371,8 @@ function normaliseOperation(operation: string): string {
 			return 'getUnposted';
 		case 'searchbydomain':
 			return 'searchByDomain';
+		case 'searchbyidentity':
+			return 'searchByIdentity';
 		case 'slahealthcheck':
 			return 'slaHealthCheck';
 		case 'moveconfigurationitem':
@@ -415,21 +415,21 @@ export const N8N_METADATA_FIELDS = new Set([
 export const N8N_METADATA_PREFIXES = ['Prompt__'];
 
 /** Extract the canonical created-entity numeric ID from a compound creator result. */
- 
+
 function buildCompoundEntityId(resource: string, result: any): number | undefined {
 	const field = COMPOUND_REGISTRY[resource]?.entityIdField;
 	return field ? result[field] : (result.id ?? result.itemId);
 }
 
 /** Extract the canonical existing-entity numeric ID from a compound creator result (skip/update). */
- 
+
 function buildCompoundExistingId(resource: string, result: any): number | undefined {
 	const field = COMPOUND_REGISTRY[resource]?.existingIdField;
 	return field ? result[field] : result.existingId;
 }
 
 /** Build the context block (parent/scope fields) for a compound creator result. */
- 
+
 function buildCompoundContext(resource: string, result: any): Record<string, unknown> | undefined {
 	switch (resource) {
 		case 'contractCharge':
@@ -682,7 +682,9 @@ export async function executeAiTool(
 	if (normalisedOperation === 'listPicklistValues') {
 		const fieldId = typeof params.fieldId === 'string' ? params.fieldId.trim() : '';
 		if (!fieldId) {
-			const targetOpProvided = typeof params.targetOperation === 'string' && (params.targetOperation as string).trim() !== '';
+			const targetOpProvided =
+				typeof params.targetOperation === 'string' &&
+				(params.targetOperation as string).trim() !== '';
 			const hint = targetOpProvided
 				? `'targetOperation' is for the 'describeOperation' helper, not 'listPicklistValues'. Pass 'fieldId' set to the picklist field name (e.g. 'status', 'priority').`
 				: `'fieldId' is required — pass the picklist field name (e.g. 'status', 'priority').`;
@@ -805,7 +807,6 @@ export async function executeAiTool(
 	const effectiveReturnAll = params.returnAll === true || isShortWindow;
 	const autoReturnAll = isShortWindow && params.returnAll !== true;
 
-	 
 	let combinedFilters: any[];
 	if (params.filtersJson) {
 		// filtersJson path — mutually exclusive with flat filter triplets
@@ -822,7 +823,7 @@ export async function executeAiTool(
 				correlationId,
 			);
 		}
-		 
+
 		let parsedFiltersJson: any[] = [];
 		try {
 			const parsed: unknown = JSON.parse(params.filtersJson as string);
@@ -1034,7 +1035,17 @@ export async function executeAiTool(
 	}
 
 	// Pre-flight: filter cross-validation (list operations)
-	const isListOperation = ['getMany', 'count', 'getPosted', 'getUnposted', 'getByAge', 'searchByKeyword', 'getByCompanyAndStatus', 'getUnassigned', 'getBySLAStatus'].includes(effectiveOperation);
+	const isListOperation = [
+		'getMany',
+		'count',
+		'getPosted',
+		'getUnposted',
+		'getByAge',
+		'searchByKeyword',
+		'getByCompanyAndStatus',
+		'getUnassigned',
+		'getBySLAStatus',
+	].includes(effectiveOperation);
 	if (isListOperation) {
 		const p = params as Record<string, unknown>;
 		const hasFiltersJson = hasProvidedValue(p.filtersJson);
@@ -1050,36 +1061,52 @@ export async function executeAiTool(
 		const filterErrors: string[] = [];
 
 		if (hasFiltersJson && (hasFlatFilter1 || hasFlatFilter2)) {
-			filterErrors.push(`Operation '${effectiveOperation}' does not allow mixing 'filtersJson' with flat filter fields.`);
+			filterErrors.push(
+				`Operation '${effectiveOperation}' does not allow mixing 'filtersJson' with flat filter fields.`,
+			);
 		}
 		const isNullCheckOp1 = ['exist', 'notexist'].includes(String(p.filter_op ?? '').toLowerCase());
 		if (hasProvidedValue(p.filter_field) && !hasProvidedValue(p.filter_value) && !isNullCheckOp1) {
-			filterErrors.push(`Operation '${effectiveOperation}' requires 'filter_value' when 'filter_field' is provided (not needed when filter_op is 'exist' or 'notExist').`);
+			filterErrors.push(
+				`Operation '${effectiveOperation}' requires 'filter_value' when 'filter_field' is provided (not needed when filter_op is 'exist' or 'notExist').`,
+			);
 		}
 		if (!hasProvidedValue(p.filter_field) && hasProvidedValue(p.filter_value)) {
-			filterErrors.push(`Operation '${effectiveOperation}' does not allow 'filter_value' without 'filter_field'.`);
+			filterErrors.push(
+				`Operation '${effectiveOperation}' does not allow 'filter_value' without 'filter_field'.`,
+			);
 		}
 		if (hasFlatFilter2) {
 			const hasFilter2Field = hasProvidedValue(p.filter_field_2);
 			const hasFilter2Value = hasProvidedValue(p.filter_value_2);
-			const isNullCheckOp2 = ['exist', 'notexist'].includes(String(p.filter_op_2 ?? '').toLowerCase());
+			const isNullCheckOp2 = ['exist', 'notexist'].includes(
+				String(p.filter_op_2 ?? '').toLowerCase(),
+			);
 			if (!hasFilter2Field || (!hasFilter2Value && !isNullCheckOp2)) {
 				filterErrors.push(
 					`Operation '${effectiveOperation}' requires 'filter_field_2' and 'filter_value_2' when using a second filter (filter_value_2 not needed when filter_op_2 is 'exist' or 'notExist').`,
 				);
 			}
 			if (!hasFlatFilter1) {
-				filterErrors.push(`Operation '${effectiveOperation}' does not allow a second filter without the first filter.`);
+				filterErrors.push(
+					`Operation '${effectiveOperation}' does not allow a second filter without the first filter.`,
+				);
 			}
 		}
 		if (hasProvidedValue(p.filter_logic) && !(hasFlatFilter1 && hasFlatFilter2)) {
-			filterErrors.push(`Operation '${effectiveOperation}' does not allow 'filter_logic' unless both filter pairs are present.`);
+			filterErrors.push(
+				`Operation '${effectiveOperation}' does not allow 'filter_logic' unless both filter pairs are present.`,
+			);
 		}
 		if (hasProvidedValue(p.recency) && (hasProvidedValue(p.since) || hasProvidedValue(p.until))) {
-			filterErrors.push(`Operation '${effectiveOperation}' does not allow 'recency' together with 'since' or 'until'.`);
+			filterErrors.push(
+				`Operation '${effectiveOperation}' does not allow 'recency' together with 'since' or 'until'.`,
+			);
 		}
 		if (hasProvidedValue(p.until) && !hasProvidedValue(p.since) && !hasProvidedValue(p.recency)) {
-			filterErrors.push(`Operation '${effectiveOperation}' requires 'since' or 'recency' when 'until' is provided.`);
+			filterErrors.push(
+				`Operation '${effectiveOperation}' requires 'since' or 'recency' when 'until' is provided.`,
+			);
 		}
 
 		if (filterErrors.length > 0) {
@@ -1118,9 +1145,9 @@ export async function executeAiTool(
 						.slice(0, 4);
 					invalidFieldErrors.push(
 						`${displayName} is not a valid filter field for ${resource}.` +
-						(suggestions.length > 0
-							? ` Did you mean: ${suggestions.join(', ')}?`
-							: ` Call autotask_${resource} with operation 'describeFields' to see valid fields.`),
+							(suggestions.length > 0
+								? ` Did you mean: ${suggestions.join(', ')}?`
+								: ` Call autotask_${resource} with operation 'describeFields' to see valid fields.`),
 					);
 				}
 			}
@@ -1164,9 +1191,16 @@ export async function executeAiTool(
 	}
 
 	if (
-		['get', 'getMany', 'getPosted', 'getUnposted', 'count', 'whoAmI', 'searchByDomain'].includes(
-			effectiveOperation,
-		)
+		[
+			'get',
+			'getMany',
+			'getPosted',
+			'getUnposted',
+			'count',
+			'whoAmI',
+			'searchByDomain',
+			'searchByIdentity',
+		].includes(effectiveOperation)
 	) {
 		const udfFilters = filters.filter((filter) => filter.udf);
 		if (udfFilters.length > 1) {
@@ -1395,7 +1429,7 @@ export async function executeAiTool(
 				) {
 					data.limit = queryLimit;
 				}
-				if (effectiveOperation === 'searchByDomain') {
+				if (['searchByDomain', 'searchByIdentity'].includes(effectiveOperation)) {
 					data.limit = effectiveLimit;
 				}
 				return JSON.stringify(data);
@@ -1579,7 +1613,7 @@ export async function executeAiTool(
 			};
 
 			const handler = await registryEntry.getHandler();
-			 
+
 			const compoundResult: any = await handler(context, 0, compoundOptions);
 
 			if (compoundResult) {
@@ -1709,13 +1743,25 @@ export async function executeAiTool(
 			// resolveAndClassifyFilters resolves string values to numeric IDs in-place.
 			const syntheticFilters: ToolFilter[] = [];
 			if (cfg.companyFilterStrategy === 'direct') {
-				syntheticFilters.push({ field: 'companyID', op: 'eq', value: companyRaw as string | number });
+				syntheticFilters.push({
+					field: 'companyID',
+					op: 'eq',
+					value: companyRaw as string | number,
+				});
 			}
 			if (params.status !== undefined && params.status !== null) {
-				syntheticFilters.push({ field: 'status', op: 'eq', value: params.status as string | number });
+				syntheticFilters.push({
+					field: 'status',
+					op: 'eq',
+					value: params.status as string | number,
+				});
 			}
 			if (cfg.hasPriority && params.priority !== undefined && params.priority !== null) {
-				syntheticFilters.push({ field: 'priority', op: 'eq', value: params.priority as string | number });
+				syntheticFilters.push({
+					field: 'priority',
+					op: 'eq',
+					value: params.priority as string | number,
+				});
 			}
 
 			const {
@@ -1723,7 +1769,13 @@ export async function executeAiTool(
 				warnings: specialWarningsRaw,
 				pendingConfirmations: specialPending,
 				unresolvedIdLikeFilters: specialUnresolved,
-			} = await resolveAndClassifyFilters(context, resource, syntheticFilters, readFields, params as IDataObject);
+			} = await resolveAndClassifyFilters(
+				context,
+				resource,
+				syntheticFilters,
+				readFields,
+				params as IDataObject,
+			);
 			const specialWarnings: string[] = [...specialWarningsRaw];
 
 			if (specialUnresolved.length > 0) {
@@ -1743,17 +1795,34 @@ export async function executeAiTool(
 			}
 
 			// viaProject company filter resolution (e.g. task → projects → projectID-IN)
-			if (cfg.companyFilterStrategy === 'viaProject' && companyRaw !== undefined && companyRaw !== null) {
-				const r = await resolveCompanyToProjectIdFilter(context, companyRaw as string | number, 'getByCompanyAndStatus', resource);
+			if (
+				cfg.companyFilterStrategy === 'viaProject' &&
+				companyRaw !== undefined &&
+				companyRaw !== null
+			) {
+				const r = await resolveCompanyToProjectIdFilter(
+					context,
+					companyRaw as string | number,
+					'getByCompanyAndStatus',
+					resource,
+				);
 				if ('error' in r) return attachCorrelation(JSON.stringify(r.error), correlationId);
 				if ('empty' in r) {
 					return attachCorrelation(
 						JSON.stringify(
-							buildListResponse(resource, 'getByCompanyAndStatus', [], {
-								hasMore: false, serverCap: MAX_QUERY_LIMIT, clientCap: MAX_QUERY_LIMIT,
-							}, {
-								resolutionWarnings: [`No projects found for company '${String(companyRaw)}'.`],
-							}),
+							buildListResponse(
+								resource,
+								'getByCompanyAndStatus',
+								[],
+								{
+									hasMore: false,
+									serverCap: MAX_QUERY_LIMIT,
+									clientCap: MAX_QUERY_LIMIT,
+								},
+								{
+									resolutionWarnings: [`No projects found for company '${String(companyRaw)}'.`],
+								},
+							),
 						),
 						correlationId,
 					);
@@ -1764,30 +1833,50 @@ export async function executeAiTool(
 
 			// After resolveAndClassifyFilters, syntheticFilters values are resolved in-place.
 			// Append recency filters (already built above) to apply date-range constraints.
-			const apiFilters: ToolFilter[] = [...syntheticFilters, ...(recencyResult.filters as ToolFilter[])];
+			const apiFilters: ToolFilter[] = [
+				...syntheticFilters,
+				...(recencyResult.filters as ToolFilter[]),
+			];
 
-			const queryLimitForOp = effectiveReturnAll ? undefined : (params.limit !== undefined ? getEffectiveLimit(params.limit) : DEFAULT_QUERY_LIMIT);
+			const queryLimitForOp = effectiveReturnAll
+				? undefined
+				: params.limit !== undefined
+					? getEffectiveLimit(params.limit)
+					: DEFAULT_QUERY_LIMIT;
 			const requestBody: IDataObject = { filter: apiFilters as unknown as IDataObject[] };
 			if (queryLimitForOp !== undefined) {
 				requestBody.MaxRecords = queryLimitForOp;
 			}
 
-			const gbcasResponse = await autotaskApiRequest.call(context, 'POST', cfg.queryEndpoint, requestBody) as { items?: IAutotaskEntity[] };
-			const gbcasItems = Array.isArray(gbcasResponse.items) ? gbcasResponse.items as Record<string, unknown>[] : [];
+			const gbcasResponse = (await autotaskApiRequest.call(
+				context,
+				'POST',
+				cfg.queryEndpoint,
+				requestBody,
+			)) as { items?: IAutotaskEntity[] };
+			const gbcasItems = Array.isArray(gbcasResponse.items)
+				? (gbcasResponse.items as Record<string, unknown>[])
+				: [];
 
 			const allGbcasWarnings = [...specialWarnings, ...labelWarnings];
 			const allGbcasResolutions = [...specialResolutions, ...labelResolutions];
 
 			const gbcasListJson = JSON.stringify(
-				buildListResponse(resource, 'getByCompanyAndStatus', gbcasItems, {
-					hasMore: queryLimitForOp !== undefined && gbcasItems.length >= queryLimitForOp,
-					serverCap: queryLimitForOp ?? MAX_QUERY_LIMIT,
-					clientCap: queryLimitForOp ?? MAX_QUERY_LIMIT,
-				}, {
-					resolutions: allGbcasResolutions.length > 0 ? allGbcasResolutions : undefined,
-					resolutionWarnings: allGbcasWarnings.length > 0 ? allGbcasWarnings : undefined,
-					pendingConfirmations: specialPending.length > 0 ? specialPending : undefined,
-				}),
+				buildListResponse(
+					resource,
+					'getByCompanyAndStatus',
+					gbcasItems,
+					{
+						hasMore: queryLimitForOp !== undefined && gbcasItems.length >= queryLimitForOp,
+						serverCap: queryLimitForOp ?? MAX_QUERY_LIMIT,
+						clientCap: queryLimitForOp ?? MAX_QUERY_LIMIT,
+					},
+					{
+						resolutions: allGbcasResolutions.length > 0 ? allGbcasResolutions : undefined,
+						resolutionWarnings: allGbcasWarnings.length > 0 ? allGbcasWarnings : undefined,
+						pendingConfirmations: specialPending.length > 0 ? specialPending : undefined,
+					},
+				),
 			);
 			const enrichedGbcasJson = await enrichResponseJson(gbcasListJson, context);
 			return attachCorrelation(enrichedGbcasJson, correlationId);
@@ -1804,11 +1893,23 @@ export async function executeAiTool(
 
 			// Optional: company and priority filters (resolve name→ID)
 			const optionalFilters: ToolFilter[] = [];
-			if (cfg.companyFilterStrategy === 'direct' && params.company !== undefined && params.company !== null) {
-				optionalFilters.push({ field: 'companyID', op: 'eq', value: params.company as string | number });
+			if (
+				cfg.companyFilterStrategy === 'direct' &&
+				params.company !== undefined &&
+				params.company !== null
+			) {
+				optionalFilters.push({
+					field: 'companyID',
+					op: 'eq',
+					value: params.company as string | number,
+				});
 			}
 			if (cfg.hasPriority && params.priority !== undefined && params.priority !== null) {
-				optionalFilters.push({ field: 'priority', op: 'eq', value: params.priority as string | number });
+				optionalFilters.push({
+					field: 'priority',
+					op: 'eq',
+					value: params.priority as string | number,
+				});
 			}
 
 			let specialUnresolved: ToolFilter[] = [];
@@ -1817,7 +1918,13 @@ export async function executeAiTool(
 			let specialPending: any[] = [];
 
 			if (optionalFilters.length > 0) {
-				const resolved = await resolveAndClassifyFilters(context, resource, optionalFilters, readFields, params as IDataObject);
+				const resolved = await resolveAndClassifyFilters(
+					context,
+					resource,
+					optionalFilters,
+					readFields,
+					params as IDataObject,
+				);
 				specialUnresolved = resolved.unresolvedIdLikeFilters;
 				specialResolutions = resolved.resolutions;
 				specialWarnings = resolved.warnings;
@@ -1841,17 +1948,36 @@ export async function executeAiTool(
 			}
 
 			// viaProject company filter resolution (e.g. task → projects → projectID-IN)
-			if (cfg.companyFilterStrategy === 'viaProject' && params.company !== undefined && params.company !== null) {
-				const r = await resolveCompanyToProjectIdFilter(context, params.company as string | number, 'getUnassigned', resource);
+			if (
+				cfg.companyFilterStrategy === 'viaProject' &&
+				params.company !== undefined &&
+				params.company !== null
+			) {
+				const r = await resolveCompanyToProjectIdFilter(
+					context,
+					params.company as string | number,
+					'getUnassigned',
+					resource,
+				);
 				if ('error' in r) return attachCorrelation(JSON.stringify(r.error), correlationId);
 				if ('empty' in r) {
 					return attachCorrelation(
 						JSON.stringify(
-							buildListResponse(resource, 'getUnassigned', [], {
-								hasMore: false, serverCap: MAX_QUERY_LIMIT, clientCap: MAX_QUERY_LIMIT,
-							}, {
-								resolutionWarnings: [`No projects found for company '${String(params.company)}'.`],
-							}),
+							buildListResponse(
+								resource,
+								'getUnassigned',
+								[],
+								{
+									hasMore: false,
+									serverCap: MAX_QUERY_LIMIT,
+									clientCap: MAX_QUERY_LIMIT,
+								},
+								{
+									resolutionWarnings: [
+										`No projects found for company '${String(params.company)}'.`,
+									],
+								},
+							),
 						),
 						correlationId,
 					);
@@ -1860,29 +1986,51 @@ export async function executeAiTool(
 				if (r.warning) specialWarnings.push(r.warning);
 			}
 
-			const apiFilters: ToolFilter[] = [...unassignedFilters, ...optionalFilters, ...(recencyResult.filters as ToolFilter[])];
-			const queryLimitForOp = effectiveReturnAll ? undefined : (params.limit !== undefined ? getEffectiveLimit(params.limit) : DEFAULT_QUERY_LIMIT);
+			const apiFilters: ToolFilter[] = [
+				...unassignedFilters,
+				...optionalFilters,
+				...(recencyResult.filters as ToolFilter[]),
+			];
+			const queryLimitForOp = effectiveReturnAll
+				? undefined
+				: params.limit !== undefined
+					? getEffectiveLimit(params.limit)
+					: DEFAULT_QUERY_LIMIT;
 			const requestBody: IDataObject = { filter: apiFilters as unknown as IDataObject[] };
 			if (queryLimitForOp !== undefined) {
 				requestBody.MaxRecords = queryLimitForOp;
 			}
 
-			const unassignedResponse = await autotaskApiRequest.call(context, 'POST', cfg.queryEndpoint, requestBody) as { items?: IAutotaskEntity[] };
-			const unassignedItems = Array.isArray(unassignedResponse.items) ? unassignedResponse.items as Record<string, unknown>[] : [];
+			const unassignedResponse = (await autotaskApiRequest.call(
+				context,
+				'POST',
+				cfg.queryEndpoint,
+				requestBody,
+			)) as { items?: IAutotaskEntity[] };
+			const unassignedItems = Array.isArray(unassignedResponse.items)
+				? (unassignedResponse.items as Record<string, unknown>[])
+				: [];
 
 			const allUnassignedWarnings = [...specialWarnings, ...labelWarnings];
 			const allUnassignedResolutions = [...specialResolutions, ...labelResolutions];
 
 			const unassignedListJson = JSON.stringify(
-				buildListResponse(resource, 'getUnassigned', unassignedItems, {
-					hasMore: queryLimitForOp !== undefined && unassignedItems.length >= queryLimitForOp,
-					serverCap: queryLimitForOp ?? MAX_QUERY_LIMIT,
-					clientCap: queryLimitForOp ?? MAX_QUERY_LIMIT,
-				}, {
-					resolutions: allUnassignedResolutions.length > 0 ? allUnassignedResolutions : undefined,
-					resolutionWarnings: allUnassignedWarnings.length > 0 ? allUnassignedWarnings : undefined,
-					pendingConfirmations: specialPending.length > 0 ? specialPending : undefined,
-				}),
+				buildListResponse(
+					resource,
+					'getUnassigned',
+					unassignedItems,
+					{
+						hasMore: queryLimitForOp !== undefined && unassignedItems.length >= queryLimitForOp,
+						serverCap: queryLimitForOp ?? MAX_QUERY_LIMIT,
+						clientCap: queryLimitForOp ?? MAX_QUERY_LIMIT,
+					},
+					{
+						resolutions: allUnassignedResolutions.length > 0 ? allUnassignedResolutions : undefined,
+						resolutionWarnings:
+							allUnassignedWarnings.length > 0 ? allUnassignedWarnings : undefined,
+						pendingConfirmations: specialPending.length > 0 ? specialPending : undefined,
+					},
+				),
 			);
 			const enrichedUnassignedJson = await enrichResponseJson(unassignedListJson, context);
 			return attachCorrelation(enrichedUnassignedJson, correlationId);
@@ -1915,25 +2063,32 @@ export async function executeAiTool(
 				slaFilters = [{ field: 'serviceLevelAgreementHasBeenMet', op: 'eq', value: true }];
 			} else {
 				// at_risk: within atRiskWindowHours hours of resolvedDueDateTime, not yet breached
-				const windowHours = typeof params.atRiskWindowHours === 'number' && params.atRiskWindowHours > 0
-					? params.atRiskWindowHours
-					: 4;
+				const windowHours =
+					typeof params.atRiskWindowHours === 'number' && params.atRiskWindowHours > 0
+						? params.atRiskWindowHours
+						: 4;
 				const now = new Date();
 				const windowEnd = new Date(now.getTime() + windowHours * 60 * 60 * 1000);
-				slaFilters = [{
-					op: 'and',
-					items: [
-						{ field: 'resolvedDueDateTime', op: 'gt', value: now.toISOString() },
-						{ field: 'resolvedDueDateTime', op: 'lt', value: windowEnd.toISOString() },
-						{ field: 'status', op: 'notIn', value: cfg.terminalStatusIds },
-					],
-				}];
+				slaFilters = [
+					{
+						op: 'and',
+						items: [
+							{ field: 'resolvedDueDateTime', op: 'gt', value: now.toISOString() },
+							{ field: 'resolvedDueDateTime', op: 'lt', value: windowEnd.toISOString() },
+							{ field: 'status', op: 'notIn', value: cfg.terminalStatusIds },
+						],
+					},
+				];
 			}
 
 			// Optional company filter (resolve name→ID)
 			const slaOptionalFilters: ToolFilter[] = [];
 			if (params.company !== undefined && params.company !== null) {
-				slaOptionalFilters.push({ field: 'companyID', op: 'eq', value: params.company as string | number });
+				slaOptionalFilters.push({
+					field: 'companyID',
+					op: 'eq',
+					value: params.company as string | number,
+				});
 			}
 
 			let slaSpecialUnresolved: ToolFilter[] = [];
@@ -1942,7 +2097,13 @@ export async function executeAiTool(
 			let slaSpecialPending: any[] = [];
 
 			if (slaOptionalFilters.length > 0) {
-				const resolved = await resolveAndClassifyFilters(context, resource, slaOptionalFilters, readFields, params as IDataObject);
+				const resolved = await resolveAndClassifyFilters(
+					context,
+					resource,
+					slaOptionalFilters,
+					readFields,
+					params as IDataObject,
+				);
 				slaSpecialUnresolved = resolved.unresolvedIdLikeFilters;
 				slaSpecialResolutions = resolved.resolutions;
 				slaSpecialWarnings = resolved.warnings;
@@ -1958,36 +2119,59 @@ export async function executeAiTool(
 							ERROR_TYPES.INVALID_FILTER_CONSTRAINT,
 							`Could not resolve company: '${String(params.company)}'`,
 							`Verify the company name is exact or use a numeric companyID.`,
-							{ pendingConfirmations: slaSpecialPending.length > 0 ? slaSpecialPending : undefined },
+							{
+								pendingConfirmations: slaSpecialPending.length > 0 ? slaSpecialPending : undefined,
+							},
 						),
 					),
 					correlationId,
 				);
 			}
 
-			const apiSlaFilters: any[] = [...slaFilters, ...slaOptionalFilters, ...(recencyResult.filters as any[])];
-			const queryLimitForSla = effectiveReturnAll ? undefined : (params.limit !== undefined ? getEffectiveLimit(params.limit) : DEFAULT_QUERY_LIMIT);
+			const apiSlaFilters: any[] = [
+				...slaFilters,
+				...slaOptionalFilters,
+				...(recencyResult.filters as any[]),
+			];
+			const queryLimitForSla = effectiveReturnAll
+				? undefined
+				: params.limit !== undefined
+					? getEffectiveLimit(params.limit)
+					: DEFAULT_QUERY_LIMIT;
 			const slaRequestBody: IDataObject = { filter: apiSlaFilters as IDataObject[] };
 			if (queryLimitForSla !== undefined) {
 				slaRequestBody.MaxRecords = queryLimitForSla;
 			}
 
-			const slaResponse = await autotaskApiRequest.call(context, 'POST', cfg.queryEndpoint, slaRequestBody) as { items?: IAutotaskEntity[] };
-			const slaItems = Array.isArray(slaResponse.items) ? slaResponse.items as Record<string, unknown>[] : [];
+			const slaResponse = (await autotaskApiRequest.call(
+				context,
+				'POST',
+				cfg.queryEndpoint,
+				slaRequestBody,
+			)) as { items?: IAutotaskEntity[] };
+			const slaItems = Array.isArray(slaResponse.items)
+				? (slaResponse.items as Record<string, unknown>[])
+				: [];
 
 			const allSlaWarnings = [...slaSpecialWarnings, ...labelWarnings];
 			const allSlaResolutions = [...slaSpecialResolutions, ...labelResolutions];
 
 			const slaListJson = JSON.stringify(
-				buildListResponse(resource, 'getBySLAStatus', slaItems, {
-					hasMore: queryLimitForSla !== undefined && slaItems.length >= queryLimitForSla,
-					serverCap: queryLimitForSla ?? MAX_QUERY_LIMIT,
-					clientCap: queryLimitForSla ?? MAX_QUERY_LIMIT,
-				}, {
-					resolutions: allSlaResolutions.length > 0 ? allSlaResolutions : undefined,
-					resolutionWarnings: allSlaWarnings.length > 0 ? allSlaWarnings : undefined,
-					pendingConfirmations: slaSpecialPending.length > 0 ? slaSpecialPending : undefined,
-				}),
+				buildListResponse(
+					resource,
+					'getBySLAStatus',
+					slaItems,
+					{
+						hasMore: queryLimitForSla !== undefined && slaItems.length >= queryLimitForSla,
+						serverCap: queryLimitForSla ?? MAX_QUERY_LIMIT,
+						clientCap: queryLimitForSla ?? MAX_QUERY_LIMIT,
+					},
+					{
+						resolutions: allSlaResolutions.length > 0 ? allSlaResolutions : undefined,
+						resolutionWarnings: allSlaWarnings.length > 0 ? allSlaWarnings : undefined,
+						pendingConfirmations: slaSpecialPending.length > 0 ? slaSpecialPending : undefined,
+					},
+				),
 			);
 			const enrichedSlaJson = await enrichResponseJson(slaListJson, context);
 			return attachCorrelation(enrichedSlaJson, correlationId);
@@ -2000,11 +2184,17 @@ export async function executeAiTool(
 			let fullDetailTicketId: string | undefined;
 			if (params.id !== undefined && params.id !== null) {
 				fullDetailTicketId = String(params.id);
-			} else if (fdIdPairConfig && typeof params.ticketNumber === 'string' && params.ticketNumber.trim()) {
-				const tnLookup = await autotaskApiRequest.call(context, 'POST', cfg.queryEndpoint, {
-					filter: [{ field: fdIdPairConfig.altIdField, op: 'eq', value: params.ticketNumber.trim() }],
+			} else if (
+				fdIdPairConfig &&
+				typeof params.ticketNumber === 'string' &&
+				params.ticketNumber.trim()
+			) {
+				const tnLookup = (await autotaskApiRequest.call(context, 'POST', cfg.queryEndpoint, {
+					filter: [
+						{ field: fdIdPairConfig.altIdField, op: 'eq', value: params.ticketNumber.trim() },
+					],
 					MaxRecords: 1,
-				} as IDataObject) as { items?: IAutotaskEntity[] };
+				} as IDataObject)) as { items?: IAutotaskEntity[] };
 				const tnItems = Array.isArray(tnLookup.items) ? tnLookup.items : [];
 				if (tnItems.length === 0) {
 					return attachCorrelation(
@@ -2045,7 +2235,11 @@ export async function executeAiTool(
 			}
 
 			const resolvedDetailId = fullDetailTicketId;
-			const fullDetailResponse = await autotaskApiRequest.call(context, 'GET', cfg.getEndpoint(resolvedDetailId)) as { item?: IAutotaskEntity };
+			const fullDetailResponse = (await autotaskApiRequest.call(
+				context,
+				'GET',
+				cfg.getEndpoint(resolvedDetailId),
+			)) as { item?: IAutotaskEntity };
 			const rawFullDetailTicket = fullDetailResponse.item;
 			if (!rawFullDetailTicket || typeof rawFullDetailTicket !== 'object') {
 				const resourceTitle = resource.charAt(0).toUpperCase() + resource.slice(1);
@@ -2069,7 +2263,9 @@ export async function executeAiTool(
 			if (cfg.getFullDetailMode === 'sla') {
 				const fdTicket = detailRecord;
 				// Derive SLA status from ticket fields — no extra API call needed
-				const fdHasSla = fdTicket.serviceLevelAgreementID !== undefined && fdTicket.serviceLevelAgreementID !== null;
+				const fdHasSla =
+					fdTicket.serviceLevelAgreementID !== undefined &&
+					fdTicket.serviceLevelAgreementID !== null;
 				const fdMet = fdTicket.serviceLevelAgreementHasBeenMet;
 				const fdPausedHours = fdTicket.serviceLevelAgreementPausedNextEventHours;
 				let fdSlaStatus: string;
@@ -2095,7 +2291,9 @@ export async function executeAiTool(
 					fdTitle ? `"${String(fdTitle)}"` : '',
 					fdStatusLabel ? `[${String(fdStatusLabel)}]` : '',
 					fdCompanyLabel ? `— ${String(fdCompanyLabel)}` : '',
-				].filter(Boolean).join(' ');
+				]
+					.filter(Boolean)
+					.join(' ');
 
 				fullDetailRecord = {
 					...fdTicket,
@@ -2112,14 +2310,14 @@ export async function executeAiTool(
 					const countResults = await Promise.all(
 						cfg.childCountEntities.map(async (entry) => {
 							try {
-								const resp = await autotaskApiRequest.call(
+								const resp = (await autotaskApiRequest.call(
 									context,
 									'POST',
 									`${entry.queryEndpoint}/count`,
 									{
 										filter: [{ field: entry.parentField, op: 'eq', value: numericId }],
 									} as IDataObject,
-								) as { queryCount?: number };
+								)) as { queryCount?: number };
 								const count = typeof resp.queryCount === 'number' ? resp.queryCount : 0;
 								return { key: entry.key, count };
 							} catch (err) {
@@ -2136,15 +2334,24 @@ export async function executeAiTool(
 						}
 					}
 				}
-				const recordTitle = (detailRecord.title ?? detailRecord.projectName ?? detailRecord.name ?? '') as string;
-				const recordStatusLabel = (detailRecord.status_label ?? detailRecord.status ?? '') as string;
-				const recordCompanyLabel = (detailRecord.companyID_label ?? detailRecord.companyName ?? '') as string;
+				const recordTitle = (detailRecord.title ??
+					detailRecord.projectName ??
+					detailRecord.name ??
+					'') as string;
+				const recordStatusLabel = (detailRecord.status_label ??
+					detailRecord.status ??
+					'') as string;
+				const recordCompanyLabel = (detailRecord.companyID_label ??
+					detailRecord.companyName ??
+					'') as string;
 				const summaryText = [
 					`${resource.charAt(0).toUpperCase()}${resource.slice(1)} ${resolvedDetailId}`,
 					recordTitle ? `"${String(recordTitle)}"` : '',
 					recordStatusLabel ? `[${String(recordStatusLabel)}]` : '',
 					recordCompanyLabel ? `— ${String(recordCompanyLabel)}` : '',
-				].filter(Boolean).join(' ');
+				]
+					.filter(Boolean)
+					.join(' ');
 				fullDetailRecord = {
 					...detailRecord,
 					...(Object.keys(childCounts).length > 0 ? { childCounts } : {}),
@@ -2163,7 +2370,17 @@ export async function executeAiTool(
 		// Short-circuit: countByPeriod
 		if (effectiveOperation === 'countByPeriod') {
 			const cfg = getConvenienceConfig(resource)!;
-			const validPeriods = ['today', 'this_week', 'last_7d', 'this_month', 'last_month', 'this_quarter', 'last_quarter', 'last_30d', 'last_90d'] as const;
+			const validPeriods = [
+				'today',
+				'this_week',
+				'last_7d',
+				'this_month',
+				'last_month',
+				'this_quarter',
+				'last_quarter',
+				'last_30d',
+				'last_90d',
+			] as const;
 			const periodParam = params.period as string | undefined;
 			if (!periodParam || !(validPeriods as readonly string[]).includes(periodParam)) {
 				return attachCorrelation(
@@ -2249,14 +2466,26 @@ export async function executeAiTool(
 
 			// Optional filters: company, status, priority
 			const cbpOptional: ToolFilter[] = [];
-			if (cfg.companyFilterStrategy === 'direct' && params.company !== undefined && params.company !== null) {
-				cbpOptional.push({ field: 'companyID', op: 'eq', value: params.company as string | number });
+			if (
+				cfg.companyFilterStrategy === 'direct' &&
+				params.company !== undefined &&
+				params.company !== null
+			) {
+				cbpOptional.push({
+					field: 'companyID',
+					op: 'eq',
+					value: params.company as string | number,
+				});
 			}
 			if (params.status !== undefined && params.status !== null) {
 				cbpOptional.push({ field: 'status', op: 'eq', value: params.status as string | number });
 			}
 			if (cfg.hasPriority && params.priority !== undefined && params.priority !== null) {
-				cbpOptional.push({ field: 'priority', op: 'eq', value: params.priority as string | number });
+				cbpOptional.push({
+					field: 'priority',
+					op: 'eq',
+					value: params.priority as string | number,
+				});
 			}
 
 			let cbpResolutions: LabelResolution[] = [];
@@ -2265,7 +2494,13 @@ export async function executeAiTool(
 			let cbpUnresolved: ToolFilter[] = [];
 
 			if (cbpOptional.length > 0) {
-				const cbpResolved = await resolveAndClassifyFilters(context, resource, cbpOptional, readFields, params as IDataObject);
+				const cbpResolved = await resolveAndClassifyFilters(
+					context,
+					resource,
+					cbpOptional,
+					readFields,
+					params as IDataObject,
+				);
 				cbpResolutions = cbpResolved.resolutions;
 				cbpWarnings = cbpResolved.warnings;
 				cbpPending = cbpResolved.pendingConfirmations;
@@ -2289,8 +2524,17 @@ export async function executeAiTool(
 			}
 
 			// viaProject company filter resolution (e.g. task → projects → projectID-IN)
-			if (cfg.companyFilterStrategy === 'viaProject' && params.company !== undefined && params.company !== null) {
-				const r = await resolveCompanyToProjectIdFilter(context, params.company as string | number, 'countByPeriod', resource);
+			if (
+				cfg.companyFilterStrategy === 'viaProject' &&
+				params.company !== undefined &&
+				params.company !== null
+			) {
+				const r = await resolveCompanyToProjectIdFilter(
+					context,
+					params.company as string | number,
+					'countByPeriod',
+					resource,
+				);
 				if ('error' in r) return attachCorrelation(JSON.stringify(r.error), correlationId);
 				if ('empty' in r) {
 					const emptyCountResponse: Record<string, unknown> = {
@@ -2333,7 +2577,11 @@ export async function executeAiTool(
 		if (effectiveOperation === 'getByAge') {
 			const cfg = getConvenienceConfig(resource)!;
 			const olderThanDays = params.olderThanDays;
-			if (typeof olderThanDays !== 'number' || !Number.isFinite(olderThanDays) || olderThanDays <= 0) {
+			if (
+				typeof olderThanDays !== 'number' ||
+				!Number.isFinite(olderThanDays) ||
+				olderThanDays <= 0
+			) {
 				return attachCorrelation(
 					JSON.stringify(
 						wrapError(
@@ -2354,9 +2602,28 @@ export async function executeAiTool(
 			];
 
 			const ageOptionalFilters: ToolFilter[] = [];
-			if (cfg.companyFilterStrategy === 'direct' && params.company !== undefined && params.company !== null) ageOptionalFilters.push({ field: 'companyID', op: 'eq', value: params.company as string | number });
-			if (params.status !== undefined && params.status !== null) ageOptionalFilters.push({ field: 'status', op: 'eq', value: params.status as string | number });
-			if (cfg.hasPriority && params.priority !== undefined && params.priority !== null) ageOptionalFilters.push({ field: 'priority', op: 'eq', value: params.priority as string | number });
+			if (
+				cfg.companyFilterStrategy === 'direct' &&
+				params.company !== undefined &&
+				params.company !== null
+			)
+				ageOptionalFilters.push({
+					field: 'companyID',
+					op: 'eq',
+					value: params.company as string | number,
+				});
+			if (params.status !== undefined && params.status !== null)
+				ageOptionalFilters.push({
+					field: 'status',
+					op: 'eq',
+					value: params.status as string | number,
+				});
+			if (cfg.hasPriority && params.priority !== undefined && params.priority !== null)
+				ageOptionalFilters.push({
+					field: 'priority',
+					op: 'eq',
+					value: params.priority as string | number,
+				});
 
 			let ageResolutions: any[] = [];
 			let ageWarnings: string[] = [];
@@ -2364,7 +2631,13 @@ export async function executeAiTool(
 			let ageUnresolved: ToolFilter[] = [];
 
 			if (ageOptionalFilters.length > 0) {
-				const ageResolved = await resolveAndClassifyFilters(context, resource, ageOptionalFilters, readFields, params as IDataObject);
+				const ageResolved = await resolveAndClassifyFilters(
+					context,
+					resource,
+					ageOptionalFilters,
+					readFields,
+					params as IDataObject,
+				);
 				ageResolutions = ageResolved.resolutions;
 				ageWarnings = ageResolved.warnings;
 				agePending = ageResolved.pendingConfirmations;
@@ -2374,27 +2647,50 @@ export async function executeAiTool(
 			if (ageUnresolved.length > 0) {
 				return attachCorrelation(
 					JSON.stringify(
-						wrapError(resource, 'getByAge', ERROR_TYPES.INVALID_FILTER_CONSTRAINT,
+						wrapError(
+							resource,
+							'getByAge',
+							ERROR_TYPES.INVALID_FILTER_CONSTRAINT,
 							`Could not resolve: ${ageUnresolved.map((f) => `${f.field}='${String(f.value)}'`).join(', ')}`,
 							`Verify names or use numeric IDs. For status/priority, call autotask_${resource} with operation 'listPicklistValues'.`,
-							{ pendingConfirmations: agePending.length > 0 ? agePending : undefined }),
+							{ pendingConfirmations: agePending.length > 0 ? agePending : undefined },
+						),
 					),
 					correlationId,
 				);
 			}
 
 			// viaProject company filter resolution (e.g. task → projects → projectID-IN)
-			if (cfg.companyFilterStrategy === 'viaProject' && params.company !== undefined && params.company !== null) {
-				const r = await resolveCompanyToProjectIdFilter(context, params.company as string | number, 'getByAge', resource);
+			if (
+				cfg.companyFilterStrategy === 'viaProject' &&
+				params.company !== undefined &&
+				params.company !== null
+			) {
+				const r = await resolveCompanyToProjectIdFilter(
+					context,
+					params.company as string | number,
+					'getByAge',
+					resource,
+				);
 				if ('error' in r) return attachCorrelation(JSON.stringify(r.error), correlationId);
 				if ('empty' in r) {
 					return attachCorrelation(
 						JSON.stringify(
-							buildListResponse(resource, 'getByAge', [], {
-								hasMore: false, serverCap: MAX_QUERY_LIMIT, clientCap: MAX_QUERY_LIMIT,
-							}, {
-								resolutionWarnings: [`No projects found for company '${String(params.company)}'.`],
-							}),
+							buildListResponse(
+								resource,
+								'getByAge',
+								[],
+								{
+									hasMore: false,
+									serverCap: MAX_QUERY_LIMIT,
+									clientCap: MAX_QUERY_LIMIT,
+								},
+								{
+									resolutionWarnings: [
+										`No projects found for company '${String(params.company)}'.`,
+									],
+								},
+							),
 						),
 						correlationId,
 					);
@@ -2403,27 +2699,48 @@ export async function executeAiTool(
 				if (r.warning) ageWarnings.push(r.warning);
 			}
 
-			const ageAllFilters: ToolFilter[] = [...ageBaseFilters, ...ageOptionalFilters, ...(recencyResult.filters as ToolFilter[])];
-			const ageQueryLimit = effectiveReturnAll ? undefined : (params.limit !== undefined ? getEffectiveLimit(params.limit) : DEFAULT_QUERY_LIMIT);
+			const ageAllFilters: ToolFilter[] = [
+				...ageBaseFilters,
+				...ageOptionalFilters,
+				...(recencyResult.filters as ToolFilter[]),
+			];
+			const ageQueryLimit = effectiveReturnAll
+				? undefined
+				: params.limit !== undefined
+					? getEffectiveLimit(params.limit)
+					: DEFAULT_QUERY_LIMIT;
 			const ageRequestBody: IDataObject = { filter: ageAllFilters as unknown as IDataObject[] };
 			if (ageQueryLimit !== undefined) ageRequestBody.MaxRecords = ageQueryLimit;
 
-			const ageResponse = await autotaskApiRequest.call(context, 'POST', cfg.queryEndpoint, ageRequestBody) as { items?: IAutotaskEntity[] };
-			const ageItems = Array.isArray(ageResponse.items) ? ageResponse.items as Record<string, unknown>[] : [];
+			const ageResponse = (await autotaskApiRequest.call(
+				context,
+				'POST',
+				cfg.queryEndpoint,
+				ageRequestBody,
+			)) as { items?: IAutotaskEntity[] };
+			const ageItems = Array.isArray(ageResponse.items)
+				? (ageResponse.items as Record<string, unknown>[])
+				: [];
 
 			const ageAllWarnings = [...ageWarnings, ...labelWarnings];
 			const ageAllResolutions = [...ageResolutions, ...labelResolutions];
 
 			const ageListJson = JSON.stringify(
-				buildListResponse(resource, 'getByAge', ageItems, {
-					hasMore: ageQueryLimit !== undefined && ageItems.length >= ageQueryLimit,
-					serverCap: ageQueryLimit ?? MAX_QUERY_LIMIT,
-					clientCap: ageQueryLimit ?? MAX_QUERY_LIMIT,
-				}, {
-					resolutions: ageAllResolutions.length > 0 ? ageAllResolutions : undefined,
-					resolutionWarnings: ageAllWarnings.length > 0 ? ageAllWarnings : undefined,
-					pendingConfirmations: agePending.length > 0 ? agePending : undefined,
-				}),
+				buildListResponse(
+					resource,
+					'getByAge',
+					ageItems,
+					{
+						hasMore: ageQueryLimit !== undefined && ageItems.length >= ageQueryLimit,
+						serverCap: ageQueryLimit ?? MAX_QUERY_LIMIT,
+						clientCap: ageQueryLimit ?? MAX_QUERY_LIMIT,
+					},
+					{
+						resolutions: ageAllResolutions.length > 0 ? ageAllResolutions : undefined,
+						resolutionWarnings: ageAllWarnings.length > 0 ? ageAllWarnings : undefined,
+						pendingConfirmations: agePending.length > 0 ? agePending : undefined,
+					},
+				),
 			);
 			const enrichedAgeJson = await enrichResponseJson(ageListJson, context);
 			return attachCorrelation(enrichedAgeJson, correlationId);
@@ -2519,11 +2836,7 @@ export async function executeAiTool(
 						: String(stage1Settled.reason);
 				return attachCorrelation(
 					JSON.stringify(
-						formatApiError(
-							`Ticket search (stage 1) failed: ${msg}`,
-							resource,
-							'searchByKeyword',
-						),
+						formatApiError(`Ticket search (stage 1) failed: ${msg}`, resource, 'searchByKeyword'),
 					),
 					correlationId,
 				);
@@ -2538,9 +2851,7 @@ export async function executeAiTool(
 					stage2Settled.reason instanceof Error
 						? stage2Settled.reason.message
 						: String(stage2Settled.reason);
-				stageWarnings.push(
-					`TicketNotes search failed: ${msg}. Results omit notes-only matches.`,
-				);
+				stageWarnings.push(`TicketNotes search failed: ${msg}. Results omit notes-only matches.`);
 			}
 
 			const stage3Items: Record<string, unknown>[] =
@@ -2729,8 +3040,10 @@ export async function executeAiTool(
 			},
 		});
 		const needsParallelCount =
-			effectiveOperation === 'getMany' &&  // excludes getPosted/getUnposted (cross-entity join; wrong total)
-			recencyResult.isActive && !isShortWindow && !effectiveReturnAll;
+			effectiveOperation === 'getMany' && // excludes getPosted/getUnposted (cross-entity join; wrong total)
+			recencyResult.isActive &&
+			!isShortWindow &&
+			!effectiveReturnAll;
 		const [result, parallelCountResult] = await Promise.all([
 			executeToolOperation.call(context),
 			needsParallelCount
@@ -2827,7 +3140,7 @@ export async function executeAiTool(
 				if (fieldMeta && fieldMeta.type.toLowerCase().includes('date')) {
 					rawDatePairWarnings.push(
 						`Filtering a date field (${params.filter_field}) with gte+lte or gt+lt is discouraged. ` +
-						`Use recency (e.g. last_7d, last_30d) or since/until for date ranges — they encode the time window more clearly.`,
+							`Use recency (e.g. last_7d, last_30d) or since/until for date ranges — they encode the time window more clearly.`,
 					);
 				}
 			}
@@ -2859,7 +3172,9 @@ export async function executeAiTool(
 			injectedTotalAvailable: injectedCount ?? undefined,
 			autoReturnAll,
 			wasReturnAll: effectiveReturnAll,
-			windowLabel: params.recency ? formatRecencyWindowLabel(params.recency) ?? undefined : undefined,
+			windowLabel: params.recency
+				? (formatRecencyWindowLabel(params.recency) ?? undefined)
+				: undefined,
 			countQueryFailed: countQueryFailed || undefined,
 		};
 

--- a/nodes/Autotask/constants/resource-operations.ts
+++ b/nodes/Autotask/constants/resource-operations.ts
@@ -1,46 +1,85 @@
 import { AUTOTASK_ENTITIES } from './entities';
 import { OperationType } from '../types/base/entity-types';
 
-const AI_OPERATION_ORDER = ['get', 'whoAmI', 'getMany', 'searchByDomain', 'slaHealthCheck', 'summary', 'getFullDetail', 'countByPeriod', 'getByAge', 'searchByKeyword', 'getByCompanyAndStatus', 'getUnassigned', 'getBySLAStatus', 'getPosted', 'getUnposted', 'getByResource', 'getByYear', 'count', 'create', 'createIfNotExists', 'moveToCompany', 'moveConfigurationItem', 'transferOwnership', 'update', 'approve', 'reject', 'delete'] as const;
+const AI_OPERATION_ORDER = [
+	'get',
+	'whoAmI',
+	'getMany',
+	'searchByIdentity',
+	'searchByDomain',
+	'slaHealthCheck',
+	'summary',
+	'getFullDetail',
+	'countByPeriod',
+	'getByAge',
+	'searchByKeyword',
+	'getByCompanyAndStatus',
+	'getUnassigned',
+	'getBySLAStatus',
+	'getPosted',
+	'getUnposted',
+	'getByResource',
+	'getByYear',
+	'count',
+	'create',
+	'createIfNotExists',
+	'moveToCompany',
+	'moveConfigurationItem',
+	'transferOwnership',
+	'update',
+	'approve',
+	'reject',
+	'delete',
+] as const;
 const EXCLUDED_TOP_LEVEL_RESOURCES = new Set(['tool', 'searchFilter']);
 
 const OP_TYPE_TO_AI_OPS: Record<OperationType, string[]> = {
-    [OperationType.CREATE]: ['create'],
-    [OperationType.READ]: ['get'],
-    [OperationType.UPDATE]: ['update'],
-    [OperationType.DELETE]: ['delete'],
-    [OperationType.QUERY]: ['get', 'getMany'],
-    [OperationType.COUNT]: ['count'],
-    [OperationType.GET_ENTITY_INFO]: [],
-    [OperationType.GET_FIELD_INFO]: [],
+	[OperationType.CREATE]: ['create'],
+	[OperationType.READ]: ['get'],
+	[OperationType.UPDATE]: ['update'],
+	[OperationType.DELETE]: ['delete'],
+	[OperationType.QUERY]: ['get', 'getMany'],
+	[OperationType.COUNT]: ['count'],
+	[OperationType.GET_ENTITY_INFO]: [],
+	[OperationType.GET_FIELD_INFO]: [],
 };
 
 const SPECIAL_AI_OPERATIONS: Record<string, string[]> = {
-    resource: ['whoAmI', 'transferOwnership'],
-    contact: ['moveToCompany'],
-    company: ['searchByDomain'],
-    ticket: ['slaHealthCheck', 'summary', 'getFullDetail', 'countByPeriod', 'getByAge', 'searchByKeyword', 'getByCompanyAndStatus', 'getUnassigned', 'getBySLAStatus'],
-    task: ['getFullDetail', 'countByPeriod', 'getByAge', 'getByCompanyAndStatus', 'getUnassigned'],
-    project: ['getFullDetail', 'countByPeriod', 'getByAge', 'getByCompanyAndStatus', 'getUnassigned'],
-    configurationItems: ['moveConfigurationItem', 'createIfNotExists'],
-    changeRequestLinks: ['createIfNotExists'],
-    contractCharge: ['createIfNotExists'],
-    ticketCharge: ['createIfNotExists'],
-    projectCharge: ['createIfNotExists'],
-    contract: ['createIfNotExists'],
-    contractService: ['createIfNotExists'],
-    expenseItem: ['createIfNotExists'],
-    holiday: ['createIfNotExists'],
-    holidaySet: ['createIfNotExists'],
-    opportunity: ['createIfNotExists'],
-    ticketAdditionalConfigurationItem: ['createIfNotExists'],
-    ticketAdditionalContact: ['createIfNotExists'],
-    timeEntry: ['getPosted', 'getUnposted', 'createIfNotExists'],
-    resourceTimeOffAdditional: ['getByResource', 'update'],
-    resourceTimeOffBalance: ['getByResource', 'getByYear'],
-    timeOffRequest: ['approve', 'reject'],
-    aiHelper: ['describeResource', 'listPicklistValues', 'validateParameters'],
-    apiThreshold: ['get'],
+	resource: ['whoAmI', 'transferOwnership'],
+	contact: ['moveToCompany'],
+	company: ['searchByIdentity', 'searchByDomain'],
+	ticket: [
+		'slaHealthCheck',
+		'summary',
+		'getFullDetail',
+		'countByPeriod',
+		'getByAge',
+		'searchByKeyword',
+		'getByCompanyAndStatus',
+		'getUnassigned',
+		'getBySLAStatus',
+	],
+	task: ['getFullDetail', 'countByPeriod', 'getByAge', 'getByCompanyAndStatus', 'getUnassigned'],
+	project: ['getFullDetail', 'countByPeriod', 'getByAge', 'getByCompanyAndStatus', 'getUnassigned'],
+	configurationItems: ['moveConfigurationItem', 'createIfNotExists'],
+	changeRequestLinks: ['createIfNotExists'],
+	contractCharge: ['createIfNotExists'],
+	ticketCharge: ['createIfNotExists'],
+	projectCharge: ['createIfNotExists'],
+	contract: ['createIfNotExists'],
+	contractService: ['createIfNotExists'],
+	expenseItem: ['createIfNotExists'],
+	holiday: ['createIfNotExists'],
+	holidaySet: ['createIfNotExists'],
+	opportunity: ['createIfNotExists'],
+	ticketAdditionalConfigurationItem: ['createIfNotExists'],
+	ticketAdditionalContact: ['createIfNotExists'],
+	timeEntry: ['getPosted', 'getUnposted', 'createIfNotExists'],
+	resourceTimeOffAdditional: ['getByResource', 'update'],
+	resourceTimeOffBalance: ['getByResource', 'getByYear'],
+	timeOffRequest: ['approve', 'reject'],
+	aiHelper: ['describeResource', 'listPicklistValues', 'validateParameters'],
+	apiThreshold: ['get'],
 };
 
 /**
@@ -51,114 +90,122 @@ const SPECIAL_AI_OPERATIONS: Record<string, string[]> = {
  * are automatically handled by the consumers of this registry.
  */
 export interface IdentifierPairConfig {
-    /** Operation names that use the id-OR-altId pattern. */
-    operations: string[];
-    /** The alternative identifier field name (e.g. 'ticketNumber'). */
-    altIdField: string;
-    /** A concrete example value for use in schema descriptions (e.g. 'T20240615.0674'). */
-    altIdExample: string;
-    /** Human-readable format hint (e.g. 'T{date}.{seq}'). */
-    altIdFormat: string;
+	/** Operation names that use the id-OR-altId pattern. */
+	operations: string[];
+	/** The alternative identifier field name (e.g. 'ticketNumber'). */
+	altIdField: string;
+	/** A concrete example value for use in schema descriptions (e.g. 'T20240615.0674'). */
+	altIdExample: string;
+	/** Human-readable format hint (e.g. 'T{date}.{seq}'). */
+	altIdFormat: string;
 }
 
 export const IDENTIFIER_PAIR_OPERATIONS: Record<string, IdentifierPairConfig> = {
-    ticket: {
-        operations: ['slaHealthCheck', 'summary', 'getFullDetail'],
-        altIdField: 'ticketNumber',
-        altIdExample: 'T20240615.0674',
-        altIdFormat: 'T{date}.{seq}',
-    },
+	ticket: {
+		operations: ['slaHealthCheck', 'summary', 'getFullDetail'],
+		altIdField: 'ticketNumber',
+		altIdExample: 'T20240615.0674',
+		altIdFormat: 'T{date}.{seq}',
+	},
 };
 
-export function getIdentifierPairConfig(resource: string, operation: string): IdentifierPairConfig | null {
-    const config = IDENTIFIER_PAIR_OPERATIONS[resource];
-    return (config && config.operations.includes(operation)) ? config : null;
+export function getIdentifierPairConfig(
+	resource: string,
+	operation: string,
+): IdentifierPairConfig | null {
+	const config = IDENTIFIER_PAIR_OPERATIONS[resource];
+	return config && config.operations.includes(operation) ? config : null;
 }
 
 function lowerCamelCase(value: string): string {
-    if (!value) return value;
-    return value.charAt(0).toLowerCase() + value.slice(1);
+	if (!value) return value;
+	return value.charAt(0).toLowerCase() + value.slice(1);
 }
 
 function isAiExcludedEntity(name: string, isAttachment?: boolean, parentChain?: string[]): boolean {
-    if (isAttachment) return true;
-    if (EXCLUDED_TOP_LEVEL_RESOURCES.has(lowerCamelCase(name))) return true;
-    if (!parentChain?.length) return false;
-    return /(?:ExcludedResource|Field|UdfField)$/.test(name);
+	if (isAttachment) return true;
+	if (EXCLUDED_TOP_LEVEL_RESOURCES.has(lowerCamelCase(name))) return true;
+	if (!parentChain?.length) return false;
+	return /(?:ExcludedResource|Field|UdfField)$/.test(name);
 }
 
 function toOrderedOperationList(ops: Set<string>): string[] {
-    const ordered = AI_OPERATION_ORDER.filter((op) => ops.has(op));
-    const remainder = [...ops].filter((op) => !AI_OPERATION_ORDER.includes(op as typeof AI_OPERATION_ORDER[number]));
-    return [...ordered, ...remainder];
+	const ordered = AI_OPERATION_ORDER.filter((op) => ops.has(op));
+	const remainder = [...ops].filter(
+		(op) => !AI_OPERATION_ORDER.includes(op as (typeof AI_OPERATION_ORDER)[number]),
+	);
+	return [...ordered, ...remainder];
 }
 
 function buildResourceOperationsMap(): Record<string, string[]> {
-    const map: Record<string, string[]> = {};
+	const map: Record<string, string[]> = {};
 
-    for (const entity of AUTOTASK_ENTITIES) {
-        if (isAiExcludedEntity(entity.name, entity.isAttachment, entity.parentChain)) {
-            continue;
-        }
+	for (const entity of AUTOTASK_ENTITIES) {
+		if (isAiExcludedEntity(entity.name, entity.isAttachment, entity.parentChain)) {
+			continue;
+		}
 
-        const resourceKey = entity.resourceKey ?? lowerCamelCase(entity.name);
-        const ops = new Set<string>();
+		const resourceKey = entity.resourceKey ?? lowerCamelCase(entity.name);
+		const ops = new Set<string>();
 
-        for (const opType of Object.keys(entity.operations) as OperationType[]) {
-            const mappedOperations = OP_TYPE_TO_AI_OPS[opType] ?? [];
-            for (const mappedOperation of mappedOperations) {
-                ops.add(mappedOperation);
-            }
-        }
+		for (const opType of Object.keys(entity.operations) as OperationType[]) {
+			const mappedOperations = OP_TYPE_TO_AI_OPS[opType] ?? [];
+			for (const mappedOperation of mappedOperations) {
+				ops.add(mappedOperation);
+			}
+		}
 
-        if (!ops.size) {
-            continue;
-        }
+		if (!ops.size) {
+			continue;
+		}
 
-        const specialOps = SPECIAL_AI_OPERATIONS[resourceKey] ?? [];
-        for (const specialOp of specialOps) {
-            ops.add(specialOp);
-        }
+		const specialOps = SPECIAL_AI_OPERATIONS[resourceKey] ?? [];
+		for (const specialOp of specialOps) {
+			ops.add(specialOp);
+		}
 
-        map[resourceKey] = toOrderedOperationList(ops);
-    }
+		map[resourceKey] = toOrderedOperationList(ops);
+	}
 
-    for (const [resourceKey, specialOps] of Object.entries(SPECIAL_AI_OPERATIONS)) {
-        if (!map[resourceKey]) {
-            map[resourceKey] = [...specialOps];
-        }
-    }
+	for (const [resourceKey, specialOps] of Object.entries(SPECIAL_AI_OPERATIONS)) {
+		if (!map[resourceKey]) {
+			map[resourceKey] = [...specialOps];
+		}
+	}
 
-    return map;
+	return map;
 }
 
 export const RESOURCE_OPERATIONS_MAP: Record<string, string[]> = buildResourceOperationsMap();
 
 const NORMALIZED_RESOURCE_OPERATIONS_MAP = Object.fromEntries(
-    Object.entries(RESOURCE_OPERATIONS_MAP).map(([key, value]) => [key.toLowerCase(), value]),
+	Object.entries(RESOURCE_OPERATIONS_MAP).map(([key, value]) => [key.toLowerCase(), value]),
 );
 
-const RESOURCE_ALIASES = AUTOTASK_ENTITIES.reduce<Record<string, string>>((aliases, entity) => {
-    const defaultResourceKey = lowerCamelCase(entity.name);
-    const resourceKey = entity.resourceKey ?? defaultResourceKey;
-    if (defaultResourceKey.toLowerCase() !== resourceKey.toLowerCase()) {
-        aliases[defaultResourceKey.toLowerCase()] = resourceKey;
-    }
-    return aliases;
-}, {
-    // Backward-compatible aliases not derivable from entity metadata.
-    companysiteconfiguration: 'companySiteConfigurations',
-    serviceLevelAgreementResult: 'serviceLevelAgreementResults',
-    servicecallticketresources: 'serviceCallTicketResource',
-    servicecalltaskresources: 'serviceCallTaskResource',
-});
+const RESOURCE_ALIASES = AUTOTASK_ENTITIES.reduce<Record<string, string>>(
+	(aliases, entity) => {
+		const defaultResourceKey = lowerCamelCase(entity.name);
+		const resourceKey = entity.resourceKey ?? defaultResourceKey;
+		if (defaultResourceKey.toLowerCase() !== resourceKey.toLowerCase()) {
+			aliases[defaultResourceKey.toLowerCase()] = resourceKey;
+		}
+		return aliases;
+	},
+	{
+		// Backward-compatible aliases not derivable from entity metadata.
+		companysiteconfiguration: 'companySiteConfigurations',
+		serviceLevelAgreementResult: 'serviceLevelAgreementResults',
+		servicecallticketresources: 'serviceCallTicketResource',
+		servicecalltaskresources: 'serviceCallTaskResource',
+	},
+);
 
 export function normaliseResourceName(resource: string): string {
-    const trimmed = resource.trim();
-    if (!trimmed) return resource;
-    return RESOURCE_ALIASES[trimmed.toLowerCase()] ?? trimmed;
+	const trimmed = resource.trim();
+	if (!trimmed) return resource;
+	return RESOURCE_ALIASES[trimmed.toLowerCase()] ?? trimmed;
 }
 
 export function getResourceOperations(resource: string): string[] {
-    return NORMALIZED_RESOURCE_OPERATIONS_MAP[normaliseResourceName(resource).toLowerCase()] || [];
+	return NORMALIZED_RESOURCE_OPERATIONS_MAP[normaliseResourceName(resource).toLowerCase()] || [];
 }

--- a/nodes/Autotask/helpers/company-domain-search.ts
+++ b/nodes/Autotask/helpers/company-domain-search.ts
@@ -8,421 +8,620 @@ const MAX_DOMAIN_LIMIT = 100;
 const DEFAULT_DOMAIN_LIMIT = 25;
 const MAX_CONTACT_FALLBACK_LIMIT = 500;
 const COMPANY_DOMAIN_FIELD_PRIORITY = [
-    'webAddress',
-    'webaddress',
-    'website',
-    'websiteUrl',
-    'webSiteURL',
-    'url',
-    'domain',
+	'webAddress',
+	'webaddress',
+	'website',
+	'websiteUrl',
+	'webSiteURL',
+	'url',
+	'domain',
 ] as const;
 
 type DomainOperator = 'eq' | 'beginsWith' | 'endsWith' | 'contains';
 
 interface DomainSearchOptions {
-    domain: string;
-    domainOperator?: string;
-    searchContactEmails?: boolean;
-    limit?: number;
-    itemIndex?: number;
-    selectColumns?: string[];
+	domain: string;
+	domainOperator?: string;
+	searchContactEmails?: boolean;
+	limit?: number;
+	itemIndex?: number;
+	selectColumns?: string[];
+}
+
+interface IdentitySearchOptions {
+	companyName?: string;
+	email?: string;
+	website?: string;
+	limit?: number;
+	itemIndex?: number;
+	selectColumns?: string[];
 }
 
 interface CompanyFrequency extends IDataObject {
-    companyId: number | string;
-    companyName: string;
-    count: number;
+	companyId: number | string;
+	companyName: string;
+	count: number;
 }
 
 export interface CompanyDomainSearchResult extends IDataObject {
-    source: 'companyWebsite' | 'contactEmailFallback' | 'none';
-    domainInput: string;
-    domainNormalised: string;
-    requestedOperator: string;
-    appliedCompanyOperator: DomainOperator;
-    searchContactEmails: boolean;
-    count: number;
-    results: IDataObject[];
-    topCompanyName?: string;
-    topCompanyId?: number | string | null;
-    matchedContacts?: number;
-    matchedCompanies?: number;
-    companyFrequencies?: CompanyFrequency[];
-    notes?: string[];
+	source: 'companyWebsite' | 'contactEmailFallback' | 'none';
+	domainInput: string;
+	domainNormalised: string;
+	requestedOperator: string;
+	appliedCompanyOperator: DomainOperator;
+	searchContactEmails: boolean;
+	count: number;
+	results: IDataObject[];
+	topCompanyName?: string;
+	topCompanyId?: number | string | null;
+	matchedContacts?: number;
+	matchedCompanies?: number;
+	companyFrequencies?: CompanyFrequency[];
+	notes?: string[];
+}
+
+interface RankedCompanyCandidate extends IDataObject {
+	confidence: number;
+	confidenceReason: string;
+	matchedSignals: string[];
+}
+
+export interface CompanyIdentitySearchResult extends IDataObject {
+	source: 'rankedIdentity' | 'none';
+	companyNameInput?: string;
+	emailInput?: string;
+	websiteInput?: string;
+	domainNormalised: string;
+	count: number;
+	results: RankedCompanyCandidate[];
+	notes?: string[];
 }
 
 function clampLimit(limit: number | undefined, fallback = DEFAULT_DOMAIN_LIMIT): number {
-    if (typeof limit !== 'number' || Number.isNaN(limit)) return fallback;
-    return Math.min(Math.max(Math.trunc(limit), 1), MAX_DOMAIN_LIMIT);
+	if (typeof limit !== 'number' || Number.isNaN(limit)) return fallback;
+	return Math.min(Math.max(Math.trunc(limit), 1), MAX_DOMAIN_LIMIT);
 }
 
 function normaliseDomainInput(value: string): string {
-    let normalised = value.trim().toLowerCase();
-    normalised = normalised.replace(/^https?:\/\//i, '');
-    normalised = normalised.replace(/^www\./i, '');
-    normalised = normalised.replace(/\/+$/, '');
-    const slashIndex = normalised.indexOf('/');
-    if (slashIndex >= 0) {
-        normalised = normalised.slice(0, slashIndex);
-    }
-    const hashIndex = normalised.indexOf('#');
-    if (hashIndex >= 0) {
-        normalised = normalised.slice(0, hashIndex);
-    }
-    const queryIndex = normalised.indexOf('?');
-    if (queryIndex >= 0) {
-        normalised = normalised.slice(0, queryIndex);
-    }
-    if (normalised.includes('@')) {
-        const [, domainPart] = normalised.split('@');
-        if (domainPart) normalised = domainPart;
-    }
-    normalised = normalised.replace(/:\d+$/, '');
-    return normalised;
+	let normalised = value.trim().toLowerCase();
+	normalised = normalised.replace(/^https?:\/\//i, '');
+	normalised = normalised.replace(/^www\./i, '');
+	normalised = normalised.replace(/\/+$/, '');
+	const slashIndex = normalised.indexOf('/');
+	if (slashIndex >= 0) {
+		normalised = normalised.slice(0, slashIndex);
+	}
+	const hashIndex = normalised.indexOf('#');
+	if (hashIndex >= 0) {
+		normalised = normalised.slice(0, hashIndex);
+	}
+	const queryIndex = normalised.indexOf('?');
+	if (queryIndex >= 0) {
+		normalised = normalised.slice(0, queryIndex);
+	}
+	if (normalised.includes('@')) {
+		const [, domainPart] = normalised.split('@');
+		if (domainPart) normalised = domainPart;
+	}
+	normalised = normalised.replace(/:\d+$/, '');
+	return normalised;
 }
 
 function normaliseOperator(operator: string | undefined): DomainOperator {
-    const lower = (operator ?? 'contains').trim().toLowerCase();
-    if (lower === 'like') return 'contains';
-    if (lower === 'eq' || lower === 'beginswith' || lower === 'endswith' || lower === 'contains') {
-        if (lower === 'beginswith') return 'beginsWith';
-        if (lower === 'endswith') return 'endsWith';
-        return lower as DomainOperator;
-    }
-    return 'contains';
+	const lower = (operator ?? 'contains').trim().toLowerCase();
+	if (lower === 'like') return 'contains';
+	if (lower === 'eq' || lower === 'beginswith' || lower === 'endswith' || lower === 'contains') {
+		if (lower === 'beginswith') return 'beginsWith';
+		if (lower === 'endswith') return 'endsWith';
+		return lower as DomainOperator;
+	}
+	return 'contains';
 }
 
 function applyTextOperator(value: string, operator: DomainOperator, search: string): boolean {
-    const left = value.toLowerCase();
-    const right = search.toLowerCase();
-    switch (operator) {
-        case 'eq':
-            return left === right;
-        case 'beginsWith':
-            return left.startsWith(right);
-        case 'endsWith':
-            return left.endsWith(right);
-        case 'contains':
-            return left.includes(right);
-        default:
-            return false;
-    }
+	const left = value.toLowerCase();
+	const right = search.toLowerCase();
+	switch (operator) {
+		case 'eq':
+			return left === right;
+		case 'beginsWith':
+			return left.startsWith(right);
+		case 'endsWith':
+			return left.endsWith(right);
+		case 'contains':
+			return left.includes(right);
+		default:
+			return false;
+	}
 }
 
 function buildWebsiteFieldList(companyFieldNames: string[]): string[] {
-    const lowerLookup = new Map(companyFieldNames.map((name) => [name.toLowerCase(), name]));
-    const ordered: string[] = [];
-    for (const field of COMPANY_DOMAIN_FIELD_PRIORITY) {
-        const match = lowerLookup.get(field.toLowerCase());
-        if (match && !ordered.includes(match)) {
-            ordered.push(match);
-        }
-    }
-    for (const name of companyFieldNames) {
-        const lower = name.toLowerCase();
-        if (ordered.includes(name)) continue;
-        if (/(web|website|url|domain)/i.test(lower)) {
-            ordered.push(name);
-        }
-    }
-    return ordered;
+	const lowerLookup = new Map(companyFieldNames.map((name) => [name.toLowerCase(), name]));
+	const ordered: string[] = [];
+	for (const field of COMPANY_DOMAIN_FIELD_PRIORITY) {
+		const match = lowerLookup.get(field.toLowerCase());
+		if (match && !ordered.includes(match)) {
+			ordered.push(match);
+		}
+	}
+	for (const name of companyFieldNames) {
+		const lower = name.toLowerCase();
+		if (ordered.includes(name)) continue;
+		if (/(web|website|url|domain)/i.test(lower)) {
+			ordered.push(name);
+		}
+	}
+	return ordered;
 }
 
 async function runBoundedQuery(
-    context: IExecuteFunctions,
-    entityType: string,
-    itemIndex: number,
-    limit: number,
-    filters: IFilterCondition[],
-    selectColumns: string[],
+	context: IExecuteFunctions,
+	entityType: string,
+	itemIndex: number,
+	limit: number,
+	filters: IFilterCondition[],
+	selectColumns: string[],
 ): Promise<IAutotaskEntity[]> {
-    const originalGetNodeParameter = context.getNodeParameter.bind(context);
-    context.getNodeParameter = ((
-        name: string,
-        index: number,
-        fallbackValue?: unknown,
-        options?: IGetNodeParameterOptions,
-    ): unknown => {
-        if (name === 'returnAll') return false;
-        if (name === 'maxRecords') return limit;
-        if (name === 'selectColumns') return selectColumns;
-        if (name === 'selectColumnsJson') return JSON.stringify(selectColumns);
-        return originalGetNodeParameter(name, index, fallbackValue, options);
-    }) as typeof context.getNodeParameter;
+	const originalGetNodeParameter = context.getNodeParameter.bind(context);
+	context.getNodeParameter = ((
+		name: string,
+		index: number,
+		fallbackValue?: unknown,
+		options?: IGetNodeParameterOptions,
+	): unknown => {
+		if (name === 'returnAll') return false;
+		if (name === 'maxRecords') return limit;
+		if (name === 'selectColumns') return selectColumns;
+		if (name === 'selectColumnsJson') return JSON.stringify(selectColumns);
+		return originalGetNodeParameter(name, index, fallbackValue, options);
+	}) as typeof context.getNodeParameter;
 
-    try {
-        const getManyOp = new GetManyOperation<IAutotaskEntity>(entityType, context);
-        const results = await getManyOp.execute({ filter: filters, MaxRecords: limit }, itemIndex);
-        return results.slice(0, limit);
-    } finally {
-        context.getNodeParameter = originalGetNodeParameter;
-    }
+	try {
+		const getManyOp = new GetManyOperation<IAutotaskEntity>(entityType, context);
+		const results = await getManyOp.execute({ filter: filters, MaxRecords: limit }, itemIndex);
+		return results.slice(0, limit);
+	} finally {
+		context.getNodeParameter = originalGetNodeParameter;
+	}
 }
 
 function isValidCompanyId(value: unknown): value is string | number {
-    if (typeof value === 'number') return Number.isFinite(value);
-    if (typeof value === 'string') return value.trim() !== '';
-    return false;
+	if (typeof value === 'number') return Number.isFinite(value);
+	if (typeof value === 'string') return value.trim() !== '';
+	return false;
 }
 
 export async function searchCompaniesByDomain(
-    context: IExecuteFunctions,
-    options: DomainSearchOptions,
+	context: IExecuteFunctions,
+	options: DomainSearchOptions,
 ): Promise<CompanyDomainSearchResult> {
-    const itemIndex = options.itemIndex ?? 0;
-    const domainInput = options.domain;
-    const domainNormalised = normaliseDomainInput(domainInput);
-    const requestedOperator = options.domainOperator ?? 'contains';
-    const requestedNormalisedOperator = normaliseOperator(requestedOperator);
-    const limit = clampLimit(options.limit);
-    const searchContactEmails = options.searchContactEmails !== false;
-    const notes: string[] = [];
+	const itemIndex = options.itemIndex ?? 0;
+	const domainInput = options.domain;
+	const domainNormalised = normaliseDomainInput(domainInput);
+	const requestedOperator = options.domainOperator ?? 'contains';
+	const requestedNormalisedOperator = normaliseOperator(requestedOperator);
+	const limit = clampLimit(options.limit);
+	const searchContactEmails = options.searchContactEmails !== false;
+	const notes: string[] = [];
 
-    if (!domainNormalised) {
-        return {
-            source: 'none',
-            domainInput,
-            domainNormalised,
-            requestedOperator,
-            appliedCompanyOperator: 'contains',
-            searchContactEmails,
-            count: 0,
-            results: [],
-            notes: ['Domain is empty after normalisation.'],
-        };
-    }
+	if (!domainNormalised) {
+		return {
+			source: 'none',
+			domainInput,
+			domainNormalised,
+			requestedOperator,
+			appliedCompanyOperator: 'contains',
+			searchContactEmails,
+			count: 0,
+			results: [],
+			notes: ['Domain is empty after normalisation.'],
+		};
+	}
 
-    const companyFields = await getFields('company', context, { fieldType: 'standard' });
-    const companyFieldNames = companyFields.map((field) => field.name);
-    const websiteFields = buildWebsiteFieldList(companyFieldNames);
-    if (websiteFields.length === 0) {
-        return {
-            source: 'none',
-            domainInput,
-            domainNormalised,
-            requestedOperator,
-            appliedCompanyOperator: 'contains',
-            searchContactEmails,
-            count: 0,
-            results: [],
-            notes: ['No company website/domain field was detected in entity metadata.'],
-        };
-    }
+	const companyFields = await getFields('company', context, { fieldType: 'standard' });
+	const companyFieldNames = companyFields.map((field) => field.name);
+	const websiteFields = buildWebsiteFieldList(companyFieldNames);
+	if (websiteFields.length === 0) {
+		return {
+			source: 'none',
+			domainInput,
+			domainNormalised,
+			requestedOperator,
+			appliedCompanyOperator: 'contains',
+			searchContactEmails,
+			count: 0,
+			results: [],
+			notes: ['No company website/domain field was detected in entity metadata.'],
+		};
+	}
 
-    let appliedCompanyOperator = requestedNormalisedOperator;
-    if (requestedNormalisedOperator === 'eq') {
-        appliedCompanyOperator = 'contains';
-        notes.push(
-            "Requested operator 'eq' was mapped to 'contains' for company website fields because Autotask stores full URLs (for example https://...).",
-        );
-    }
+	let appliedCompanyOperator = requestedNormalisedOperator;
+	if (requestedNormalisedOperator === 'eq') {
+		appliedCompanyOperator = 'contains';
+		notes.push(
+			"Requested operator 'eq' was mapped to 'contains' for company website fields because Autotask stores full URLs (for example https://...).",
+		);
+	}
 
-    const companyFilterItems = websiteFields.map((fieldName) => ({
-        field: fieldName,
-        op: appliedCompanyOperator,
-        value: domainNormalised,
-    }));
-    const companyFilters = companyFilterItems.length === 1
-        ? companyFilterItems
-        : [{ op: 'or', items: companyFilterItems }];
-    const userSelectColumns = options.selectColumns ?? [];
-    // If user specified columns, merge with websiteFields so matching still works.
-    // If no columns (default), pass [] → API returns all fields.
-    const queryColumns = userSelectColumns.length > 0
-        ? Array.from(new Set([...userSelectColumns, 'id', ...websiteFields]))
-        : [];
-    const companyResults = await runBoundedQuery(
-        context,
-        'company',
-        itemIndex,
-        limit,
-        companyFilters,
-        queryColumns,
-    );
+	const companyFilterItems = websiteFields.map((fieldName) => ({
+		field: fieldName,
+		op: appliedCompanyOperator,
+		value: domainNormalised,
+	}));
+	const companyFilters =
+		companyFilterItems.length === 1
+			? companyFilterItems
+			: [{ op: 'or', items: companyFilterItems }];
+	const userSelectColumns = options.selectColumns ?? [];
+	// If user specified columns, merge with websiteFields so matching still works.
+	// If no columns (default), pass [] → API returns all fields.
+	const queryColumns =
+		userSelectColumns.length > 0
+			? Array.from(new Set([...userSelectColumns, 'id', ...websiteFields]))
+			: [];
+	const companyResults = await runBoundedQuery(
+		context,
+		'company',
+		itemIndex,
+		limit,
+		companyFilters,
+		queryColumns,
+	);
 
-    const enrichedResults: IDataObject[] = companyResults.map((company) => {
-        let matchedField: string | null = null;
-        let matchedValue: string | null = null;
-        for (const fieldName of websiteFields) {
-            const raw = company[fieldName];
-            if (typeof raw !== 'string' || raw.trim() === '') continue;
-            if (applyTextOperator(raw, appliedCompanyOperator, domainNormalised)) {
-                matchedField = fieldName;
-                matchedValue = raw;
-                break;
-            }
-        }
+	const enrichedResults: IDataObject[] = companyResults.map((company) => {
+		let matchedField: string | null = null;
+		let matchedValue: string | null = null;
+		for (const fieldName of websiteFields) {
+			const raw = company[fieldName];
+			if (typeof raw !== 'string' || raw.trim() === '') continue;
+			if (applyTextOperator(raw, appliedCompanyOperator, domainNormalised)) {
+				matchedField = fieldName;
+				matchedValue = raw;
+				break;
+			}
+		}
 
-        let resultEntity: IDataObject;
-        if (userSelectColumns.length === 0) {
-            resultEntity = { ...company };
-        } else {
-            resultEntity = { id: (company.id as number | string | undefined) ?? null };
-            for (const col of userSelectColumns) {
-                if (col in company) resultEntity[col] = company[col];
-            }
-        }
+		let resultEntity: IDataObject;
+		if (userSelectColumns.length === 0) {
+			resultEntity = { ...company };
+		} else {
+			resultEntity = { id: (company.id as number | string | undefined) ?? null };
+			for (const col of userSelectColumns) {
+				if (col in company) resultEntity[col] = company[col];
+			}
+		}
 
-        return { ...resultEntity, matchedField, matchedValue };
-    });
+		return { ...resultEntity, matchedField, matchedValue };
+	});
 
-    if (enrichedResults.length > 0) {
-        return {
-            source: 'companyWebsite',
-            domainInput,
-            domainNormalised,
-            requestedOperator,
-            appliedCompanyOperator,
-            searchContactEmails,
-            count: enrichedResults.length,
-            results: enrichedResults,
-            ...(notes.length > 0 ? { notes } : {}),
-        };
-    }
+	if (enrichedResults.length > 0) {
+		return {
+			source: 'companyWebsite',
+			domainInput,
+			domainNormalised,
+			requestedOperator,
+			appliedCompanyOperator,
+			searchContactEmails,
+			count: enrichedResults.length,
+			results: enrichedResults,
+			...(notes.length > 0 ? { notes } : {}),
+		};
+	}
 
-    if (!searchContactEmails) {
-        notes.push('No company website/domain records matched and contact email fallback is disabled.');
-        return {
-            source: 'none',
-            domainInput,
-            domainNormalised,
-            requestedOperator,
-            appliedCompanyOperator,
-            searchContactEmails,
-            count: 0,
-            results: [],
-            notes,
-        };
-    }
+	if (!searchContactEmails) {
+		notes.push('No company website/domain records matched and contact email fallback is disabled.');
+		return {
+			source: 'none',
+			domainInput,
+			domainNormalised,
+			requestedOperator,
+			appliedCompanyOperator,
+			searchContactEmails,
+			count: 0,
+			results: [],
+			notes,
+		};
+	}
 
-    let contactOperator: DomainOperator = requestedNormalisedOperator;
-    let contactValue = domainNormalised;
-    if (requestedNormalisedOperator === 'eq') {
-        contactOperator = 'endsWith';
-        contactValue = `@${domainNormalised}`;
-        notes.push("Requested contact fallback operator 'eq' was mapped to 'endsWith' using '@domain'.");
-    }
+	let contactOperator: DomainOperator = requestedNormalisedOperator;
+	let contactValue = domainNormalised;
+	if (requestedNormalisedOperator === 'eq') {
+		contactOperator = 'endsWith';
+		contactValue = `@${domainNormalised}`;
+		notes.push(
+			"Requested contact fallback operator 'eq' was mapped to 'endsWith' using '@domain'.",
+		);
+	}
 
-    const contactLimit = Math.min(Math.max(limit * 10, 50), MAX_CONTACT_FALLBACK_LIMIT);
-    const contactFilters = [
-        {
-            field: 'emailAddress',
-            op: contactOperator,
-            value: contactValue,
-        },
-    ];
-    const contactResults = await runBoundedQuery(
-        context,
-        'contact',
-        itemIndex,
-        contactLimit,
-        contactFilters,
-        ['id', 'companyID', 'companyName', 'emailAddress'],
-    );
+	const contactLimit = Math.min(Math.max(limit * 10, 50), MAX_CONTACT_FALLBACK_LIMIT);
+	const contactFilters = [
+		{
+			field: 'emailAddress',
+			op: contactOperator,
+			value: contactValue,
+		},
+	];
+	const contactResults = await runBoundedQuery(
+		context,
+		'contact',
+		itemIndex,
+		contactLimit,
+		contactFilters,
+		['id', 'companyID', 'companyName', 'emailAddress'],
+	);
 
-    const companyFrequencyById = new Map<string, { companyId: string | number; count: number }>();
-    for (const contact of contactResults) {
-        const companyIdRaw = contact.companyID;
-        if (!isValidCompanyId(companyIdRaw)) continue;
-        const key = String(companyIdRaw);
-        const current = companyFrequencyById.get(key);
-        if (current) {
-            current.count += 1;
-        } else {
-            companyFrequencyById.set(key, { companyId: companyIdRaw, count: 1 });
-        }
-    }
+	const companyFrequencyById = new Map<string, { companyId: string | number; count: number }>();
+	for (const contact of contactResults) {
+		const companyIdRaw = contact.companyID;
+		if (!isValidCompanyId(companyIdRaw)) continue;
+		const key = String(companyIdRaw);
+		const current = companyFrequencyById.get(key);
+		if (current) {
+			current.count += 1;
+		} else {
+			companyFrequencyById.set(key, { companyId: companyIdRaw, count: 1 });
+		}
+	}
 
-    if (companyFrequencyById.size === 0) {
-        notes.push('No contacts with a valid companyID were found for the supplied domain.');
-        return {
-            source: 'none',
-            domainInput,
-            domainNormalised,
-            requestedOperator,
-            appliedCompanyOperator,
-            searchContactEmails,
-            count: 0,
-            results: [],
-            matchedContacts: contactResults.length,
-            notes,
-        };
-    }
+	if (companyFrequencyById.size === 0) {
+		notes.push('No contacts with a valid companyID were found for the supplied domain.');
+		return {
+			source: 'none',
+			domainInput,
+			domainNormalised,
+			requestedOperator,
+			appliedCompanyOperator,
+			searchContactEmails,
+			count: 0,
+			results: [],
+			matchedContacts: contactResults.length,
+			notes,
+		};
+	}
 
-    const companyIds = Array.from(companyFrequencyById.values()).map((entry) => entry.companyId);
-    const resolvedCompanies = await runBoundedQuery(
-        context,
-        'company',
-        itemIndex,
-        Math.min(companyIds.length, MAX_CONTACT_FALLBACK_LIMIT),
-        [
-            {
-                field: 'id',
-                op: 'in',
-                value: companyIds,
-            },
-        ],
-        ['id', 'companyName'],
-    );
+	const companyIds = Array.from(companyFrequencyById.values()).map((entry) => entry.companyId);
+	const resolvedCompanies = await runBoundedQuery(
+		context,
+		'company',
+		itemIndex,
+		Math.min(companyIds.length, MAX_CONTACT_FALLBACK_LIMIT),
+		[
+			{
+				field: 'id',
+				op: 'in',
+				value: companyIds,
+			},
+		],
+		['id', 'companyName'],
+	);
 
-    const companyNameById = new Map<string, string>();
-    for (const company of resolvedCompanies) {
-        if (!isValidCompanyId(company.id)) continue;
-        const companyName = company.companyName;
-        if (typeof companyName === 'string' && companyName.trim() !== '') {
-            companyNameById.set(String(company.id), companyName.trim());
-        }
-    }
+	const companyNameById = new Map<string, string>();
+	for (const company of resolvedCompanies) {
+		if (!isValidCompanyId(company.id)) continue;
+		const companyName = company.companyName;
+		if (typeof companyName === 'string' && companyName.trim() !== '') {
+			companyNameById.set(String(company.id), companyName.trim());
+		}
+	}
 
-    const companyFrequencies: CompanyFrequency[] = [];
-    for (const { companyId, count } of companyFrequencyById.values()) {
-        const companyName = companyNameById.get(String(companyId));
-        if (!companyName) continue;
-        companyFrequencies.push({
-            companyId,
-            companyName,
-            count,
-        });
-    }
+	const companyFrequencies: CompanyFrequency[] = [];
+	for (const { companyId, count } of companyFrequencyById.values()) {
+		const companyName = companyNameById.get(String(companyId));
+		if (!companyName) continue;
+		companyFrequencies.push({
+			companyId,
+			companyName,
+			count,
+		});
+	}
 
-    companyFrequencies.sort((a, b) => {
-        const countDiff = (b.count as number) - (a.count as number);
-        if (countDiff !== 0) return countDiff;
-        return String(a.companyName).localeCompare(String(b.companyName), 'en-AU');
-    });
+	companyFrequencies.sort((a, b) => {
+		const countDiff = (b.count as number) - (a.count as number);
+		if (countDiff !== 0) return countDiff;
+		return String(a.companyName).localeCompare(String(b.companyName), 'en-AU');
+	});
 
-    if (companyFrequencies.length === 0) {
-        notes.push('Contacts matched, but no canonical company names could be resolved from companyID values.');
-        return {
-            source: 'none',
-            domainInput,
-            domainNormalised,
-            requestedOperator,
-            appliedCompanyOperator,
-            searchContactEmails,
-            count: 0,
-            results: [],
-            matchedContacts: contactResults.length,
-            matchedCompanies: resolvedCompanies.length,
-            notes,
-        };
-    }
+	if (companyFrequencies.length === 0) {
+		notes.push(
+			'Contacts matched, but no canonical company names could be resolved from companyID values.',
+		);
+		return {
+			source: 'none',
+			domainInput,
+			domainNormalised,
+			requestedOperator,
+			appliedCompanyOperator,
+			searchContactEmails,
+			count: 0,
+			results: [],
+			matchedContacts: contactResults.length,
+			matchedCompanies: resolvedCompanies.length,
+			notes,
+		};
+	}
 
-    const topCompany = companyFrequencies[0];
-    return {
-        source: 'contactEmailFallback',
-        domainInput,
-        domainNormalised,
-        requestedOperator,
-        appliedCompanyOperator,
-        searchContactEmails,
-        count: 1,
-        results: [],
-        topCompanyName: topCompany.companyName as string,
-        topCompanyId: topCompany.companyId as string | number,
-        matchedContacts: contactResults.length,
-        matchedCompanies: resolvedCompanies.length,
-        companyFrequencies,
-        ...(notes.length > 0 ? { notes } : {}),
-    };
+	const topCompany = companyFrequencies[0];
+	return {
+		source: 'contactEmailFallback',
+		domainInput,
+		domainNormalised,
+		requestedOperator,
+		appliedCompanyOperator,
+		searchContactEmails,
+		count: 1,
+		results: [],
+		topCompanyName: topCompany.companyName as string,
+		topCompanyId: topCompany.companyId as string | number,
+		matchedContacts: contactResults.length,
+		matchedCompanies: resolvedCompanies.length,
+		companyFrequencies,
+		...(notes.length > 0 ? { notes } : {}),
+	};
+}
+
+function scoreCompanyCandidate(
+	company: IDataObject,
+	nameNeedle: string,
+	domainNeedle: string,
+	websiteFields: string[],
+): RankedCompanyCandidate {
+	let confidence = 0;
+	const matchedSignals: string[] = [];
+	let confidenceReason = 'Low confidence';
+
+	if (domainNeedle) {
+		for (const fieldName of websiteFields) {
+			const raw = company[fieldName];
+			if (typeof raw !== 'string' || raw.trim() === '') continue;
+			const fieldDomain = normaliseDomainInput(raw);
+			if (!fieldDomain) continue;
+			if (fieldDomain === domainNeedle) {
+				confidence += 90;
+				matchedSignals.push(`domainExact:${fieldName}`);
+				confidenceReason = 'Exact domain match on company website field';
+				break;
+			}
+			if (fieldDomain.includes(domainNeedle) || domainNeedle.includes(fieldDomain)) {
+				confidence += 70;
+				matchedSignals.push(`domainPartial:${fieldName}`);
+				confidenceReason = 'Partial domain match on company website field';
+				break;
+			}
+		}
+	}
+
+	const companyName =
+		typeof company.companyName === 'string' ? company.companyName.toLowerCase() : '';
+	if (nameNeedle && companyName.includes(nameNeedle)) {
+		confidence += companyName === nameNeedle ? 60 : 40;
+		matchedSignals.push('companyNameContains');
+		if (!domainNeedle) {
+			confidenceReason =
+				companyName === nameNeedle ? 'Exact company name match' : 'Company name contains match';
+		}
+	}
+
+	return {
+		...company,
+		confidence,
+		confidenceReason,
+		matchedSignals,
+	};
+}
+
+export async function searchCompaniesByIdentity(
+	context: IExecuteFunctions,
+	options: IdentitySearchOptions,
+): Promise<CompanyIdentitySearchResult> {
+	const itemIndex = options.itemIndex ?? 0;
+	const limit = clampLimit(options.limit);
+	const companyNameInput = options.companyName?.trim() ?? '';
+	const emailInput = options.email?.trim() ?? '';
+	const websiteInput = options.website?.trim() ?? '';
+	const notes: string[] = [];
+
+	const domainFromEmail = emailInput ? normaliseDomainInput(emailInput) : '';
+	const domainFromWebsite = websiteInput ? normaliseDomainInput(websiteInput) : '';
+	const domainNormalised = domainFromWebsite || domainFromEmail;
+
+	const userSelectColumns = options.selectColumns ?? [];
+	const companyFields = await getFields('company', context, { fieldType: 'standard' });
+	const websiteFields = buildWebsiteFieldList(companyFields.map((field) => field.name));
+	const selectColumns =
+		userSelectColumns.length > 0
+			? Array.from(new Set([...userSelectColumns, 'id', 'companyName', ...websiteFields]))
+			: [];
+
+	const candidatesById = new Map<string, IDataObject>();
+
+	if (domainNormalised) {
+		const domainResults = await searchCompaniesByDomain(context, {
+			domain: domainNormalised,
+			domainOperator: 'contains',
+			searchContactEmails: true,
+			limit,
+			itemIndex,
+			selectColumns,
+		});
+
+		if (domainResults.source === 'companyWebsite' && domainResults.results.length > 0) {
+			for (const result of domainResults.results) {
+				const id = result.id;
+				if (!isValidCompanyId(id)) continue;
+				candidatesById.set(String(id), result);
+			}
+		} else if (domainResults.source === 'contactEmailFallback') {
+			notes.push(
+				'Domain matched contacts but not a direct company website field; lowering confidence.',
+			);
+			for (const entry of domainResults.companyFrequencies ?? []) {
+				if (!isValidCompanyId(entry.companyId)) continue;
+				candidatesById.set(String(entry.companyId), {
+					id: entry.companyId,
+					companyName: entry.companyName,
+					contactMatchCount: entry.count,
+				});
+			}
+		}
+	}
+
+	const hasConfidentDomainMatch = Array.from(candidatesById.values()).length > 0;
+	if (companyNameInput) {
+		if (hasConfidentDomainMatch) {
+			notes.push('Company name search also executed to enrich ranking among domain candidates.');
+		} else {
+			notes.push('No confident domain match found; using company name contains search.');
+		}
+		const nameResults = await runBoundedQuery(
+			context,
+			'company',
+			itemIndex,
+			Math.min(Math.max(limit * 2, 25), MAX_CONTACT_FALLBACK_LIMIT),
+			[{ field: 'companyName', op: 'contains', value: companyNameInput }],
+			selectColumns,
+		);
+		for (const result of nameResults) {
+			const id = result.id;
+			if (!isValidCompanyId(id)) continue;
+			const key = String(id);
+			const existing = candidatesById.get(key);
+			candidatesById.set(key, existing ? { ...existing, ...result } : result);
+		}
+	}
+
+	const nameNeedle = companyNameInput.toLowerCase();
+	const rankedResults = Array.from(candidatesById.values())
+		.map((candidate) =>
+			scoreCompanyCandidate(candidate, nameNeedle, domainNormalised, websiteFields),
+		)
+		.sort((a, b) => {
+			const scoreDiff = (b.confidence as number) - (a.confidence as number);
+			if (scoreDiff !== 0) return scoreDiff;
+			return String(a.companyName ?? '').localeCompare(String(b.companyName ?? ''), 'en-US');
+		})
+		.slice(0, limit);
+
+	if (rankedResults.length === 0) {
+		return {
+			source: 'none',
+			companyNameInput: companyNameInput || undefined,
+			emailInput: emailInput || undefined,
+			websiteInput: websiteInput || undefined,
+			domainNormalised,
+			count: 0,
+			results: [],
+			notes: ['No candidates found from identity signals.', ...notes],
+		};
+	}
+
+	return {
+		source: 'rankedIdentity',
+		companyNameInput: companyNameInput || undefined,
+		emailInput: emailInput || undefined,
+		websiteInput: websiteInput || undefined,
+		domainNormalised,
+		count: rankedResults.length,
+		results: rankedResults,
+		...(notes.length > 0 ? { notes } : {}),
+	};
 }

--- a/nodes/Autotask/operations/common/select-columns/description.ts
+++ b/nodes/Autotask/operations/common/select-columns/description.ts
@@ -8,11 +8,21 @@ export const selectColumnsOption: INodeProperties = {
 	name: 'selectColumns',
 	type: 'multiOptions',
 	default: [],
-	description: 'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+	description:
+		'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 	hint: 'Choose which fields to include in the response. If no fields are selected, all fields will be returned. The ID field is always included regardless of selection.',
 	displayOptions: {
 		show: {
-			operation: ['get', 'getMany', 'getManyAdvanced', 'getUnposted', 'getPosted', 'whoAmI', 'searchByDomain'],
+			operation: [
+				'get',
+				'getMany',
+				'getManyAdvanced',
+				'getUnposted',
+				'getPosted',
+				'whoAmI',
+				'searchByDomain',
+				'searchByIdentity',
+			],
 		},
 	},
 	typeOptions: {

--- a/nodes/Autotask/resources/companies/description.ts
+++ b/nodes/Autotask/resources/companies/description.ts
@@ -32,9 +32,17 @@ const operationOptions = [
 		action: 'Count companies',
 	},
 	{
+		name: 'Search by Identity',
+		value: 'searchByIdentity',
+		description:
+			'Preferred AI search: resolve companies using company name, email, website/domain, and ranking',
+		action: 'Search companies by identity',
+	},
+	{
 		name: 'Search by Domain',
 		value: 'searchByDomain',
-		description: 'Search companies by website domain with optional contact-email fallback',
+		description:
+			'Legacy search by website domain with optional contact-email fallback (searchByIdentity is preferred)',
 		action: 'Search companies by domain',
 	},
 ];
@@ -47,9 +55,7 @@ const baseFields: INodeProperties[] = [
 		noDataExpression: true,
 		displayOptions: {
 			show: {
-				resource: [
-					'company',
-				],
+				resource: ['company'],
 			},
 		},
 		options: operationOptions,
@@ -98,6 +104,45 @@ const baseFields: INodeProperties[] = [
 				supportAutoMap: true,
 			},
 		},
+	},
+	{
+		displayName: 'Company Name',
+		name: 'companyName',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['company'],
+				operation: ['searchByIdentity'],
+			},
+		},
+		description: 'Optional company name to match (contains search)',
+	},
+	{
+		displayName: 'Email',
+		name: 'email',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['company'],
+				operation: ['searchByIdentity'],
+			},
+		},
+		description: 'Optional email used to infer domain (for example person@autotask.net)',
+	},
+	{
+		displayName: 'Website/Domain',
+		name: 'website',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['company'],
+				operation: ['searchByIdentity'],
+			},
+		},
+		description: 'Optional website or domain (for example https://www.autotask.net)',
 	},
 	{
 		displayName: 'Domain',
@@ -159,7 +204,8 @@ const baseFields: INodeProperties[] = [
 				operation: ['searchByDomain'],
 			},
 		},
-		description: 'Whether to search contacts by email domain when no company website matches are found',
+		description:
+			'Whether to search contacts by email domain when no company website matches are found',
 	},
 	{
 		displayName: 'Limit',
@@ -173,7 +219,7 @@ const baseFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['company'],
-				operation: ['searchByDomain'],
+				operation: ['searchByDomain', 'searchByIdentity'],
 			},
 		},
 		description: 'Max number of results to return',

--- a/nodes/Autotask/resources/companies/execute.ts
+++ b/nodes/Autotask/resources/companies/execute.ts
@@ -7,7 +7,10 @@ import {
 	GetManyOperation,
 	CountOperation,
 } from '../../operations/base';
-import { searchCompaniesByDomain } from '../../helpers/company-domain-search';
+import {
+	searchCompaniesByDomain,
+	searchCompaniesByIdentity,
+} from '../../helpers/company-domain-search';
 import { getSelectedColumns } from '../../operations/common/select-columns/filter-entity';
 
 const ENTITY_TYPE = 'company';
@@ -67,13 +70,35 @@ export async function executeCompanyOperation(
 				case 'searchByDomain': {
 					const domain = this.getNodeParameter('domain', i) as string;
 					const domainOperator = this.getNodeParameter('domainOperator', i, 'contains') as string;
-					const searchContactEmails = this.getNodeParameter('searchContactEmails', i, true) as boolean;
+					const searchContactEmails = this.getNodeParameter(
+						'searchContactEmails',
+						i,
+						true,
+					) as boolean;
 					const limit = this.getNodeParameter('limit', i, 25) as number;
 					const selectColumns = getSelectedColumns(this, i);
 					const response = await searchCompaniesByDomain(this, {
 						domain,
 						domainOperator,
 						searchContactEmails,
+						limit,
+						selectColumns,
+						itemIndex: i,
+					});
+					returnData.push({ json: response });
+					break;
+				}
+
+				case 'searchByIdentity': {
+					const companyName = this.getNodeParameter('companyName', i, '') as string;
+					const email = this.getNodeParameter('email', i, '') as string;
+					const website = this.getNodeParameter('website', i, '') as string;
+					const limit = this.getNodeParameter('limit', i, 25) as number;
+					const selectColumns = getSelectedColumns(this, i);
+					const response = await searchCompaniesByIdentity(this, {
+						companyName,
+						email,
+						website,
 						limit,
 						selectColumns,
 						itemIndex: i,


### PR DESCRIPTION
### Motivation

- Provide a preferred AI-first company resolution operation that can accept partial/noisy identity signals (company name, email, website/domain) and return ranked candidate companies with confidence metadata.
- Keep existing `searchByDomain` for backward compatibility while surfacing a more robust `searchByIdentity` for model-driven flows.

### Description

- Added a new operation `searchByIdentity` to the Companies resource UI with optional `companyName`, `email`, `website`, and shared `limit` parameters, and documented `searchByDomain` as legacy (`nodes/Autotask/resources/companies/description.ts`).
- Implemented `searchCompaniesByIdentity` in `nodes/Autotask/helpers/company-domain-search.ts` that normalises domains (from `website` then `email`), runs domain-first lookups (company website fields + contact-email fallback), falls back to `companyName` contains search when needed, merges candidates and ranks them with `confidence` and `matchedSignals`.
- Routed `searchByIdentity` in `nodes/Autotask/resources/companies/execute.ts` to call the new helper while retaining `searchByDomain` behaviour.
- Updated AI tooling and metadata so the LLM sees `searchByIdentity` first: added operation metadata, descriptions, schema entries, validation, select-columns visibility, AI operation ordering, and dispatch/executor handling (`nodes/Autotask/ai-tools/*`, `nodes/Autotask/constants/resource-operations.ts`, `nodes/Autotask/AutotaskAiTools.node.ts`).

### Testing

- Ran static type checks via `pnpm -s typecheck` which succeeded.
- Ran formatting checks via `pnpm -s prettier --check` and fixed style issues with `pnpm -s prettier --write`, after which `prettier --check` passed for modified files.
- No runtime unit tests were added; changes were validated by the above automated type/format checks and local build/format pipeline steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee001cbf0483208642dc7e55f9430b)