### PR TITLE
fix(ai-tools): replace rz.union() with rz.coerce to fix Copilot Studio MCP enumeration (v2.12.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.12.5] — 2026-04-29
+
+### Fixed
+- **AI tools — Copilot Studio MCP enumeration failure on Contact (and all resources with write fields):** `rz.union([rz.number(), rz.string()])` and `rz.union([rz.boolean(), rz.number()])` in `schema-generator.ts` produce `anyOf: [{type: ["number","string"]}, {type: "null"}]` in JSON Schema — the **type array inside anyOf** pattern is what Copilot Studio's .NET parser cannot handle, causing the entire `tools/list` MCP response to fail. Root cause: v2.12.4 re-introduced this pattern for write fields and boolean params. Fix: replaced all 46 `.union()` calls with `rz.coerce.string()` (for picklist/reference/ID fields) and `rz.coerce.boolean()` (for boolean params). Both produce `{type: ["T", "null"]}` — no `anyOf` — while still accepting Copilot Studio's coerced integers at runtime (`42 → "42"` via coerce.string(), `1 → true` / `0 → false` via coerce.boolean()). `isLikelyId()` correctly identifies coerced string IDs; `toBool()` correctly handles coerced booleans. Affects `schema-generator.ts` only.
+
 ## [2.12.4] — 2026-04-29
 
 ### Fixed

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -248,7 +248,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		// resourceID — used by getByResource and getByYear (parent-path operations)
 		if (hasGetByResource || hasGetByYear) {
 			shape.resourceID = rz
-				.union([rz.number(), rz.string()])
+				.coerce.string()
 				.nullish()
 				.describe(
 					'Resource name, email, or numeric ID (auto-resolved). Required for getByResource and getByYear. ' +
@@ -297,13 +297,13 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			}
 			if (!shape.excludeTerminalStatuses) {
 				shape.excludeTerminalStatuses = rz
-					.union([rz.boolean(), rz.number()])
+					.coerce.boolean()
 					.nullish()
 					.describe('Exclude terminal statuses Complete/Cancelled (default true). Set false to include closed tickets.');
 			}
 			if (!shape.returnAll) {
 				shape.returnAll = rz
-					.union([rz.boolean(), rz.number()])
+					.coerce.boolean()
 					.nullish()
 					.describe('Fetch all matching records per branch. Default false = up to limit.');
 			}
@@ -460,7 +460,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					'JSON IFilterCondition array. No label resolution — use numeric IDs (call listPicklistValues for picklist IDs). Mutually exclusive with filter_field. Dates UTC.',
 				);
 			shape.returnAll = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe(
 					'Fetch ALL matching records (API pagination). Default false = up to limit. Use tight filters; subject to MAX_RESPONSE_RECORDS truncation.',
@@ -479,7 +479,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				!shape.excludeTerminalStatuses
 			) {
 				shape.excludeTerminalStatuses = rz
-					.union([rz.boolean(), rz.number()])
+					.coerce.boolean()
 					.nullish()
 					.describe(
 						'Exclude terminal statuses from results (default true). Set false only when user explicitly asks for completed, cancelled, or historical records.',
@@ -526,7 +526,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					"Domain comparison operator (default 'contains'). When a domain is available, do domain matching first; avoid strict exact-name-only matching.",
 				);
 			shape.searchContactEmails = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('When true (default), fall back to contact email search if no website match.');
 			shape.limit = rz
@@ -549,7 +549,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		// summary fields
 		if (hasSummary) {
 			shape.includeRaw = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe(
 					'Include pre-alias-rename payload: labels/UDFs intact, raw changeInfoField{N} keys, no null filtering. Use _meta.aliasMap for changeInfo mapping.',
@@ -561,7 +561,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					'Maximum characters for description and resolution fields in the summary. Default 500. Pass 0 for no limit.',
 				);
 			shape.includeChildCounts = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe(
 					'Include childCounts block (notes, time entries, attachments, etc.). Default false — adds parallel API calls.',
@@ -588,7 +588,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.nullish()
 				.describe('Filter by resource name or numeric ID — applies to note author, time entry resource, history actor');
 			shape.includeHistories = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Include field-change audit history events (default false — can be high volume on active tickets)');
 			shape.textLimit = rz
@@ -711,7 +711,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			}
 			if (!shape.includeNotes) {
 				shape.includeNotes = rz
-					.union([rz.boolean(), rz.number()])
+					.coerce.boolean()
 					.nullish()
 					.describe(
 						'When true, also search TicketNotes.description. Default false. Adds one parallel API call. Capped at 200 matched notes.',
@@ -719,7 +719,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			}
 			if (!shape.includeTimeEntries) {
 				shape.includeTimeEntries = rz
-					.union([rz.boolean(), rz.number()])
+					.coerce.boolean()
 					.nullish()
 					.describe(
 						'When true, also search TimeEntries.summaryNotes. Default false. Adds one parallel API call. Capped at 200 matched time entries.',
@@ -747,21 +747,21 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				// human-readable labels (e.g. "Will Spence") which the executor auto-resolves to IDs.
 				const needsLabelResolution = field.isPickList || field.isReference;
 				const base = needsLabelResolution
-					? rz.union([rz.number(), rz.string()])
+					? rz.coerce.string()
 					: field.type === 'number'
 						? rz.number()
 						: field.type === 'boolean'
-							? rz.union([rz.boolean(), rz.number()])
+							? rz.coerce.boolean()
 							: rz.string();
 				shape[field.id] = base.nullish().describe(desc);
 			}
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
-					.union([rz.number(), rz.string()])
+					.coerce.string()
 					.nullish()
 					.describe(IMPERSONATION_RESOURCE_ID_DESCRIBE);
 				shape.proceedWithoutImpersonationIfDenied = rz
-					.union([rz.boolean(), rz.number()])
+					.coerce.boolean()
 					.nullish()
 					.describe(IMPERSONATION_PROCEED_DESCRIBE);
 			}
@@ -796,20 +796,20 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.nullish()
 				.describe('Optional destination contact ID.');
 			shape.copyUdfs = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to copy user-defined fields (default true).');
 			shape.copyAttachments = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to copy CI attachments (default true).');
-			shape.copyNotes = rz.union([rz.boolean(), rz.number()]).nullish().describe('Whether to copy notes (default true).');
+			shape.copyNotes = rz.coerce.boolean().nullish().describe('Whether to copy notes (default true).');
 			shape.copyNoteAttachments = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to copy note attachments (default true).');
 			shape.deactivateSource = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to deactivate the source CI after safety checks (default true).');
 			shape.idempotencyKey = rz.string().nullish().describe('Optional run key for traceability.');
@@ -842,7 +842,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.nullish()
 				.describe('Retry base delay in milliseconds (default 500).');
 			shape.retryJitter = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to use jitter in retry backoff (default true).');
 			shape.throttleMaxBytesPer5Min = rz
@@ -859,11 +859,11 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.describe('Maximum attachment size per file in bytes (default 6291456).');
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
-					.union([rz.number(), rz.string()])
+					.coerce.string()
 					.nullish()
 					.describe(IMPERSONATION_RESOURCE_ID_DESCRIBE);
 				shape.proceedWithoutImpersonationIfDenied = rz
-					.union([rz.boolean(), rz.number()])
+					.coerce.boolean()
 					.nullish()
 					.describe(IMPERSONATION_PROCEED_DESCRIBE);
 			}
@@ -892,21 +892,21 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.nullish()
 				.describe('Optional destination company location ID.');
 			shape.skipIfDuplicateEmailFound = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe(
 					'Whether to skip move when duplicate email exists on destination (default true).',
 				);
 			shape.copyContactGroups = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to copy contact group memberships (default true).');
 			shape.copyCompanyNotes = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to copy company notes linked to the contact (default true).');
 			shape.copyNoteAttachments = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to copy attachments for copied notes (default true).');
 			shape.sourceAuditNote = rz
@@ -919,11 +919,11 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.describe('Optional audit note written to the destination company context.');
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
-					.union([rz.number(), rz.string()])
+					.coerce.string()
 					.nullish()
 					.describe(IMPERSONATION_RESOURCE_ID_DESCRIBE);
 				shape.proceedWithoutImpersonationIfDenied = rz
-					.union([rz.boolean(), rz.number()])
+					.coerce.boolean()
 					.nullish()
 					.describe(IMPERSONATION_PROCEED_DESCRIBE);
 			}
@@ -946,23 +946,23 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					.nullish()
 					.describe('Receiving resource ID. Must be active.');
 			shape.includeTickets = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to include tickets (default false).');
 			shape.includeProjects = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to include projects (default false).');
 			shape.includeServiceCallAssignments = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to reassign service call task/ticket resources (default false).');
 			shape.includeAppointments = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to reassign appointments (default false).');
 			shape.includeCompanies = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to transfer companies owned by the source resource (default false).');
 			shape.companyIdAllowlist = rz
@@ -970,7 +970,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.nullish()
 				.describe('Optional comma-separated company IDs to scope company transfer.');
 			shape.includeOpportunities = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe(
 					'Whether to transfer opportunities owned by the source resource (default false).',
@@ -997,11 +997,11 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					"Required when dueWindowPreset is 'custom'. Accepts YYYY-MM-DD or ISO-8601 datetime.",
 				);
 			shape.onlyOpenActive = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('When true, excludes terminal statuses (default true).');
 			shape.includeItemsWithNoDueDate = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe(
 					'Whether items with no due date are included (default true, unless due window is set).',
@@ -1043,7 +1043,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.nullish()
 				.describe('Optional comma-separated status integer values to include.');
 			shape.addAuditNotes = rz
-				.union([rz.boolean(), rz.number()])
+				.coerce.boolean()
 				.nullish()
 				.describe('Whether to create per-entity audit notes (default false).');
 			shape.auditNoteTemplate = rz
@@ -1054,11 +1054,11 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				);
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
-					.union([rz.number(), rz.string()])
+					.coerce.string()
 					.nullish()
 					.describe(IMPERSONATION_RESOURCE_ID_DESCRIBE);
 				shape.proceedWithoutImpersonationIfDenied = rz
-					.union([rz.boolean(), rz.number()])
+					.coerce.boolean()
 					.nullish()
 					.describe(IMPERSONATION_PROCEED_DESCRIBE);
 			}
@@ -1067,7 +1067,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		// getAvailableRoles fields
 		if (operations.includes('getAvailableRoles')) {
 			if (!shape.resourceID) {
-				shape.resourceID = rz.union([rz.number(), rz.string()]).describe(
+				shape.resourceID = rz.coerce.string().describe(
 					'Required. The resource (technician) ID or name to find available roles for.'
 				);
 			}
@@ -1100,11 +1100,11 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					const desc = buildFieldDescription(field);
 					const needsLabelResolution = field.isPickList || field.isReference;
 					const base = needsLabelResolution
-						? rz.union([rz.number(), rz.string()])
+						? rz.coerce.string()
 						: field.type === 'number'
 							? rz.number()
 							: field.type === 'boolean'
-								? rz.union([rz.boolean(), rz.number()])
+								? rz.coerce.boolean()
 								: rz.string();
 					shape[field.id] = base.nullish().describe(desc);
 				}
@@ -1126,18 +1126,18 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					);
 			if (!shape.errorOnDuplicate)
 				shape.errorOnDuplicate = rz
-					.union([rz.boolean(), rz.number()])
+					.coerce.boolean()
 					.nullish()
 					.describe(
 						"If true, error on duplicate instead of returning outcome: skipped. Default false.",
 					);
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
-					.union([rz.number(), rz.string()])
+					.coerce.string()
 					.nullish()
 					.describe(IMPERSONATION_RESOURCE_ID_DESCRIBE);
 				shape.proceedWithoutImpersonationIfDenied = rz
-					.union([rz.boolean(), rz.number()])
+					.coerce.boolean()
 					.nullish()
 					.describe(IMPERSONATION_PROCEED_DESCRIBE);
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.12.4",
+  "version": "2.12.5",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

- `rz.union([rz.number(), rz.string()]).nullish()` and `rz.union([rz.boolean(), rz.number()]).nullish()` produce `anyOf: [{type:["T1","T2"]},{type:"null"}]` in JSON Schema — the **type array inside `anyOf`** breaks Copilot Studio's .NET JSON Schema parser, causing the entire `tools/list` MCP response to fail and all tools to disappear
- Root cause: v2.12.4 re-introduced this pattern in 46 places (dynamic write-field loops + explicit boolean params); Contact was the trigger because it's the first resource with writable boolean API fields hitting the dynamic write loop's boolean branch
- Fix: replaced all 46 `.union()` calls in `schema-generator.ts` with `rz.coerce.string()` (picklist/reference/ID fields) and `rz.coerce.boolean()` (boolean params) — both produce `{type:["T","null"]}` with no `anyOf`; runtime coercion preserved (`42 → "42"` via coerce.string, `1 → true` via coerce.boolean)

## Test plan

- [ ] Deploy to n8n instance with Contact resource exposed in AutotaskAiTools node
- [ ] Verify Copilot Studio can enumerate all tools (tools/list succeeds)
- [ ] Verify integer IDs still pass through for picklist/reference fields (isLikelyId recognises coerced strings)
- [ ] Verify boolean coercion still works (Copilot sends `1`/`0`, handler receives `true`/`false`)
- [ ] Verify other resources (ticket, company, timeEntry) still work normally