### PR TITLE
fix(search-filter): add array value type for in/notIn operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the n8n-nodes-autotask project will be documented in this
 
 ## [2.11.0] — 2026-04-26
 
+### Fixed
+
+- **Search Filter — Array value type for In/Not In operators**: Dynamic Build and Build operations now support an **Array** value type that serialises comma-separated input (e.g. `200,201,202`) as a proper JSON array, fixing the type mismatch that caused `notIn`/`in` filters to fail. Numeric strings are auto-cast to numbers. Value Type dropdown and field tooltip both warn that Array is only valid with In List / Not In List operators.
+
 ### Added
 
 - **AI tools — Tool description appendix**: New optional textarea on the `AutotaskAiTools` node appends deployer-supplied content to the generated tool description, allowing instance-specific context or constraints to reach the AI agent.

--- a/nodes/Autotask/helpers/searchFilterBuilder.ts
+++ b/nodes/Autotask/helpers/searchFilterBuilder.ts
@@ -6,7 +6,7 @@ import type { IExecuteFunctions } from 'n8n-workflow';
 interface IAutotaskFilterCondition {
 	op: string;
 	field: string;
-	value: string | number | boolean;
+	value: string | number | boolean | Array<string | number>;
 	udf?: boolean;
 }
 
@@ -20,18 +20,18 @@ interface IAutotaskFilter {
 }
 
 async function convertValue(
-	value: string | boolean,
+	value: string | boolean | Array<string | number>,
 	valueType: string,
 	isUtc = false,
 	context: IExecuteFunctions,
-): Promise<string | number | boolean> {
+): Promise<string | number | boolean | Array<string | number>> {
 	if (valueType === 'boolean') {
 		// Handle case where value is already a boolean (from the UI toggle)
 		if (typeof value === 'boolean') {
 			return value;
 		}
 		// Handle case where value is a string (for backward compatibility)
-		return value.toLowerCase() === 'true';
+		return (value as string).toLowerCase() === 'true';
 	}
 	if (valueType === 'number') {
 		const num = Number(value);
@@ -39,6 +39,18 @@ async function convertValue(
 			throw new Error(`Invalid number value: ${value}`);
 		}
 		return num;
+	}
+	if (valueType === 'array') {
+		const items = Array.isArray(value)
+			? value
+			: String(value).split(',').map(s => s.trim()).filter(s => s.length > 0);
+		return items.map(el => {
+			const num = Number(el);
+			if (typeof el === 'number' || (!Number.isNaN(num) && Number.isFinite(num) && String(el).trim() !== '')) {
+				return num;
+			}
+			return String(el);
+		});
 	}
 	if (valueType === 'date') {
 		try {
@@ -65,7 +77,9 @@ async function convertValue(
 		}
 	}
 	// Ensure we return a string for all other cases
-	return typeof value === 'boolean' ? value.toString() : value;
+	if (typeof value === 'boolean') return value.toString();
+	if (Array.isArray(value)) return value.join(',');
+	return value;
 }
 
 export async function convertToAutotaskFilter(
@@ -149,7 +163,9 @@ export function validateFilterInput(input: ISearchFilterBuilderInput): void {
 			}
 			// Only check for value if operator is not exist/notExist
 			if (item.itemType.op !== 'exist' && item.itemType.op !== 'notExist') {
-				if (item.itemType.value === undefined) {
+				const isArrayOp = item.itemType.op === 'in' || item.itemType.op === 'notIn';
+				const hasArrayValue = isArrayOp && item.itemType.arrayValue !== undefined;
+				if (item.itemType.value === undefined && !hasArrayValue) {
 					throw new Error('Condition must have a value (empty string is allowed for searching empty fields)');
 				}
 
@@ -158,7 +174,9 @@ export function validateFilterInput(input: ISearchFilterBuilderInput): void {
 					const value = item.itemType.value ?? '';
 					if (value !== '') {
 						// Convert value to string before passing to moment
-						const valueStr = typeof value === 'boolean' ? value.toString() : value;
+						const valueStr = Array.isArray(value)
+							? value.join(',')
+							: typeof value === 'boolean' ? value.toString() : value;
 						const date = moment(valueStr);
 						if (!date.isValid()) {
 							throw new Error(`Invalid date format: ${value}`);

--- a/nodes/Autotask/resources/searchFilter/description.ts
+++ b/nodes/Autotask/resources/searchFilter/description.ts
@@ -150,19 +150,19 @@ export const searchFilterOperations: INodeProperties[] = [
 										options: [
 											{ name: 'String', value: 'string' },
 											{ name: 'Number', value: 'number' },
-											{ name: 'Array (for In/Not In)', value: 'array' },
+											{ name: 'Array (In List / Not In List only)', value: 'array' },
 											{ name: 'Boolean', value: 'boolean' },
 											{ name: 'Date', value: 'date' },
 										],
 										default: 'string',
-										description: 'The type of value to be compared',
+										description: 'Data type for the filter value. Select <b>Array</b> only when the operator is <b>In List</b> or <b>Not In List</b> — using Array with any other operator will produce an invalid filter.',
 									},
 									{
 										displayName: 'Value',
 										name: 'value',
 										type: 'string',
 										default: '',
-										description: 'For boolean values, use "true" or "false"',
+										description: 'Filter value. For boolean use "true" or "false".',
 										displayOptions: {
 											hide: {
 												valueType: ['date', 'boolean', 'array'],
@@ -170,15 +170,14 @@ export const searchFilterOperations: INodeProperties[] = [
 										},
 									},
 									{
-										displayName: 'Value',
+										displayName: 'Values (comma-separated)',
 										name: 'arrayValue',
 										type: 'string',
 										default: '',
-										description: 'Comma-separated list of values, e.g. 200,201,202. Numbers and strings supported.',
+										description: 'Comma-separated list of values for In List / Not In List, e.g. <code>200,201,202</code>. Numeric strings are automatically cast to numbers. <b>Only valid with In List or Not In List operators.</b>',
 										displayOptions: {
 											show: {
 												valueType: ['array'],
-												op: ['in', 'notIn'],
 											},
 										},
 									},

--- a/nodes/Autotask/resources/searchFilter/description.ts
+++ b/nodes/Autotask/resources/searchFilter/description.ts
@@ -150,6 +150,7 @@ export const searchFilterOperations: INodeProperties[] = [
 										options: [
 											{ name: 'String', value: 'string' },
 											{ name: 'Number', value: 'number' },
+											{ name: 'Array (for In/Not In)', value: 'array' },
 											{ name: 'Boolean', value: 'boolean' },
 											{ name: 'Date', value: 'date' },
 										],
@@ -164,7 +165,20 @@ export const searchFilterOperations: INodeProperties[] = [
 										description: 'For boolean values, use "true" or "false"',
 										displayOptions: {
 											hide: {
-												valueType: ['date', 'boolean'],
+												valueType: ['date', 'boolean', 'array'],
+											},
+										},
+									},
+									{
+										displayName: 'Value',
+										name: 'arrayValue',
+										type: 'string',
+										default: '',
+										description: 'Comma-separated list of values, e.g. 200,201,202. Numbers and strings supported.',
+										displayOptions: {
+											show: {
+												valueType: ['array'],
+												op: ['in', 'notIn'],
 											},
 										},
 									},

--- a/nodes/Autotask/resources/searchFilter/execute.ts
+++ b/nodes/Autotask/resources/searchFilter/execute.ts
@@ -10,9 +10,10 @@ interface RawFilterInput {
 				field: string;
 				op: string;
 				value?: string;
-				valueType?: 'string' | 'number' | 'boolean' | 'date';
+				valueType?: 'string' | 'number' | 'boolean' | 'date' | 'array';
 				dateValue?: string;
 				booleanValue?: boolean;
+				arrayValue?: string;
 				udf?: boolean;
 				isUtc?: boolean;
 			}>;
@@ -66,6 +67,8 @@ export async function build(this: IExecuteFunctions): Promise<INodeExecutionData
 									itemValue = item.dateValue;
 								} else if (item.valueType === 'boolean' && item.booleanValue !== undefined) {
 									itemValue = item.booleanValue;
+								} else if (item.valueType === 'array' && item.arrayValue !== undefined) {
+									itemValue = item.arrayValue;
 								} else {
 									itemValue = item.value;
 								}
@@ -80,6 +83,7 @@ export async function build(this: IExecuteFunctions): Promise<INodeExecutionData
 										dateValue: item.dateValue,
 										isUtc: item.isUtc,
 										booleanValue: item.booleanValue,
+										arrayValue: item.arrayValue,
 										udf: item.udf
 									}
 								};

--- a/nodes/Autotask/types/SearchFilter.ts
+++ b/nodes/Autotask/types/SearchFilter.ts
@@ -6,7 +6,7 @@ export interface IFilterGroup {
 export interface IFilterCondition {
 	field: string;
 	op: string;
-	value: string | number | boolean;
+	value: string | number | boolean | Array<string | number>;
 	isUdf?: boolean;
 }
 
@@ -19,11 +19,12 @@ export interface ISearchFilterBuilderInput {
 					type: 'condition';
 					field: string;
 					op: string;
-					value?: string | boolean;
+					value?: string | boolean | Array<string | number>;
 					dateValue?: string;
 					isUtc?: boolean;
 					booleanValue?: boolean;
-					valueType?: 'string' | 'number' | 'boolean' | 'date';
+					arrayValue?: string;
+					valueType?: 'string' | 'number' | 'boolean' | 'date' | 'array';
 					udf?: boolean;
 				};
 			}>;


### PR DESCRIPTION
## Summary

- Adds **Array** value type to Search Filter Dynamic Build and Build operations, fixing `in`/`notIn` filters that previously serialised array values as quoted strings (e.g. `"[200]"` instead of `[200]`)
- Comma-separated input (e.g. `200,201,202`) is split and numeric strings auto-cast to numbers
- Value Type dropdown label and field tooltip both warn Array is only valid with In List / Not In List operators

## Test Plan

- [ ] Search Filter → Dynamic Build: set operator to `Not In List`, Value Type to `Array`, enter `200,201` — confirm output JSON has `"value":[200,201]` not `"value":"[200,201]"`
- [ ] Same with string values (e.g. `foo,bar`) — confirm `"value":["foo","bar"]`
- [ ] Confirm existing String / Number / Boolean / Date value types unaffected
- [ ] Confirm Array value field visible for all operators when Array type selected (not just in/notIn)
- [ ] Build operation: same array behaviour applies

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)