### PR TITLE
feat(ai-tools): release v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.12.0] — 2026-04-28
+
+### Added
+- **AI tools — Response enrichment expanded:** `ENRICHMENT_REGISTRY` extended with 8 new foreign-key enrichments auto-injected into all `records[]` and `record{}` responses: `resourceID` → `resourceFullName`, `resourceEmail`; `assignedResourceID` → `assignedResourceFullName`, `assignedResourceEmail`; `companyID` → `companyName`; `contractID` → `contractName`+`contractNumber`; `contactID` → `contactFullName`, `contactEmail`; `billingCodeID` → `billingCodeName`; `projectID` → `projectName`+`projectNumber`; `productID` → `productName`. Covers the top-8 most-frequent foreign keys by Autotask swagger occurrence count. Existing `ticketID` and `taskID` (with Project nextHop) entries unchanged. Cache refactored to store only raw records (avoiding outputFields shape collision when multiple registry entries share the same entity).
+- **AI tools — `ticket.timeline` operation:** New read operation on the ticket resource returns a chronological merged event stream of notes, time entries, and (optionally) field-change history for a single ticket. Accepts `id` or `ticketNumber`. Parameters: `since`/`until` (date range), `resourceId` (name or numeric ID, filters all event types), `includeHistories` (default false), `textLimit` (default 500 chars), `limit` (default 50 per entity type). Partial-failure tolerant: if one entity type fails, others are returned with a warning.
+- **AI tools — Time Entry Notes Guidance**: New optional textarea on the `AutotaskAiTools` node, displayed only when the selected resource is **Time Entry**. The supplied text is appended (under a `TIME ENTRY NOTES GUIDANCE:` header) to the generated tool description, letting deployers convey their org's note-format standards (Summary Notes, Internal Notes) to the AI agent inline. Combined description is hard-capped at 2400 characters with a `…[truncated]` marker; truncation is logged via the existing `traceToolBuild` instrumentation under a new `description-truncated` phase.
+
+### Changed
+- **AI tools — Tool description compression:** Reduce per-tool description overhead by ~1 400 chars across five changes targeting Qwen3-class (3–7 B-active) models: compress `buildToolContractBlock` from 492 → ~340 chars; remove verbose name-resolution examples from create/update descriptions; compress `buildTicketSummaryDescription` response-shape prose while preserving `includeRaw`, SLA routing, and population-level filter pattern; deduplicate trailing helper-op reminders; reorder `buildUnifiedDescriptionTemplate` so per-op summaries are truncated last.
+
+### Fixed
+- **MCP schema compliance (Copilot Studio):** Replace Zod `.positive()` with `.min(1)` or `.nullish()` on all 11 integer/float ID fields to eliminate `"exclusiveMinimum": 0` in emitted JSON Schema. Microsoft Copilot Studio throws `System.FormatException` on numeric `exclusiveMinimum` values, causing the entire `tools/list` MCP response to fail and all tools to disappear.
+- **MCP schema compliance (Copilot Studio):** Replace all 18 `rz.union([rz.number(), rz.string()])` fields and 3 compound union schemas (`rFilterValueSchema`, `rRecencySchema`) with `rz.string()` to eliminate `anyOf` from emitted JSON Schema. Simplifies schemas for broader MCP client compatibility.
+- **MCP schema compliance (Copilot Studio):** Update `filter_value` description to specify comma-separated string format for `in`/`notIn` operators (e.g. `'1,2,3'`) to match new `rz.string()` schema type.
+
 ## [2.11.0] — 2026-04-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The node supports the following Autotask resources:
 | Tag | Manage ticket and article tags with unique label requirements |
 | Tag Alias | Manage alternative names for tags to improve searchability |
 | Tag Group | Organise tags into categories with display colours and system group protections |
-| Ticket | Manage service tickets. Includes SLA Health Check (SLA milestone timing and status) and Summary (compact type-aware summary with filtered fields, computed values, child entity counts, and relationships). |
+| Ticket | Manage service tickets. Includes SLA Health Check (SLA milestone timing and status), Summary (compact type-aware summary with filtered fields, computed values, child entity counts, and relationships), and Timeline (merged chronological event stream — notes, time entries, optional history — for escalation briefs and effort audits). |
 | Ticket Attachment | Manage files attached directly to tickets |
 | Ticket Category | Manage ticket categories with display colors and default field values |
 | Ticket Category Field Default | Query default field values for ticket categories |

--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -148,6 +148,7 @@ function getMetadataNeeds(operations: string[]): { needsReadFields: boolean; nee
 			'countByPeriod',
 			'getByAge',
 			'searchByKeyword',
+			'timeline',
 		].includes(op),
 	);
 	const needsWriteFields = operations.some((op) => ['create', 'createIfNotExists', 'update'].includes(op));
@@ -365,6 +366,22 @@ export class AutotaskAiTools implements INodeType {
 				description:
 					'Optional text appended to the generated tool description. Use to add deployment-specific context or constraints visible to the AI agent.',
 			},
+			{
+				displayName: 'Time Entry Notes Guidance',
+				name: 'timeEntryNotesGuidance',
+				type: 'string',
+				typeOptions: { rows: 6 },
+				default: '',
+				placeholder:
+					'e.g. Summary Notes: customer-visible, present tense, no jargon. Internal Notes: troubleshooting steps, root cause, follow-ups.',
+				description:
+					'Optional guidance for time entry note formatting (Summary Notes, Internal Notes). Appended to the tool description only when the selected resource is Time Entry. Combined description is capped at 2400 characters.',
+				displayOptions: {
+					show: {
+						resource: ['timeEntry'],
+					},
+				},
+			},
 		],
 	};
 
@@ -534,7 +551,32 @@ export class AutotaskAiTools implements INodeType {
 
 		const appendix = (this.getNodeParameter('toolDescriptionAppendix', itemIndex, '') as string).trim();
 		const baseDescription = injectDescriptionReferenceUtc(descriptionTemplate, referenceUtc);
-		const description = appendix ? `${baseDescription}\n\n${appendix}` : baseDescription;
+		const withAppendix = appendix ? `${baseDescription}\n\n${appendix}` : baseDescription;
+
+		const timeEntryNotesGuidance = resource === 'timeEntry'
+			? (this.getNodeParameter('timeEntryNotesGuidance', itemIndex, '') as string).trim()
+			: '';
+		const withGuidance = timeEntryNotesGuidance
+			? `${withAppendix}\n\nTIME ENTRY NOTES GUIDANCE:\n${timeEntryNotesGuidance}`
+			: withAppendix;
+
+		const DESCRIPTION_HARD_LIMIT = 2400;
+		let description = withGuidance;
+		if (description.length > DESCRIPTION_HARD_LIMIT) {
+			const originalLength = description.length;
+			const marker = '…[truncated]';
+			description = `${description.slice(0, DESCRIPTION_HARD_LIMIT - marker.length)}${marker}`;
+			traceToolBuild({
+				phase: 'description-truncated',
+				resource,
+				itemIndex,
+				summary: {
+					originalLength,
+					truncatedLength: description.length,
+				},
+			});
+		}
+
 		const schemaKeys = safeSchemaKeys(schema);
 		traceToolBuild({
 			phase: 'tool-built',

--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -41,13 +41,8 @@ const RESOURCE_LANGUAGE_CONFIG: Record<string, ResourceLanguageConfig> = {
 
 export function buildToolContractBlock(): string {
 	return [
-		'API CAPABILITIES: filter, count, paging only.',
-		'NO groupBy, aggregation (avg/sum/count-by), server-side sort, or cross-entity joins.',
-		"For 'which X has most Y' or 'breakdown by Z': do NOT iterate all entities.",
-		'Ask user to provide a shortlist (≤10 IDs) then run one count per ID.',
-		'',
-		'ERROR RECOVERY: When response contains "error":true, the "nextAction" field is a directive TO YOU.',
-		'Execute it on your next call before responding to the user. Never retry same failed call unchanged.',
+		'CAPABILITIES: filter, count, paging only. NO groupBy, aggregation, server-side sort, or cross-entity joins. For breakdowns: ask user for ≤10 IDs, then run one count per ID.',
+		'ERRORS: when response has "error":true, the "nextAction" field is a directive TO YOU — execute it on your next call before responding. Never retry the same failed call unchanged.',
 	].join('\n');
 }
 
@@ -226,9 +221,8 @@ export function buildCreateDescription(
 		ref +
 		`Create a new ${resourceLabel} record. ` +
 		`${requiredSummary}${parentHint} ` +
-		`Name-based resolution: you can pass human-readable names instead of numeric IDs for picklist and reference fields (e.g. resourceName "Will Spence" instead of resourceID 29683, or category name "Internal Meeting" instead of numeric billingCodeID). The tool auto-resolves names to IDs. ` +
+		`Picklist and reference fields accept human-readable names — auto-resolved to IDs. ` +
 		`Date-time values must be ISO-8601 and UTC-safe (for example 2026-02-14T03:15:00Z). ` +
-		`Successful creates typically return an itemId and any resolvedLabels showing name→ID mappings. ` +
 		`Confirm field values with user before executing when acting autonomously. ` +
 		`If picklist values fail validation, call autotask_${resourceName} with operation 'listPicklistValues'.`
 	);
@@ -246,7 +240,7 @@ export function buildUpdateDescription(
 		`PREREQUISITE: you need the numeric ID. If you only have a name or text, call autotask_${resourceName} with operation 'getMany' with a filter to find the record and get its 'id' first. ` +
 		`Only provide fields to change (PATCH-style behaviour). ` +
 		`Do not assume PUT-style replacement where omitted fields become null. ` +
-		`Name-based resolution: you can pass human-readable names instead of numeric IDs for picklist and reference fields. The tool auto-resolves names to IDs. ` +
+		`Picklist and reference fields accept human-readable names — auto-resolved to IDs. ` +
 		`Date-time values must be ISO-8601 and UTC-safe (for example 2026-02-14T03:15:00Z). ` +
 		`Confirm field values with user before executing when acting autonomously. ` +
 		`${describeFieldsHint(resourceName, 'write')} ` +
@@ -329,17 +323,14 @@ export function buildTicketSummaryDescription(resourceName: string): string {
 	const ruleText = getOperationContractRuleText(resourceName, 'summary');
 	const identifierRule = ruleText.length > 0 ? `${ruleText.join(' ')} ` : '';
 	return (
-		'Get a compact, type-aware summary of any Autotask ticket. ' +
+		'Compact, type-aware ticket summary (auto-detects Service Request/Incident/Problem/Change Request/Alert). ' +
 		identifierRule +
-		'Automatically detects ticket type (Service Request, Incident, Problem, Change Request, Alert) and prioritises the most relevant fields. ' +
-		'Filters out null and empty fields to reduce noise. ' +
-		"Includes a 'computed' block with pre-calculated values: ageHours, daysSinceLastActivity, isAssigned; for open tickets: isOverdue, plus hoursUntilDue (not yet overdue) or hoursOverdue (past due); when SLA is assigned: slaStatus, slaNextMilestoneDueHours, slaEarliestBreachHours. " +
-		"Optionally includes a 'childCounts' block with counts of: notes, timeEntries, attachments, additionalConfigurationItems, additionalContacts, checklistItems (with completed/remaining breakdown), and changeRequestLinks (Change Request tickets only). Set 'includeChildCounts=true' to fetch these counts (adds several parallel API calls; omitted by default). " +
-		"Includes a 'relationships' block when the ticket is linked to a project, problem ticket, or opportunity. " +
-		"Use 'summaryTextLimit' to cap description/resolution length (default 500 chars). " +
-		"Set 'includeRaw=true' to receive the full enriched payload before alias renaming — label/UDF enrichments intact, original changeInfoField{N} keys, no null filtering or text truncation. " +
-		'For full SLA milestone timing and elapsed hours, use slaHealthCheck instead. ' +
-		"For population-level SLA queries (e.g. 'how many breached this week?'), use operation 'count' or 'getMany' with filter_field='serviceLevelAgreementHasBeenMet', filter_op='eq', filter_value=false instead. " +
+		"Returns a 'computed' block (age, SLA status, overdue flags) and a 'relationships' block when linked. " +
+		"'includeChildCounts=true' adds child-entity counts (extra parallel API calls; off by default). " +
+		"'summaryTextLimit' caps description/resolution length (default 500 chars). " +
+		"'includeRaw=true' returns the full enriched pre-alias payload (raw changeInfoField{N} keys, no null filtering). " +
+		'For full SLA milestone timing, use slaHealthCheck instead. ' +
+		"For population-level SLA queries (e.g. 'how many breached this week?'), use operation 'count' or 'getMany' with filter_field='serviceLevelAgreementHasBeenMet', filter_op='eq', filter_value=false. " +
 		describeFieldsHint(resourceName)
 	);
 }
@@ -379,6 +370,24 @@ export function buildTicketSlaHealthCheckDescription(resourceName: string): stri
 		'Includes wallClockRemainingHours, where negative values indicate overdue milestones. ' +
 		'This operation combines data from Ticket and ServiceLevelAgreementResults entities. ' +
 		"For population-level SLA queries (e.g. 'how many breached this week?'), do NOT call slaHealthCheck without an id. Use operation 'count' or 'getMany' with filter_field='serviceLevelAgreementHasBeenMet', filter_op='eq', filter_value=false instead. " +
+		describeFieldsHint(resourceName)
+	);
+}
+
+export function buildTicketTimelineDescription(resourceName: string): string {
+	const ruleText = getOperationContractRuleText(resourceName, 'timeline');
+	const identifierRule = ruleText.length > 0 ? `${ruleText.join(' ')} ` : '';
+	return (
+		'Chronological merged event stream (notes, time entries, and optionally field-change history) for a single ticket — use for escalation briefs, effort audits, and manager summaries. ' +
+		identifierRule +
+		"Events sorted oldest-first. Each event has a 'type' field: 'note' (communications), 'timeEntry' (work logged), or 'history' (field changes). " +
+		"Parameters: 'since'/'until' (ISO date — strongly recommended for active tickets to scope results); " +
+		"'resourceId' (name or numeric ID — filters note authors, time entry resources, and history actors); " +
+		"'includeHistories' (default false — enable for full field-change audit; can be very large on busy tickets — combine with since/until); " +
+		"'textLimit' (default 500 chars for note/entry text, 0=no limit); " +
+		"'limit' (default 50 per entity type). " +
+		"'hasMore: true' in response means at least one entity type hit the per-type cap — narrow with since/until or increase limit. " +
+		'For SLA milestone timing use slaHealthCheck. For ticket field overview use summary. ' +
 		describeFieldsHint(resourceName)
 	);
 }
@@ -633,6 +642,20 @@ export function buildUnifiedDescriptionTemplate(
 		dateTimeReferenceSnippet(DESCRIPTION_REFERENCE_PLACEHOLDER),
 	);
 
+	sections.push(
+		`operation 'describeFields': field metadata. Param: mode='read'|'write'.`,
+	);
+	sections.push(
+		`operation 'listPicklistValues': picklist values. Param: fieldId (NOT targetOperation).`,
+	);
+	sections.push(
+		`operation 'describeOperation': full docs for an op. Param: targetOperation.`,
+	);
+
+	if (supportsImpersonation) {
+		sections.push(`Impersonation supported: pass 'impersonationResourceId' for write attribution.`);
+	}
+
 	for (const op of operations) {
 		const metadata = getOperationMetadata(op);
 		let summary = metadata
@@ -655,23 +678,6 @@ export function buildUnifiedDescriptionTemplate(
 			summary = `operation '${op}': ${metadata?.docsFragment ?? ''}`.trim();
 		}
 		sections.push(summary);
-	}
-
-	sections.push(
-		`Name-based resolution (create/update/filters): picklist/reference values accept human-readable names, auto-resolved to IDs.`,
-	);
-	sections.push(
-		`operation 'describeFields': List field IDs/types/metadata. Use mode 'read' or 'write'.`,
-	);
-	sections.push(
-		`operation 'listPicklistValues': Get valid values for a picklist field. Use 'fieldId'.`,
-	);
-	sections.push(
-		`operation 'describeOperation': Full docs for a given operation. Use 'targetOperation' parameter.`,
-	);
-
-	if (supportsImpersonation) {
-		sections.push(`Impersonation supported: pass 'impersonationResourceId' for write attribution.`);
 	}
 
 	const combined = sections.join(' ');
@@ -760,15 +766,17 @@ const READ_OP_PARAMS: Record<string, { required: OperationParam[]; optional: Ope
 			},
 			{
 				field: 'filter_value',
-				type: 'string | number | boolean | array',
-				description: 'Filter value. Use arrays for in/notIn.',
+				type: 'string',
+				description:
+					"Filter value as string. For in/notIn, comma-separate values (e.g. '1,2,3'). Booleans: 'true'/'false'.",
 			},
 			{ field: 'filter_field_2', type: 'string', description: 'Second filter field.' },
 			{ field: 'filter_op_2', type: 'string', description: 'Second filter operator.' },
 			{
 				field: 'filter_value_2',
-				type: 'string | number | boolean | array',
-				description: 'Second filter value.',
+				type: 'string',
+				description:
+					"Second filter value as string. For in/notIn, comma-separate values (e.g. '1,2,3').",
 			},
 			{ field: 'filter_logic', type: 'string', description: "'and' (default) or 'or'." },
 			{
@@ -803,15 +811,17 @@ const READ_OP_PARAMS: Record<string, { required: OperationParam[]; optional: Ope
 			{ field: 'filter_op', type: 'string', description: 'Filter operator.' },
 			{
 				field: 'filter_value',
-				type: 'string | number | boolean | array',
-				description: 'Filter value.',
+				type: 'string',
+				description:
+					"Filter value as string. For in/notIn, comma-separate values (e.g. '1,2,3').",
 			},
 			{ field: 'filter_field_2', type: 'string', description: 'Second filter field.' },
 			{ field: 'filter_op_2', type: 'string', description: 'Second filter operator.' },
 			{
 				field: 'filter_value_2',
-				type: 'string | number | boolean | array',
-				description: 'Second filter value.',
+				type: 'string',
+				description:
+					"Second filter value as string. For in/notIn, comma-separate values (e.g. '1,2,3').",
 			},
 			{ field: 'filter_logic', type: 'string', description: "'and' (default) or 'or'." },
 			{ field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array.' },
@@ -837,8 +847,9 @@ const READ_OP_PARAMS: Record<string, { required: OperationParam[]; optional: Ope
 			{ field: 'filter_op', type: 'string', description: 'Filter operator.' },
 			{
 				field: 'filter_value',
-				type: 'string | number | boolean | array',
-				description: 'Filter value.',
+				type: 'string',
+				description:
+					"Filter value as string. For in/notIn, comma-separate values (e.g. '1,2,3').",
 			},
 			{ field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array.' },
 			{ field: 'returnAll', type: 'boolean', description: 'Fetch ALL matching records.' },
@@ -856,8 +867,9 @@ const READ_OP_PARAMS: Record<string, { required: OperationParam[]; optional: Ope
 			{ field: 'filter_op', type: 'string', description: 'Filter operator.' },
 			{
 				field: 'filter_value',
-				type: 'string | number | boolean | array',
-				description: 'Filter value.',
+				type: 'string',
+				description:
+					"Filter value as string. For in/notIn, comma-separate values (e.g. '1,2,3').",
 			},
 			{ field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array.' },
 			{ field: 'returnAll', type: 'boolean', description: 'Fetch ALL matching records.' },
@@ -1217,6 +1229,8 @@ function getOperationPurpose(
 			return buildTicketSlaHealthCheckDescription(resource);
 		case 'summary':
 			return buildTicketSummaryDescription(resource);
+		case 'timeline':
+			return buildTicketTimelineDescription(resource);
 		case 'getFullDetail':
 			return buildGetFullDetailDescription(resource);
 		case 'countByPeriod':
@@ -1268,6 +1282,7 @@ function getOperationNotes(resource: string, operation: string): string[] {
 			return [...contractNotes, ...LABEL_RESOLUTION_NOTES, ...DEDUP_NOTES];
 		case 'slaHealthCheck':
 		case 'summary':
+		case 'timeline':
 		case 'getFullDetail':
 		case 'countByPeriod':
 			return [...contractNotes];

--- a/nodes/Autotask/ai-tools/field-validator.ts
+++ b/nodes/Autotask/ai-tools/field-validator.ts
@@ -129,6 +129,7 @@ export function validateEntityId(
         'whoAmI',
         'slaHealthCheck',
         'summary',
+        'timeline',
         'getByResource',
         'getByYear',
         'getByCompanyAndStatus',

--- a/nodes/Autotask/ai-tools/operation-contracts.ts
+++ b/nodes/Autotask/ai-tools/operation-contracts.ts
@@ -67,6 +67,9 @@ export const OPERATION_CONTRACTS: ResourceOperationContracts = {
 			xorGroups: [['id', 'ticketNumber']],
 			forbiddenFields: ['filter_field', 'filter_op', 'filter_value', 'filter_field_2', 'filter_op_2', 'filter_value_2'],
 		},
+		timeline: {
+			xorGroups: [['id', 'ticketNumber']],
+		},
 		searchByKeyword: {
 			requiredFields: ['keyword'],
 			forbiddenFields: ['filter_field', 'filter_op', 'filter_value', 'filter_field_2', 'filter_op_2', 'filter_value_2', 'filter_logic', 'filtersJson', 'offset'],

--- a/nodes/Autotask/ai-tools/operation-metadata.ts
+++ b/nodes/Autotask/ai-tools/operation-metadata.ts
@@ -234,6 +234,15 @@ const OPERATION_METADATA_LIST: OperationMetadata[] = [
 			'Cross-entity full-text search for tickets. Matches keyword in title and description (always), and optionally in TicketNotes.description and TimeEntries.summaryNotes. Each returned ticket has a matchedIn array indicating where the keyword was found.',
 	},
 	{
+		name: 'timeline',
+		isWrite: false,
+		label: 'Ticket timeline',
+		supportsFilters: false,
+		responseKind: 'list',
+		docsFragment:
+			"Chronological merged event stream (notes, time entries, and optionally field-change history) for a single ticket. Requires 'id' or 'ticketNumber'. Use for escalation briefs, effort audits, and manager summaries.",
+	},
+	{
 		name: 'approve',
 		isWrite: true,
 		label: 'Approve time off request',

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -135,54 +135,15 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		'notIn',
 	]);
 	const rFilterValueSchema = rz
-		.union([
-			rz.string(),
-			rz.number(),
-			rz.boolean(),
-			rz.array(rz.union([rz.string(), rz.number(), rz.boolean()])),
-		])
-		.describe(
-			"Filter value. For reference and picklist fields, pass a human-readable name (e.g. 'In Progress', 'Contoso', 'High') — auto-resolves to ID. Or pass a numeric ID directly if known.",
-		);
-	const rRecencyEnum = rz.enum([
-		'last_15m',
-		'last_1h',
-		'last_2h',
-		'last_3h',
-		'last_4h',
-		'last_6h',
-		'last_8h',
-		'last_12h',
-		'last_24h',
-		'last_1d',
-		'last_2d',
-		'last_3d',
-		'last_4d',
-		'last_5d',
-		'last_6d',
-		'last_7d',
-		'last_14d',
-		'last_30d',
-		'last_90d',
-	]);
-	const rRecencyCustomDays = rz
 		.string()
-		.regex(/^last_\d+d$/)
-		.refine(
-			(s) => {
-				const n = parseInt(s.replace(/^last_(\d+)d$/, '$1'), 10);
-				return Number.isFinite(n) && n >= 1 && n <= 365;
-			},
-			{
-				message:
-					'Custom recency must be last_Nd with N between 1 and 365 (e.g. last_5d, last_45d).',
-			},
+		.describe(
+			"Filter value as string. For reference/picklist fields, pass human-readable name (e.g. 'In Progress', 'Contoso', 'High') — auto-resolves to ID, or pass numeric ID directly. For in/notIn operators, comma-separate values (e.g. '1,2,3'). Booleans: 'true'/'false'.",
 		);
 	const rRecencySchema = rz
-		.union([rRecencyEnum, rRecencyCustomDays])
+		.string()
 		.nullish()
 		.describe(
-			'Preset time window (last_7d, last_30d) or last_Nd (N=1–365). Mutually exclusive with since/until.',
+			'Preset time window: last_15m, last_1h, last_2h, last_3h, last_4h, last_6h, last_8h, last_12h, last_24h, last_1d–last_7d, last_14d, last_30d, last_90d. Or last_Nd (N=1–365). Mutually exclusive with since/until.',
 		);
 
 	function buildUnifiedSchema(
@@ -287,7 +248,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		// resourceID — used by getByResource and getByYear (parent-path operations)
 		if (hasGetByResource || hasGetByYear) {
 			shape.resourceID = rz
-				.union([rz.number(), rz.string()])
+				.string()
 				.nullish()
 				.describe(
 					'Resource ID or name (auto-resolved). Required for getByResource and getByYear.',
@@ -493,11 +454,46 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				);
 		}
 
+		// timeline fields
+		const hasTimeline = operations.includes('timeline');
+		if (hasTimeline) {
+			if (!shape.since) {
+				shape.since = rz
+					.string()
+					.nullish()
+					.describe('ISO 8601 date — filter events on or after this date');
+			}
+			if (!shape.until) {
+				shape.until = rz
+					.string()
+					.nullish()
+					.describe('ISO 8601 date — filter events on or before this date');
+			}
+			shape.resourceId = rz
+				.string()
+				.nullish()
+				.describe('Filter by resource name or numeric ID — applies to note author, time entry resource, history actor');
+			shape.includeHistories = rz
+				.boolean()
+				.nullish()
+				.describe('Include field-change audit history events (default false — can be high volume on active tickets)');
+			shape.textLimit = rz
+				.number()
+				.nullish()
+				.describe('Max characters for note/entry text fields (default 500; 0 = no limit)');
+			if (!shape.limit) {
+				shape.limit = rz
+					.number()
+					.nullish()
+					.describe('Max events per entity type — notes, time entries, histories each capped independently (default 50)');
+			}
+		}
+
 		// getByCompanyAndStatus / getUnassigned shared fields
 		if (hasGetByCompanyAndStatus || hasGetUnassigned) {
 			if (!shape.company) {
 				shape.company = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe(
 						hasGetByCompanyAndStatus
@@ -507,13 +503,13 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			}
 			if (RESOURCES_WITH_PRIORITY.has(resource) && !shape.priority) {
 				shape.priority = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe('Priority picklist label or ID (optional).');
 			}
 			if (hasGetByCompanyAndStatus && !shape.status) {
 				shape.status = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe('Status picklist label or ID (optional). Omit for all statuses.');
 			}
@@ -531,13 +527,12 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			if (!shape.atRiskWindowHours) {
 				shape.atRiskWindowHours = rz
 					.number()
-					.positive()
 					.nullish()
 					.describe('Hours before resolvedDueDateTime to consider a ticket at-risk (default 4). Only applies when slaStatus=at_risk.');
 			}
 			if (!shape.company) {
 				shape.company = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe('Company name or numeric companyID (auto-resolved). Optional.');
 			}
@@ -554,19 +549,19 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			}
 			if (!shape.company) {
 				shape.company = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe('Company name or numeric companyID (auto-resolved). Optional.');
 			}
 			if (!shape.status) {
 				shape.status = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe('Status picklist label or ID (optional).');
 			}
 			if (RESOURCES_WITH_PRIORITY.has(resource) && !shape.priority) {
 				shape.priority = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe('Priority picklist label or ID (optional).');
 			}
@@ -579,13 +574,13 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				shape.olderThanDays = rz
 					.number()
 					.int()
-					.positive()
+					.min(1)
 					.nullish()
 					.describe('Required for getByAge: return records older than N days (e.g. 30 for records created more than 30 days ago). Positive integer.');
 			}
-			if (!shape.company) shape.company = rz.union([rz.number(), rz.string()]).nullish().describe('Company name or companyID (auto-resolved).');
-			if (!shape.status) shape.status = rz.union([rz.number(), rz.string()]).nullish().describe('Status picklist label or ID (optional).');
-			if (RESOURCES_WITH_PRIORITY.has(resource) && !shape.priority) shape.priority = rz.union([rz.number(), rz.string()]).nullish().describe('Priority picklist label or ID (optional).');
+			if (!shape.company) shape.company = rz.string().nullish().describe('Company name or companyID (auto-resolved).');
+			if (!shape.status) shape.status = rz.string().nullish().describe('Status picklist label or ID (optional).');
+			if (RESOURCES_WITH_PRIORITY.has(resource) && !shape.priority) shape.priority = rz.string().nullish().describe('Priority picklist label or ID (optional).');
 		}
 
 		// searchByKeyword fields
@@ -638,7 +633,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				// human-readable labels (e.g. "Will Spence") which the executor auto-resolves to IDs.
 				const needsLabelResolution = field.isPickList || field.isReference;
 				const base = needsLabelResolution
-					? rz.union([rz.number(), rz.string()])
+					? rz.string()
 					: field.type === 'number'
 						? rz.number()
 						: field.type === 'boolean'
@@ -648,7 +643,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			}
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe(IMPERSONATION_RESOURCE_ID_DESCRIBE);
 				shape.proceedWithoutImpersonationIfDenied = rz
@@ -664,26 +659,26 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				shape.sourceConfigurationItemId = rz
 					.number()
 					.int()
-					.positive()
+					.min(1)
 					.nullish()
 					.describe('Source configuration item ID to clone.');
 			if (!shape.destinationCompanyId)
 				shape.destinationCompanyId = rz
 					.number()
 					.int()
-					.positive()
+					.min(1)
 					.nullish()
 					.describe('Destination company ID.');
 			shape.destinationCompanyLocationId = rz
 				.number()
 				.int()
-				.positive()
+				.min(1)
 				.nullish()
 				.describe('Optional destination company location ID.');
 			shape.destinationContactId = rz
 				.number()
 				.int()
-				.positive()
+				.min(1)
 				.nullish()
 				.describe('Optional destination contact ID.');
 			shape.copyUdfs = rz
@@ -750,7 +745,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.describe('Maximum attachment size per file in bytes (default 6291456).');
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe(IMPERSONATION_RESOURCE_ID_DESCRIBE);
 				shape.proceedWithoutImpersonationIfDenied = rz
@@ -766,20 +761,20 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				shape.sourceContactId = rz
 					.number()
 					.int()
-					.positive()
+					.min(1)
 					.nullish()
 					.describe('Source contact ID to move.');
 			if (!shape.destinationCompanyId)
 				shape.destinationCompanyId = rz
 					.number()
 					.int()
-					.positive()
+					.min(1)
 					.nullish()
 					.describe('Destination company ID for the cloned contact.');
 			shape.destinationCompanyLocationId = rz
 				.number()
 				.int()
-				.positive()
+				.min(1)
 				.nullish()
 				.describe('Optional destination company location ID.');
 			shape.skipIfDuplicateEmailFound = rz
@@ -810,7 +805,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.describe('Optional audit note written to the destination company context.');
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe(IMPERSONATION_RESOURCE_ID_DESCRIBE);
 				shape.proceedWithoutImpersonationIfDenied = rz
@@ -826,14 +821,14 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				shape.sourceResourceId = rz
 					.number()
 					.int()
-					.positive()
+					.min(1)
 					.nullish()
 					.describe('Source resource ID currently assigned to work. Can be inactive.');
 			if (!shape.destinationResourceId)
 				shape.destinationResourceId = rz
 					.number()
 					.int()
-					.positive()
+					.min(1)
 					.nullish()
 					.describe('Receiving resource ID. Must be active.');
 			shape.includeTickets = rz
@@ -945,7 +940,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				);
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe(IMPERSONATION_RESOURCE_ID_DESCRIBE);
 				shape.proceedWithoutImpersonationIfDenied = rz
@@ -967,7 +962,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					const desc = buildFieldDescription(field);
 					const needsLabelResolution = field.isPickList || field.isReference;
 					const base = needsLabelResolution
-						? rz.union([rz.number(), rz.string()])
+						? rz.string()
 						: field.type === 'number'
 							? rz.number()
 							: field.type === 'boolean'
@@ -1000,7 +995,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					);
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
-					.union([rz.number(), rz.string()])
+					.string()
 					.nullish()
 					.describe(IMPERSONATION_RESOURCE_ID_DESCRIBE);
 				shape.proceedWithoutImpersonationIfDenied = rz

--- a/nodes/Autotask/ai-tools/tool-executor.ts
+++ b/nodes/Autotask/ai-tools/tool-executor.ts
@@ -2719,6 +2719,149 @@ export async function executeAiTool(
 			return attachCorrelation(enrichedSearchByKeywordJson, correlationId);
 		}
 
+		// Short-circuit: timeline
+		// Merged chronological event stream (TicketNotes + TimeEntries + optional TicketHistory).
+		// Parallel fetch via Promise.allSettled; per-stage failures degrade gracefully.
+		if (effectiveOperation === 'timeline') {
+			const cfg = getConvenienceConfig(resource)!;
+			const tlIdPairConfig = getIdentifierPairConfig(resource, 'timeline');
+			let timelineTicketId: string | undefined;
+			if (params.id !== undefined && params.id !== null) {
+				timelineTicketId = String(params.id);
+			} else if (tlIdPairConfig && typeof params.ticketNumber === 'string' && params.ticketNumber.trim()) {
+				const tnLookup = await autotaskApiRequest.call(context, 'POST', cfg.queryEndpoint, {
+					filter: [{ field: tlIdPairConfig.altIdField, op: 'eq', value: params.ticketNumber.trim() }],
+					MaxRecords: 1,
+				} as IDataObject) as { items?: IAutotaskEntity[] };
+				const tnItems = Array.isArray(tnLookup.items) ? tnLookup.items : [];
+				if (tnItems.length === 0) {
+					return attachCorrelation(
+						JSON.stringify(
+							wrapError(
+								resource,
+								'timeline',
+								ERROR_TYPES.ENTITY_NOT_FOUND,
+								`Ticket with ${tlIdPairConfig.altIdField} '${params.ticketNumber}' not found.`,
+								`Verify the ticket number format (e.g. ${tlIdPairConfig.altIdExample}) and retry autotask_${resource} with operation 'getMany'.`,
+							),
+						),
+						correlationId,
+					);
+				}
+				timelineTicketId = String(tnItems[0].id);
+			}
+
+			if (!timelineTicketId) {
+				const missingMsg = tlIdPairConfig
+					? `Either 'id' (numeric) or '${tlIdPairConfig.altIdField}' (e.g. ${tlIdPairConfig.altIdExample}) is required for timeline.`
+					: `'id' (numeric) is required for timeline.`;
+				const missingNext = tlIdPairConfig
+					? `Call autotask_${resource} with operation 'timeline' and provide 'id' or '${tlIdPairConfig.altIdField}'.`
+					: `Call autotask_${resource} with operation 'timeline' and provide 'id'.`;
+				return attachCorrelation(
+					JSON.stringify(
+						wrapError(
+							resource,
+							'timeline',
+							ERROR_TYPES.MISSING_REQUIRED_FIELDS,
+							missingMsg,
+							missingNext,
+						),
+					),
+					correlationId,
+				);
+			}
+
+			const resolvedTimelineTicketId = Number(timelineTicketId);
+
+			// Resolve resourceId string to numeric ID if provided
+			let resolvedTimelineResourceId: number | undefined;
+			const rawTimelineResourceId = (params as Record<string, unknown>).resourceId;
+			if (typeof rawTimelineResourceId === 'string' && rawTimelineResourceId.trim()) {
+				const rid = rawTimelineResourceId.trim();
+				const numericRid = parseInt(rid, 10);
+				if (!isNaN(numericRid) && String(numericRid) === rid) {
+					resolvedTimelineResourceId = numericRid;
+				} else {
+					try {
+						const resourceLookup = await autotaskApiRequest.call(
+							context, 'POST', 'Resources/query',
+							{
+								filter: [
+									{ op: 'or', items: [
+										{ field: 'firstName', op: 'contains', value: rid },
+										{ field: 'lastName', op: 'contains', value: rid },
+										{ field: 'email', op: 'eq', value: rid },
+									]},
+								],
+								MaxRecords: 1,
+							} as IDataObject,
+						) as { items?: IAutotaskEntity[] };
+						const ridItems = Array.isArray(resourceLookup.items) ? resourceLookup.items : [];
+						if (ridItems.length > 0) {
+							resolvedTimelineResourceId = Number(ridItems[0].id);
+						} else {
+							labelWarnings.push(
+								`Could not resolve resource '${rid}' to a numeric ID — timeline will not be filtered by resource.`,
+							);
+						}
+					} catch (err) {
+						const msg = err instanceof Error ? err.message : String(err);
+						labelWarnings.push(
+							`[INFRASTRUCTURE] Resource resolution failed for '${rid}': ${msg} — timeline will not be filtered by resource.`,
+						);
+					}
+				}
+			} else if (typeof rawTimelineResourceId === 'number' && rawTimelineResourceId > 0) {
+				resolvedTimelineResourceId = rawTimelineResourceId;
+			}
+
+			const includeHistories = (params as Record<string, unknown>).includeHistories === true;
+			const textLimit = typeof params.textLimit === 'number' ? params.textLimit : 500;
+			const timelineLimit = typeof params.limit === 'number' ? Math.min(Math.max(Math.trunc(params.limit), 1), MAX_QUERY_LIMIT) : 50;
+
+			const { buildTicketTimeline } = await import('../helpers/ticket-timeline');
+			const timelineResult = await buildTicketTimeline(context as unknown as import('n8n-workflow').IExecuteFunctions, {
+				ticketId: resolvedTimelineTicketId,
+				since: typeof params.since === 'string' && params.since.trim() ? params.since.trim() : undefined,
+				until: typeof params.until === 'string' && params.until.trim() ? params.until.trim() : undefined,
+				resourceId: resolvedTimelineResourceId,
+				includeHistories,
+				textLimit,
+				limit: timelineLimit,
+			});
+
+			const allTimelineWarnings = [...timelineResult.stageWarnings, ...labelWarnings];
+
+			const baseTimelineResponse = buildListResponse(
+				resource,
+				'timeline',
+				timelineResult.events as unknown as Record<string, unknown>[],
+				{
+					hasMore: timelineResult.hasMore,
+					serverCap: timelineLimit,
+					clientCap: timelineLimit,
+				},
+				{
+					resolutions: labelResolutions.length > 0 ? labelResolutions : undefined,
+					resolutionWarnings: allTimelineWarnings.length > 0 ? allTimelineWarnings : undefined,
+				},
+			);
+
+			const timelineResponseObject: Record<string, unknown> = {
+				...baseTimelineResponse,
+				ticketId: resolvedTimelineTicketId,
+				totalEvents: timelineResult.events.length,
+				noteCount: timelineResult.noteCount,
+				timeEntryCount: timelineResult.timeEntryCount,
+				historyCount: timelineResult.historyCount,
+			};
+
+			const timelineJson = JSON.stringify(timelineResponseObject);
+			const enrichedTimelineJson = await enrichResponseJson(timelineJson, context);
+			return attachCorrelation(enrichedTimelineJson, correlationId);
+		}
+
 		traceExecutor({
 			phase: 'api-call-start',
 			resource,

--- a/nodes/Autotask/constants/resource-operations.ts
+++ b/nodes/Autotask/constants/resource-operations.ts
@@ -1,7 +1,7 @@
 import { AUTOTASK_ENTITIES } from './entities';
 import { OperationType } from '../types/base/entity-types';
 
-const AI_OPERATION_ORDER = ['get', 'whoAmI', 'getMany', 'searchByIdentity', 'searchByDomain', 'slaHealthCheck', 'summary', 'getFullDetail', 'countByPeriod', 'getByAge', 'searchByKeyword', 'getByCompanyAndStatus', 'getUnassigned', 'getBySLAStatus', 'getPosted', 'getUnposted', 'getByResource', 'getByYear', 'count', 'create', 'createIfNotExists', 'moveToCompany', 'moveConfigurationItem', 'transferOwnership', 'update', 'approve', 'reject', 'delete'] as const;
+const AI_OPERATION_ORDER = ['get', 'whoAmI', 'getMany', 'searchByIdentity', 'searchByDomain', 'slaHealthCheck', 'summary', 'timeline', 'getFullDetail', 'countByPeriod', 'getByAge', 'searchByKeyword', 'getByCompanyAndStatus', 'getUnassigned', 'getBySLAStatus', 'getPosted', 'getUnposted', 'getByResource', 'getByYear', 'count', 'create', 'createIfNotExists', 'moveToCompany', 'moveConfigurationItem', 'transferOwnership', 'update', 'approve', 'reject', 'delete'] as const;
 const EXCLUDED_TOP_LEVEL_RESOURCES = new Set(['tool', 'searchFilter']);
 
 const OP_TYPE_TO_AI_OPS: Record<OperationType, string[]> = {
@@ -19,7 +19,7 @@ const SPECIAL_AI_OPERATIONS: Record<string, string[]> = {
     resource: ['whoAmI', 'transferOwnership'],
     contact: ['moveToCompany'],
     company: ['searchByIdentity', 'searchByDomain'],
-    ticket: ['slaHealthCheck', 'summary', 'getFullDetail', 'countByPeriod', 'getByAge', 'searchByKeyword', 'getByCompanyAndStatus', 'getUnassigned', 'getBySLAStatus'],
+    ticket: ['slaHealthCheck', 'summary', 'timeline', 'getFullDetail', 'countByPeriod', 'getByAge', 'searchByKeyword', 'getByCompanyAndStatus', 'getUnassigned', 'getBySLAStatus'],
     task: ['getFullDetail', 'countByPeriod', 'getByAge', 'getByCompanyAndStatus', 'getUnassigned'],
     project: ['getFullDetail', 'countByPeriod', 'getByAge', 'getByCompanyAndStatus', 'getUnassigned'],
     configurationItems: ['moveConfigurationItem', 'createIfNotExists'],
@@ -63,7 +63,7 @@ export interface IdentifierPairConfig {
 
 export const IDENTIFIER_PAIR_OPERATIONS: Record<string, IdentifierPairConfig> = {
     ticket: {
-        operations: ['slaHealthCheck', 'summary', 'getFullDetail'],
+        operations: ['slaHealthCheck', 'summary', 'timeline', 'getFullDetail'],
         altIdField: 'ticketNumber',
         altIdExample: 'T20240615.0674',
         altIdFormat: 'T{date}.{seq}',

--- a/nodes/Autotask/helpers/enrichment.ts
+++ b/nodes/Autotask/helpers/enrichment.ts
@@ -28,10 +28,13 @@ interface EnrichmentCacheEntry {
 	expiresAt: number;
 }
 
-/** Cache of output fields keyed by `${entityName}:${id}` */
-const enrichmentCache = new Map<string, EnrichmentCacheEntry>();
-
-/** Cache of raw source records keyed by `raw:${entityName}:${id}` — used for nextHop idField lookup */
+/**
+ * Cache of raw source records keyed by `raw:${entityName}:${id}`.
+ * Raw records are entity/outputFields-agnostic — outputFields are computed per call,
+ * avoiding shape collision when multiple registry entries share the same entityName
+ * (e.g. resourceID + assignedResourceID both resolve Resource; taskID nextHop + direct
+ * projectID both resolve Project).
+ */
 const rawCache = new Map<string, EnrichmentCacheEntry>();
 
 const inFlightMap = new Map<string, Promise<Record<string, unknown>[]>>();
@@ -57,20 +60,86 @@ const ENRICHMENT_REGISTRY: Record<string, EnrichmentConfig> = {
 			outputFields: { taskProjectNumber: 'projectNumber', taskProjectName: 'projectName' },
 		},
 	},
+	resourceID: {
+		entityName: 'Resource',
+		fetchFields: ['id', 'firstName', 'lastName', 'email'],
+		outputFields: {
+			resourceFirstName: 'firstName',
+			resourceLastName: 'lastName',
+			resourceFullName: (r: Record<string, unknown>) =>
+				[r['firstName'], r['lastName']].filter(Boolean).join(' '),
+			resourceEmail: 'email',
+		},
+	},
+	assignedResourceID: {
+		entityName: 'Resource',
+		fetchFields: ['id', 'firstName', 'lastName', 'email'],
+		outputFields: {
+			assignedResourceFirstName: 'firstName',
+			assignedResourceLastName: 'lastName',
+			assignedResourceFullName: (r: Record<string, unknown>) =>
+				[r['firstName'], r['lastName']].filter(Boolean).join(' '),
+			assignedResourceEmail: 'email',
+		},
+	},
+	creatorResourceID: {
+		entityName: 'Resource',
+		fetchFields: ['id', 'firstName', 'lastName', 'email'],
+		outputFields: {
+			creatorResourceFirstName: 'firstName',
+			creatorResourceLastName: 'lastName',
+			creatorResourceFullName: (r: Record<string, unknown>) =>
+				[r['firstName'], r['lastName']].filter(Boolean).join(' '),
+			creatorResourceEmail: 'email',
+		},
+	},
+	companyID: {
+		entityName: 'Company',
+		fetchFields: ['id', 'companyName'],
+		outputFields: { companyName: 'companyName' },
+	},
+	contractID: {
+		entityName: 'Contract',
+		fetchFields: ['id', 'contractName', 'contractNumber'],
+		outputFields: { contractName: 'contractName', contractNumber: 'contractNumber' },
+	},
+	contactID: {
+		entityName: 'Contact',
+		fetchFields: ['id', 'firstName', 'lastName', 'emailAddress'],
+		outputFields: {
+			contactFirstName: 'firstName',
+			contactLastName: 'lastName',
+			contactFullName: (r: Record<string, unknown>) =>
+				[r['firstName'], r['lastName']].filter(Boolean).join(' '),
+			contactEmail: 'emailAddress',
+		},
+	},
+	billingCodeID: {
+		entityName: 'BillingCode',
+		fetchFields: ['id', 'name'],
+		outputFields: { billingCodeName: 'name' },
+	},
+	projectID: {
+		entityName: 'Project',
+		fetchFields: ['id', 'projectName', 'projectNumber'],
+		outputFields: { projectName: 'projectName', projectNumber: 'projectNumber' },
+	},
+	productID: {
+		entityName: 'Product',
+		fetchFields: ['id', 'name'],
+		outputFields: { productName: 'name' },
+	},
 };
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getCachedEntry(
-	cache: Map<string, EnrichmentCacheEntry>,
-	key: string,
-): Record<string, unknown> | undefined {
-	const entry = cache.get(key);
+function getCachedRaw(key: string): Record<string, unknown> | undefined {
+	const entry = rawCache.get(key);
 	if (!entry) return undefined;
 	if (Date.now() > entry.expiresAt) {
-		cache.delete(key);
+		rawCache.delete(key);
 		return undefined;
 	}
 	return entry.fields;
@@ -94,6 +163,11 @@ function applyOutputFields(
 /**
  * Fetches enrichment fields for a batch of IDs using EntityValueHelper.getValuesByIds().
  * Returns a Map<id, outputFields> of resolved output fields.
+ *
+ * Caches only the raw source record (rawCache). outputFields are computed per call so that
+ * multiple registry entries sharing the same entityName but different outputFields shapes
+ * never return stale/wrong fields from a previous entry's cache population.
+ *
  * Also populates rawCache so callers can look up source-record fields (e.g. nextHop idField).
  */
 async function fetchEntityFields(
@@ -107,12 +181,14 @@ async function fetchEntityFields(
 ): Promise<Map<number, Record<string, unknown>>> {
 	const resultMap = new Map<number, Record<string, unknown>>();
 
-	// Check cache for each id
+	// Check raw cache — compute outputFields on the fly from cached raw record.
+	// This avoids the shape-collision bug that would occur if we cached computed outputFields
+	// per entity:id, since multiple registry entries can share an entityName.
 	const uncachedIds: number[] = [];
 	for (const id of ids) {
-		const cached = getCachedEntry(enrichmentCache, `${entityName}:${id}`);
-		if (cached !== undefined) {
-			resultMap.set(id, cached);
+		const rawRecord = getCachedRaw(`raw:${entityName}:${id}`);
+		if (rawRecord !== undefined) {
+			resultMap.set(id, applyOutputFields(rawRecord, outputFields));
 		} else {
 			uncachedIds.push(id);
 		}
@@ -161,14 +237,10 @@ async function fetchEntityFields(
 		const id = rawResult['id'] as number;
 		if (id == null) continue;
 
-		// Cache the raw source record (for nextHop idField lookups)
+		// Cache only the raw source record — outputFields computed per call (see above)
 		rawCache.set(`raw:${entityName}:${id}`, { fields: rawResult, expiresAt });
 
-		// Compute and cache output fields
-		const fields = applyOutputFields(rawResult, outputFields);
-		enrichmentCache.set(`${entityName}:${id}`, { fields, expiresAt });
-
-		resultMap.set(id, fields);
+		resultMap.set(id, applyOutputFields(rawResult, outputFields));
 	}
 
 	return resultMap;
@@ -248,7 +320,7 @@ export async function enrichResponseJson(
 				// Collect unique next-hop IDs by reading raw source records from rawCache
 				const nextHopIdSet = new Set<number>();
 				for (const id of uniqueIds) {
-					const rawRecord = getCachedEntry(rawCache, `raw:${config.entityName}:${id}`);
+					const rawRecord = getCachedRaw(`raw:${config.entityName}:${id}`);
 					if (rawRecord) {
 						const nextIdRaw = rawRecord[nextHop.idField];
 						if (typeof nextIdRaw === 'number' && nextIdRaw > 0) {
@@ -287,7 +359,7 @@ export async function enrichResponseJson(
 
 				// Inject next-hop output fields
 				if (nextHopMap && config.nextHop) {
-					const rawRecord = getCachedEntry(rawCache, `raw:${config.entityName}:${v}`);
+					const rawRecord = getCachedRaw(`raw:${config.entityName}:${v}`);
 					if (rawRecord) {
 						const nextId = rawRecord[config.nextHop.idField];
 						if (typeof nextId === 'number' && nextId > 0) {

--- a/nodes/Autotask/helpers/ticket-timeline.ts
+++ b/nodes/Autotask/helpers/ticket-timeline.ts
@@ -1,0 +1,199 @@
+import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
+import { autotaskApiRequest } from './http';
+
+// ---------------------------------------------------------------------------
+// Public interfaces
+// ---------------------------------------------------------------------------
+
+export interface TicketTimelineOptions {
+    ticketId: number;
+    since?: string;
+    until?: string;
+    resourceId?: number;        // already resolved to numeric ID by caller
+    includeHistories?: boolean; // default false
+    textLimit?: number;         // default 500; 0 = no limit
+    limit?: number;             // per-entity cap; default 50
+}
+
+export interface TimelineEvent {
+    type: 'note' | 'timeEntry' | 'history';
+    dateTime: string;
+    id: number;
+    [key: string]: unknown;
+}
+
+export interface TicketTimelineResult {
+    events: TimelineEvent[];
+    noteCount: number;
+    timeEntryCount: number;
+    historyCount: number;
+    hasMore: boolean;
+    stageWarnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function buildTicketTimeline(
+    context: IExecuteFunctions,
+    options: TicketTimelineOptions,
+): Promise<TicketTimelineResult> {
+    const {
+        ticketId,
+        since,
+        until,
+        resourceId,
+        includeHistories = false,
+        textLimit = 500,
+        limit = 50,
+    } = options;
+
+    function maybeTruncate(value: unknown): unknown {
+        if (typeof value !== 'string') return value;
+        if (textLimit <= 0 || value.length <= textLimit) return value;
+        const originalLength = value.length;
+        return `${value.slice(0, textLimit)}…[truncated, ${originalLength} chars total]`;
+    }
+
+    // Build date filter pairs for a given date field
+    function buildDateFilters(dateField: string): Array<{ field: string; op: string; value: string }> {
+        const filters: Array<{ field: string; op: string; value: string }> = [];
+        if (since) filters.push({ field: dateField, op: 'gte', value: since });
+        if (until) filters.push({ field: dateField, op: 'lte', value: until });
+        return filters;
+    }
+
+    // Fetch TicketNotes
+    const notesFilters: Array<{ field: string; op: string; value: unknown }> = [
+        { field: 'ticketID', op: 'eq', value: ticketId },
+        ...buildDateFilters('createDateTime'),
+    ];
+    if (resourceId != null) notesFilters.push({ field: 'creatorResourceID', op: 'eq', value: resourceId });
+
+    // Fetch TimeEntries
+    const teFilters: Array<{ field: string; op: string; value: unknown }> = [
+        { field: 'ticketID', op: 'eq', value: ticketId },
+        ...buildDateFilters('dateWorked'),
+    ];
+    if (resourceId != null) teFilters.push({ field: 'resourceID', op: 'eq', value: resourceId });
+
+    // Fetch TicketHistories (optional)
+    const histFilters: Array<{ field: string; op: string; value: unknown }> = [
+        { field: 'ticketID', op: 'eq', value: ticketId },
+        ...buildDateFilters('date'),
+    ];
+    if (resourceId != null) histFilters.push({ field: 'resourceID', op: 'eq', value: resourceId });
+
+    const notesRequest = autotaskApiRequest.call(
+        context,
+        'POST',
+        'TicketNotes/query',
+        { filter: notesFilters, MaxRecords: limit } as unknown as IDataObject,
+    );
+
+    const teRequest = autotaskApiRequest.call(
+        context,
+        'POST',
+        'TimeEntries/query',
+        { filter: teFilters, MaxRecords: limit } as unknown as IDataObject,
+    );
+
+    const histRequest = includeHistories
+        ? autotaskApiRequest.call(
+            context,
+            'POST',
+            'TicketHistory/query',
+            { filter: histFilters, MaxRecords: limit } as unknown as IDataObject,
+          )
+        : Promise.resolve({ items: [] as unknown[] });
+
+    const [notesResult, teResult, histResult] = await Promise.allSettled([
+        notesRequest,
+        teRequest,
+        histRequest,
+    ]);
+
+    const stageWarnings: string[] = [];
+    const events: TimelineEvent[] = [];
+
+    // Process notes
+    let noteCount = 0;
+    if (notesResult.status === 'fulfilled') {
+        const notes = ((notesResult.value as { items?: unknown[] })?.items) ?? [];
+        noteCount = notes.length;
+        for (const raw of notes) {
+            const n = raw as Record<string, unknown>;
+            events.push({
+                type: 'note',
+                dateTime: (n['createDateTime'] as string) ?? '',
+                id: n['id'] as number,
+                title: n['title'],
+                description: maybeTruncate(n['description']),
+                noteType: n['noteType'],
+                creatorResourceID: n['creatorResourceID'],
+                createdByContactID: n['createdByContactID'],
+            });
+        }
+    } else {
+        const msg = notesResult.reason instanceof Error ? notesResult.reason.message : String(notesResult.reason);
+        stageWarnings.push(`TicketNote query failed: ${msg} — notes omitted from timeline`);
+    }
+
+    // Process time entries
+    let timeEntryCount = 0;
+    if (teResult.status === 'fulfilled') {
+        const entries = ((teResult.value as { items?: unknown[] })?.items) ?? [];
+        timeEntryCount = entries.length;
+        for (const raw of entries) {
+            const e = raw as Record<string, unknown>;
+            events.push({
+                type: 'timeEntry',
+                dateTime: e['dateWorked'] ? `${e['dateWorked'] as string}T00:00:00Z` : '',
+                id: e['id'] as number,
+                hoursWorked: e['hoursWorked'],
+                hoursToBill: e['hoursToBill'],
+                summaryNotes: maybeTruncate(e['summaryNotes']),
+                internalNotes: maybeTruncate(e['internalNotes']),
+                resourceID: e['resourceID'],
+                billingCodeID: e['billingCodeID'],
+                isNonBillable: e['isNonBillable'],
+            });
+        }
+    } else {
+        const msg = teResult.reason instanceof Error ? teResult.reason.message : String(teResult.reason);
+        stageWarnings.push(`TimeEntry query failed: ${msg} — time entries omitted from timeline`);
+    }
+
+    // Process histories
+    let historyCount = 0;
+    if (histResult.status === 'fulfilled') {
+        const histories = ((histResult.value as { items?: unknown[] })?.items) ?? [];
+        historyCount = histories.length;
+        for (const raw of histories) {
+            const h = raw as Record<string, unknown>;
+            events.push({
+                type: 'history',
+                dateTime: (h['date'] as string) ?? '',
+                id: h['id'] as number,
+                action: h['action'],
+                detail: h['detail'],
+                resourceID: h['resourceID'],
+            });
+        }
+    } else if (includeHistories) {
+        const msg = histResult.reason instanceof Error ? histResult.reason.message : String(histResult.reason);
+        stageWarnings.push(`TicketHistory query failed: ${msg} — history events omitted from timeline`);
+    }
+
+    // Sort chronologically (oldest-first)
+    events.sort((a, b) => {
+        const da = (a['dateTime'] as string) ?? '';
+        const db = (b['dateTime'] as string) ?? '';
+        return da < db ? -1 : da > db ? 1 : 0;
+    });
+
+    const hasMore = noteCount === limit || timeEntryCount === limit || (includeHistories && historyCount === limit);
+
+    return { events, noteCount, timeEntryCount, historyCount, hasMore, stageWarnings };
+}

--- a/nodes/Autotask/resources/tickets/description.ts
+++ b/nodes/Autotask/resources/tickets/description.ts
@@ -43,6 +43,12 @@ export const ticketFields: INodeProperties[] = [
                 action: 'Get ticket summary',
             },
             {
+                name: 'Timeline',
+                value: 'timeline',
+                description: 'Fetch chronological event stream (notes, time entries, history) for a ticket',
+                action: 'Get ticket timeline',
+            },
+            {
                 name: 'Update',
                 value: 'update',
                 description: 'Update a ticket',
@@ -75,10 +81,10 @@ export const ticketFields: INodeProperties[] = [
         displayOptions: {
             show: {
                 resource: ['ticket'],
-                operation: ['slaHealthCheck', 'summary'],
+                operation: ['slaHealthCheck', 'summary', 'timeline'],
             },
         },
-        description: 'How to identify the ticket for SLA health checks or summary',
+        description: 'How to identify the ticket for SLA health checks, summary, or timeline',
     },
     {
         displayName: 'Ticket ID',
@@ -103,7 +109,7 @@ export const ticketFields: INodeProperties[] = [
         displayOptions: {
             show: {
                 resource: ['ticket'],
-                operation: ['slaHealthCheck', 'summary'],
+                operation: ['slaHealthCheck', 'summary', 'timeline'],
                 ticketIdentifierType: ['id'],
             },
         },
@@ -119,11 +125,61 @@ export const ticketFields: INodeProperties[] = [
         displayOptions: {
             show: {
                 resource: ['ticket'],
-                operation: ['slaHealthCheck', 'summary'],
+                operation: ['slaHealthCheck', 'summary', 'timeline'],
                 ticketIdentifierType: ['ticketNumber'],
             },
         },
         description: 'The ticket number to check, for example T20240615.0674',
+    },
+    {
+        displayName: 'Since',
+        name: 'since',
+        type: 'string',
+        default: '',
+        placeholder: '2024-01-01T00:00:00Z',
+        displayOptions: { show: { resource: ['ticket'], operation: ['timeline'] } },
+        description: 'Filter events on or after this date (ISO 8601)',
+    },
+    {
+        displayName: 'Until',
+        name: 'until',
+        type: 'string',
+        default: '',
+        placeholder: '2024-12-31T23:59:59Z',
+        displayOptions: { show: { resource: ['ticket'], operation: ['timeline'] } },
+        description: 'Filter events on or before this date (ISO 8601)',
+    },
+    {
+        displayName: 'Resource',
+        name: 'resourceId',
+        type: 'string',
+        default: '',
+        displayOptions: { show: { resource: ['ticket'], operation: ['timeline'] } },
+        description: 'Filter by resource name or numeric ID (applies to note author, time entry resource, history actor)',
+    },
+    {
+        displayName: 'Include Histories',
+        name: 'includeHistories',
+        type: 'boolean',
+        default: false,
+        displayOptions: { show: { resource: ['ticket'], operation: ['timeline'] } },
+        description: 'Whether to include field-change audit history (can be high volume on active tickets)',
+    },
+    {
+        displayName: 'Text Limit',
+        name: 'textLimit',
+        type: 'number',
+        default: 500,
+        displayOptions: { show: { resource: ['ticket'], operation: ['timeline'] } },
+        description: 'Max characters for note/entry text fields (0 = no limit)',
+    },
+    {
+        displayName: 'Limit',
+        name: 'limit',
+        type: 'number',
+        default: 50,
+        displayOptions: { show: { resource: ['ticket'], operation: ['timeline'] } },
+        description: 'Max events per entity type (notes, time entries, histories each capped independently)',
     },
     {
         displayName: 'Ticket Field Names or IDs',

--- a/nodes/Autotask/resources/tickets/execute.ts
+++ b/nodes/Autotask/resources/tickets/execute.ts
@@ -426,6 +426,86 @@ export async function executeTicketOperation(
                     break;
                 }
 
+                case 'timeline': {
+                    const ticketIdentifierType = this.getNodeParameter('ticketIdentifierType', i, 'id') as string;
+                    let resolvedTicketId: number;
+
+                    if (ticketIdentifierType === 'ticketNumber') {
+                        const ticketNumber = (this.getNodeParameter('ticketNumber', i, '') as string).trim();
+                        if (!ticketNumber) {
+                            throw new Error('Ticket Number is required for timeline');
+                        }
+                        const queryResponse = await autotaskApiRequest.call(
+                            this,
+                            'POST',
+                            'Tickets/query',
+                            {
+                                filter: [{ field: 'ticketNumber', op: 'eq', value: ticketNumber }],
+                                MaxRecords: 1,
+                            } as IDataObject,
+                        ) as { items?: Array<{ id: number }> };
+                        const items = Array.isArray(queryResponse.items) ? queryResponse.items : [];
+                        if (items.length === 0) {
+                            throw new Error(`Ticket not found: ${ticketNumber}`);
+                        }
+                        resolvedTicketId = Number(items[0].id);
+                    } else {
+                        resolvedTicketId = Number(this.getNodeParameter('id', i, 0));
+                    }
+
+                    const since = this.getNodeParameter('since', i, '') as string;
+                    const until = this.getNodeParameter('until', i, '') as string;
+                    const resourceIdRaw = this.getNodeParameter('resourceId', i, '') as string;
+                    const includeHistories = this.getNodeParameter('includeHistories', i, false) as boolean;
+                    const textLimit = this.getNodeParameter('textLimit', i, 500) as number;
+                    const limit = this.getNodeParameter('limit', i, 50) as number;
+
+                    // Resolve resourceId string to numeric ID if needed
+                    let resolvedResourceId: number | undefined;
+                    if (resourceIdRaw) {
+                        const numericId = parseInt(resourceIdRaw, 10);
+                        if (!isNaN(numericId) && String(numericId) === resourceIdRaw) {
+                            resolvedResourceId = numericId;
+                        } else {
+                            const resourceResults = await autotaskApiRequest.call(
+                                this,
+                                'POST',
+                                'Resources/query',
+                                {
+                                    filter: [
+                                        { op: 'or', items: [
+                                            { field: 'firstName', op: 'contains', value: resourceIdRaw },
+                                            { field: 'lastName', op: 'contains', value: resourceIdRaw },
+                                            { field: 'email', op: 'eq', value: resourceIdRaw },
+                                        ]},
+                                    ],
+                                    MaxRecords: 1,
+                                } as unknown as IDataObject,
+                            ) as { items?: Array<{ id: number }> };
+                            const resItems = Array.isArray(resourceResults.items) ? resourceResults.items : [];
+                            if (resItems.length > 0) {
+                                resolvedResourceId = Number(resItems[0].id);
+                            }
+                        }
+                    }
+
+                    const { buildTicketTimeline } = await import('../../helpers/ticket-timeline');
+                    const result = await buildTicketTimeline(this, {
+                        ticketId: resolvedTicketId,
+                        since: since || undefined,
+                        until: until || undefined,
+                        resourceId: resolvedResourceId,
+                        includeHistories,
+                        textLimit,
+                        limit,
+                    });
+
+                    for (const event of result.events) {
+                        returnData.push({ json: event as unknown as IDataObject });
+                    }
+                    break;
+                }
+
                 case 'count': {
                     const countOp = new CountOperation<IAutotaskEntity>(ENTITY_TYPE, this);
                     const count = await countOp.execute(i);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

- **ticket.timeline**: new read operation returning chronological merged event stream (notes, time entries, optional field-change histories) for a ticket by `id` or `ticketNumber`
- **Response enrichment expanded**: 8 new auto-enriched foreign keys (`resourceID`, `assignedResourceID`, `companyID`, `contractID`, `contactID`, `billingCodeID`, `projectID`, `productID`) across all `records[]` / `record{}` responses
- **Time Entry Notes Guidance**: deployer-configurable textarea on `AutotaskAiTools` node injected into tool description when `resource=timeEntry`; hard-capped at 2400 chars with `…[truncated]` marker and `traceToolBuild` emission
- **Tool description compression**: ~1 400-char reduction targeting small-model (Qwen3 3–7B) token budgets across 5 description sections
- **MCP schema compliance (Copilot Studio)**: eliminate `exclusiveMinimum` and `anyOf` from emitted JSON Schema; update `filter_value` description for comma-separated format

## Test Plan

- [ ] `pnpm build` exits 0
- [ ] `timeEntryNotesGuidance` textarea visible in n8n UI only when resource = Time Entry
- [ ] Guidance text appended to tool description under `TIME ENTRY NOTES GUIDANCE:` header
- [ ] Description truncated at 2400 chars when exceeded
- [ ] `ticket.timeline` returns merged event stream for a valid ticket
- [ ] Enriched responses include new foreign-key display fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)