### PR TITLE
Enforce domain-first company resolution in AI tool guidance

### DIFF
--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -304,6 +304,7 @@ export function buildUnpostedTimeEntriesDescription(
 export function buildCompanySearchByDomainDescription(resourceName: string): string {
 	return (
 		'Search companies by domain using website-style fields. ' +
+		'Identifier priority for company resolution: first extract/use domain from any provided email or website, then use company-name contains matching only as fallback. ' +
 		'Input can be a bare domain or full URL; the tool normalises it to a domain fragment (for example autotask.net). ' +
 		'IMPORTANT: Autotask typically stores company websites as full URLs (for example https://www.autotask.net/), so exact operator matches can fail on bare domain input. ' +
 		'To avoid false negatives, eq/like semantics are handled safely for website matching. ' +
@@ -611,6 +612,11 @@ export function buildUnifiedDescriptionTemplate(
 	if (identityHint) {
 		sections.push(identityHint);
 	}
+	if (resource === 'company') {
+		sections.push(
+			'Company identifier priority rule: derive domain from email/website first; only fall back to companyName contains matching when no domain signal is available.',
+		);
+	}
 	sections.push(
 		`Operations: ${allOps.join(', ')}. Set 'operation' to one.`,
 		dateTimeReferenceSnippet(DESCRIPTION_REFERENCE_PLACEHOLDER),
@@ -854,11 +860,17 @@ const READ_OP_PARAMS: Record<string, { required: OperationParam[]; optional: Ope
 	searchByDomain: {
 		required: [],
 		optional: [
-			{ field: 'domain', type: 'string', description: 'Domain to search, e.g. autotask.net.' },
+			{
+				field: 'domain',
+				type: 'string',
+				description:
+					"Domain to search. Prefer domain extracted from email/website first (e.g. email='user@domain.com' -> 'domain.com').",
+			},
 			{
 				field: 'domainOperator',
 				type: 'string',
-				description: "Operator: eq, beginsWith, endsWith, contains (default 'contains').",
+				description:
+					"Operator: eq, beginsWith, endsWith, contains (default 'contains'). Do domain matching first; avoid strict exact-name-only matching when a domain exists.",
 			},
 			{
 				field: 'searchContactEmails',

--- a/nodes/Autotask/ai-tools/operation-metadata.ts
+++ b/nodes/Autotask/ai-tools/operation-metadata.ts
@@ -64,7 +64,8 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 		label: 'Search by domain',
 		supportsFilters: false,
 		responseKind: 'list',
-		docsFragment: 'Search companies by domain string.',
+		docsFragment:
+			'Search companies by domain string. Identifier priority: when an email or website is present, extract and use the domain first (email/user URL domain) before any company-name matching. Use company-name contains matching only as fallback.',
 	},
 	{
 		name: 'count',

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -417,11 +417,15 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.string()
 				.min(1)
 				.nullish()
-				.describe('Domain to search, e.g. autotask.net or https://www.autotask.net/');
+				.describe(
+					"Domain to search. Prefer extracting domain from email/website first (e.g. email='user@domain.com' -> domain='domain.com'; website='https://www.domain.com/about' -> domain='domain.com'). Accepts bare domains or full URLs.",
+				);
 			shape.domainOperator = rz
 				.enum(['eq', 'beginsWith', 'endsWith', 'contains'])
 				.nullish()
-				.describe("Domain comparison operator (default 'contains').");
+				.describe(
+					"Domain comparison operator (default 'contains'). When a domain is available, do domain matching first; avoid strict exact-name-only matching.",
+				);
 			shape.searchContactEmails = rz
 				.boolean()
 				.nullish()

--- a/nodes/Autotask/constants/ai-identity.ts
+++ b/nodes/Autotask/constants/ai-identity.ts
@@ -23,7 +23,7 @@ const PROFILE_OVERRIDES: Record<string, AiIdentityProfile> = {
         hint: 'Identity includes parent context when available.',
     },
     company: {
-        hint: "Filter by company name using filter_field='companyName' (NOT 'name' — that field does not exist). ALWAYS use filter_op='contains' for name lookups — company names often include suffixes like '(NRL)' that cause exact matches to fail.",
+        hint: "Identifier priority for company resolution: Preferred: derive domain from email/website first. Fallback: companyName contains matching. Filter by company name using filter_field='companyName' (NOT 'name' — that field does not exist). ALWAYS use filter_op='contains' for name lookups — company names often include suffixes like '(NRL)' that cause exact matches to fail.",
     },
     resource: {
         hint: "Filter by resource name using filter_field='firstName' and/or filter_field_2='lastName' (NOT 'name'). Use filter_logic='and' for first+last name lookup.",


### PR DESCRIPTION
### Motivation
- Reduce ambiguous company lookups by ensuring AI/planning agents prioritise domain signals (from emails or websites) before falling back to name-based matching.
- Explicitly document the preferred resolution order so tool descriptions, schema hints, and identity guidance present a consistent rule for agents.

### Description
- Update `searchByDomain` operation docs to state identifier priority: extract/use domain from email/website first, then use company-name `contains` matching as a fallback (files: `nodes/Autotask/ai-tools/operation-metadata.ts`).
- Prepend the same priority rule to the company AI identity hint so `getAiIdentityHint('company')` reflects domain-first behaviour (file: `nodes/Autotask/constants/ai-identity.ts`).
- Expand schema parameter descriptions for `searchByDomain` to include explicit extraction examples (e.g. `email='user@domain.com' -> domain='domain.com'`) and guidance to avoid strict exact-name-only matching when a domain exists (file: `nodes/Autotask/ai-tools/schema-generator.ts`).
- Ensure company tool descriptions and the unified description template include the domain-first rule and update the `describeOperation` parameter docs for `searchByDomain` (file: `nodes/Autotask/ai-tools/description-builders.ts`).

### Testing
- Ran `pnpm -s lint`, which completed successfully.
- Ran `pnpm -s typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee01430528832090d1ed193350833c)