### PR TITLE
fix(createifnotexists): UDF dedup field support + centralised dedup logic (v2.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [Unreleased]
+
+### Planned
+- **`createIfNotExists` — remaining UDF-supported entities:** `company`, `companySiteConfiguration`, `contact`, `product`, `project`, `salesOrder`, `serviceBundle`, `service`, `subscription`, `task`, and `ticket` all support UDFs per Autotask docs but have no `createIfNotExists` operation implemented yet. When added, they will automatically inherit UDF dedup support via `entity-dedup.ts`.
+
+## [2.13.0] - 2026-05-03
+
+### Changed
+- **`createIfNotExists` — UDF dedup field support + centralised dedup logic:** All `createIfNotExists` operations (`contract`, `configurationItem`, `opportunity`, `expenseItem`, `timeEntry`, `contractService`, `contractCharge`, `ticketCharge`, `projectCharge`) now correctly handle user-defined fields in `dedupFields`. Previously, UDF field names were sent as standard API filter fields, causing Autotask to return a 500 error ("Unable to find \<field\> in the Entity"). Fix: new `helpers/entity-dedup.ts` centralises duplicate detection — calls `getFields()` at runtime to classify each dedup field as standard or UDF, pushes the first dedup field server-side (standard fields use normal filter shape; UDF fields use `{ field, udf: true, op, value }`, respecting Autotask's one-UDF-per-query limit), and compares all dedup fields client-side. UDF values are read from `record.userDefinedFields[]` via new `getEntityFieldValue()` in `dedup-utils.ts`. All per-creator inline dedup loops replaced with calls to `findDuplicate()`. `computeFieldDiffs` in `update-fields-on-duplicate.ts` fixed to read UDF values via `getEntityFieldValue()` when comparing for update-on-duplicate; `applyDuplicateUpdate` fixed to send UDF patch fields in `userDefinedFields: [{name, value}]` format rather than flat root (Autotask requirement).
+
 ## [2.12.6] - 2026-04-29
 
 ### Fixed

--- a/nodes/Autotask/ai-tools/operation-handlers/compound-operations.ts
+++ b/nodes/Autotask/ai-tools/operation-handlers/compound-operations.ts
@@ -9,18 +9,11 @@ import {
 	COMPOUND_PARENT_NOT_FOUND_OUTCOMES,
 } from '../../constants/compound-registry';
 
-/** Extract the canonical created-entity numeric ID from a compound creator result. */
+/** Extract the entity numeric ID from a compound creator result (all outcomes use the same field). */
 
-function buildCompoundEntityId(resource: string, result: Record<string, unknown>): number | undefined {
+function buildCompoundId(resource: string, result: Record<string, unknown>): number | undefined {
 	const field = COMPOUND_REGISTRY[resource]?.entityIdField;
 	return field ? (result[field] as number | undefined) : ((result.id ?? result.itemId) as number | undefined);
-}
-
-/** Extract the canonical existing-entity numeric ID from a compound creator result (skip/update). */
-
-function buildCompoundExistingId(resource: string, result: Record<string, unknown>): number | undefined {
-	const field = COMPOUND_REGISTRY[resource]?.existingIdField;
-	return field ? (result[field] as number | undefined) : (result.existingId as number | undefined);
 }
 
 /** Build the context block (parent/scope fields) for a compound creator result. */
@@ -166,15 +159,19 @@ export async function handleCreateIfNotExists(state: ExecutorState): Promise<str
 		: [];
 	const allWarnings = [...rawCompoundWarnings, ...labelWarnings];
 
-	const entityId = buildCompoundEntityId(resource, compoundResult);
-	const existingEntityId = buildCompoundExistingId(resource, compoundResult);
+	const compoundId = buildCompoundId(resource, compoundResult);
 	const compoundContext = buildCompoundContext(resource, compoundResult);
 
 	const compoundData: Record<string, unknown> = {
 		outcome: compoundResult.outcome,
 	};
-	if (entityId !== undefined) compoundData.id = entityId;
-	if (existingEntityId !== undefined) compoundData.existingId = existingEntityId;
+	if (compoundId !== undefined) {
+		if (compoundResult.outcome === 'created') {
+			compoundData.id = compoundId;
+		} else {
+			compoundData.existingId = compoundId;
+		}
+	}
 	if (compoundResult.matchedDedupFields !== undefined)
 		compoundData.matchedDedupFields = compoundResult.matchedDedupFields;
 	if (compoundResult.fieldsUpdated !== undefined)

--- a/nodes/Autotask/constants/compound-registry.ts
+++ b/nodes/Autotask/constants/compound-registry.ts
@@ -21,10 +21,8 @@ export interface CompoundRegistryEntry {
 	getHandler: () => Promise<CompoundOperationHandler>;
 	/** Default dedup fields when the caller does not specify dedupFields. */
 	defaultDedupFields: string[];
-	/** Field in the result containing the created entity's numeric ID. */
+	/** Field in the result containing the entity's numeric ID (all outcomes: created/skipped/updated). */
 	entityIdField: string;
-	/** Field in the result containing the existing entity's numeric ID (on skip/update). */
-	existingIdField: string;
 	/**
 	 * Outcome string that indicates the parent entity was not found.
 	 * When the compound result's `outcome` matches this, the tool returns
@@ -52,7 +50,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['name', 'datePurchased'],
 		entityIdField: 'chargeId',
-		existingIdField: 'existingChargeId',
 		notFoundOutcome: 'contract_not_found',
 	},
 	ticketCharge: {
@@ -62,7 +59,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['name', 'datePurchased'],
 		entityIdField: 'chargeId',
-		existingIdField: 'existingChargeId',
 		notFoundOutcome: 'ticket_not_found',
 	},
 	projectCharge: {
@@ -72,7 +68,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['name', 'datePurchased'],
 		entityIdField: 'chargeId',
-		existingIdField: 'existingChargeId',
 		notFoundOutcome: 'project_not_found',
 	},
 	configurationItems: {
@@ -82,7 +77,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['serialNumber'],
 		entityIdField: 'configurationItemId',
-		existingIdField: 'existingConfigurationItemId',
 		notFoundOutcome: 'company_not_found',
 	},
 	timeEntry: {
@@ -92,7 +86,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['dateWorked', 'hoursWorked'],
 		entityIdField: 'timeEntryId',
-		existingIdField: 'existingTimeEntryId',
 	},
 	contractService: {
 		getHandler: () =>
@@ -101,7 +94,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['serviceID'],
 		entityIdField: 'contractServiceId',
-		existingIdField: 'existingContractServiceId',
 		notFoundOutcome: 'contract_not_found',
 	},
 	contract: {
@@ -111,7 +103,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['contractName'],
 		entityIdField: 'contractId',
-		existingIdField: 'existingContractId',
 		notFoundOutcome: 'company_not_found',
 	},
 	opportunity: {
@@ -121,7 +112,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['title'],
 		entityIdField: 'opportunityId',
-		existingIdField: 'existingId',
 		notFoundOutcome: 'company_not_found',
 	},
 	expenseItem: {
@@ -131,7 +121,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['expenseDate', 'description'],
 		entityIdField: 'expenseItemId',
-		existingIdField: 'existingExpenseItemId',
 	},
 	ticketAdditionalConfigurationItem: {
 		getHandler: () =>
@@ -140,7 +129,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['configurationItemID'],
 		entityIdField: 'ticketAdditionalConfigurationItemId',
-		existingIdField: 'existingId',
 		notFoundOutcome: 'ticket_not_found',
 	},
 	ticketAdditionalContact: {
@@ -150,7 +138,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['contactID'],
 		entityIdField: 'ticketAdditionalContactId',
-		existingIdField: 'existingId',
 		notFoundOutcome: 'ticket_not_found',
 	},
 	changeRequestLink: {
@@ -160,7 +147,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['changeRequestTicketID', 'problemOrIncidentTicketID'],
 		entityIdField: 'linkId',
-		existingIdField: 'existingLinkId',
 	},
 	holidaySet: {
 		getHandler: () =>
@@ -169,7 +155,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['holidaySetName'],
 		entityIdField: 'holidaySetId',
-		existingIdField: 'existingHolidaySetId',
 	},
 	holiday: {
 		getHandler: () =>
@@ -178,7 +163,6 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['holidayDate'],
 		entityIdField: 'holidayId',
-		existingIdField: 'existingHolidayId',
 		notFoundOutcome: 'holiday_set_not_found',
 	},
 };

--- a/nodes/Autotask/helpers/change-request-link-creator.ts
+++ b/nodes/Autotask/helpers/change-request-link-creator.ts
@@ -17,7 +17,6 @@ export interface IChangeRequestLinkCreateResult {
 	changeRequestTicketID?: string | number;
 	problemOrIncidentTicketID?: string | number;
 	linkId?: number;
-	existingLinkId?: number;
 	reason?: string;
 	matchedDedupFields?: string[];
 	warnings: string[];
@@ -135,7 +134,7 @@ export async function createChangeRequestLinkIfNotExists(
 			outcome: 'skipped',
 			changeRequestTicketID,
 			problemOrIncidentTicketID,
-			existingLinkId: duplicate.id as number,
+			linkId: duplicate.id as number,
 			reason: 'duplicate_link',
 			matchedDedupFields: matchedFields,
 			warnings,

--- a/nodes/Autotask/helpers/charge-creator-base.ts
+++ b/nodes/Autotask/helpers/charge-creator-base.ts
@@ -21,7 +21,6 @@ export interface IChargeCreateResult {
 	outcome: ChargeCreateOutcome;
 	parentId?: number;
 	chargeId?: number;
-	existingChargeId?: number;
 	parentLookupValue: string;
 	chargeName: string;
 	datePurchased: string;
@@ -270,7 +269,7 @@ export async function createChargeIfNotExists(
 				});
 				return {
 					outcome: 'updated',
-					existingChargeId: duplicate.id as number,
+					chargeId: duplicate.id as number,
 					parentId,
 					parentLookupValue,
 					chargeName: (options.createFields.name as string) ?? (updatedEntity.name as string) ?? '',
@@ -286,7 +285,7 @@ export async function createChargeIfNotExists(
 				return {
 					outcome: 'skipped',
 					reason: 'duplicate_no_changes',
-					existingChargeId: duplicate.id as number,
+					chargeId: duplicate.id as number,
 					parentId,
 					parentLookupValue,
 					chargeName: (options.createFields.name as string) ?? '',
@@ -301,7 +300,7 @@ export async function createChargeIfNotExists(
 		return {
 			outcome: 'skipped',
 			reason: 'duplicate_charge',
-			existingChargeId: duplicate.id as number,
+			chargeId: duplicate.id as number,
 			parentId,
 			parentLookupValue,
 			chargeName: (options.createFields.name as string) ?? '',

--- a/nodes/Autotask/helpers/charge-creator-base.ts
+++ b/nodes/Autotask/helpers/charge-creator-base.ts
@@ -1,7 +1,8 @@
 import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
 import { autotaskApiRequest } from './http';
-import { compareDedupField, extractId, extractItems } from './dedup-utils';
+import { extractId, extractItems } from './dedup-utils';
 import { computeFieldDiffs, applyDuplicateUpdate } from './update-fields-on-duplicate';
+import { findDuplicate } from './entity-dedup';
 
 // ─── Interfaces ──────────────────────────────────────────────────────────────
 
@@ -87,60 +88,20 @@ export async function findParentEntity(
 /**
  * Step 2: Check for duplicate charges using configurable dedup fields.
  */
-export async function findDuplicateCharge(
+export function findDuplicateCharge(
 	ctx: IExecuteFunctions,
 	config: ChargeCreatorConfig,
 	parentId: number,
 	options: IChargeCreateIfNotExistsOptions,
 ): Promise<{ duplicate: IDataObject | null; matchedFields: string[] }> {
-	const { dedupFields, createFields } = options;
-
-	if (!dedupFields || dedupFields.length === 0) {
-		return { duplicate: null, matchedFields: [] };
-	}
-
-	// API filter: always filter by parent ID, plus name if in dedupFields
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const apiFilter: any[] = [
-		{ field: config.chargeParentIdField, op: 'eq', value: parentId },
-	];
-	if (dedupFields.includes('name')) {
-		apiFilter.push({ field: 'name', op: 'eq', value: createFields.name });
-	}
-
-	const response = await autotaskApiRequest.call(
-		ctx, 'POST', config.chargeQueryEndpoint, { filter: apiFilter },
-	);
-
-	const charges = extractItems(response as IDataObject);
-	const fieldTypeMap = config.fieldTypeMap ?? {};
-
-	// Client-side precision match on ALL selected dedupFields
-	for (const charge of charges) {
-		const matched: string[] = [];
-		let allMatch = true;
-
-		for (const field of dedupFields) {
-			const fieldType = fieldTypeMap[field] ?? 'string';
-
-			// Get the input value from createFields
-			const inputValue = createFields[field];
-			const apiValue = charge[field];
-
-			if (compareDedupField(fieldType, apiValue, inputValue)) {
-				matched.push(field);
-			} else {
-				allMatch = false;
-				break;
-			}
-		}
-
-		if (allMatch && matched.length === dedupFields.length) {
-			return { duplicate: charge, matchedFields: matched };
-		}
-	}
-
-	return { duplicate: null, matchedFields: [] };
+	return findDuplicate(ctx, {
+		entityType: config.entityName,
+		queryEndpoint: config.chargeQueryEndpoint,
+		scopeFilters: [{ field: config.chargeParentIdField, op: 'eq', value: parentId }],
+		dedupFields: options.dedupFields,
+		createFields: options.createFields,
+		fieldTypeMap: config.fieldTypeMap,
+	});
 }
 
 /**

--- a/nodes/Autotask/helpers/configuration-item-creator.ts
+++ b/nodes/Autotask/helpers/configuration-item-creator.ts
@@ -21,7 +21,6 @@ export interface IConfigurationItemCreateResult {
 	outcome: ConfigurationItemCreateOutcome;
 	companyID: string | number;
 	configurationItemId?: number;
-	existingConfigurationItemId?: number;
 	reason?: string;
 	matchedDedupFields?: string[];
 	fieldsUpdated?: string[];
@@ -170,7 +169,7 @@ export async function createConfigurationItemIfNotExists(
 				return {
 					outcome: 'updated',
 					companyID,
-					existingConfigurationItemId: duplicate.id as number,
+					configurationItemId: duplicate.id as number,
 					matchedDedupFields: matchedFields,
 					fieldsUpdated: Object.keys(patch),
 					fieldsCompared: compared,
@@ -181,7 +180,7 @@ export async function createConfigurationItemIfNotExists(
 					outcome: 'skipped',
 					reason: 'duplicate_no_changes',
 					companyID,
-					existingConfigurationItemId: duplicate.id as number,
+					configurationItemId: duplicate.id as number,
 					matchedDedupFields: matchedFields,
 					fieldsCompared: compared,
 					warnings: [...warnings, ...diffWarnings],
@@ -193,7 +192,7 @@ export async function createConfigurationItemIfNotExists(
 			outcome: 'skipped',
 			companyID,
 			reason: 'duplicate_configuration_item',
-			existingConfigurationItemId: duplicate.id as number,
+			configurationItemId: duplicate.id as number,
 			matchedDedupFields: matchedFields,
 			warnings,
 		};

--- a/nodes/Autotask/helpers/configuration-item-creator.ts
+++ b/nodes/Autotask/helpers/configuration-item-creator.ts
@@ -1,7 +1,8 @@
 import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
 import { autotaskApiRequest } from './http';
-import { compareDedupField, extractId, extractItems } from './dedup-utils';
+import { extractId, extractItems } from './dedup-utils';
 import { computeFieldDiffs, applyDuplicateUpdate } from './update-fields-on-duplicate';
+import { findDuplicate } from './entity-dedup';
 
 // ─── Interfaces ───────────────────────────────────────────────────────────────
 
@@ -60,61 +61,20 @@ async function verifyCompanyExists(
 
 // ─── Step 2: Find duplicate CI ───────────────────────────────────────────────
 
-async function findDuplicateConfigurationItem(
+function findDuplicateConfigurationItem(
 	ctx: IExecuteFunctions,
 	companyID: string | number,
 	dedupFields: string[],
 	createFields: Record<string, unknown>,
 ): Promise<{ duplicate: IDataObject | null; matchedFields: string[] }> {
-	if (!dedupFields || dedupFields.length === 0) {
-		return { duplicate: null, matchedFields: [] };
-	}
-
-	// Server-side: always filter by companyID, plus first dedup field for narrowing
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const apiFilter: any[] = [
-		{ field: 'companyID', op: 'eq', value: companyID },
-	];
-
-	const firstDedupField = dedupFields[0];
-	const firstDedupValue = createFields[firstDedupField];
-	if (firstDedupValue !== undefined && firstDedupValue !== null) {
-		apiFilter.push({ field: firstDedupField, op: 'eq', value: firstDedupValue });
-	}
-
-	const response = await autotaskApiRequest.call(
-		ctx,
-		'POST',
-		'ConfigurationItems/query',
-		{ filter: apiFilter },
-	);
-
-	const items = extractItems(response as IDataObject);
-
-	// Client-side precision match on ALL selected dedupFields
-	for (const item of items) {
-		const matched: string[] = [];
-		let allMatch = true;
-
-		for (const field of dedupFields) {
-			const fieldType = CI_FIELD_TYPE_MAP[field] ?? 'string';
-			const inputValue = createFields[field];
-			const apiValue = item[field];
-
-			if (compareDedupField(fieldType, apiValue, inputValue)) {
-				matched.push(field);
-			} else {
-				allMatch = false;
-				break;
-			}
-		}
-
-		if (allMatch && matched.length === dedupFields.length) {
-			return { duplicate: item, matchedFields: matched };
-		}
-	}
-
-	return { duplicate: null, matchedFields: [] };
+	return findDuplicate(ctx, {
+		entityType: 'ConfigurationItem',
+		queryEndpoint: 'ConfigurationItems/query',
+		scopeFilters: [{ field: 'companyID', op: 'eq', value: companyID }],
+		dedupFields,
+		createFields,
+		fieldTypeMap: CI_FIELD_TYPE_MAP,
+	});
 }
 
 // ─── Step 3: Create the configuration item ───────────────────────────────────

--- a/nodes/Autotask/helpers/contract-charge-creator.ts
+++ b/nodes/Autotask/helpers/contract-charge-creator.ts
@@ -16,7 +16,6 @@ export interface IContractChargeCreateIfNotExistsResult {
 	outcome: ContractChargeCreateIfNotExistsOutcome;
 	contractId?: number;
 	chargeId?: number;
-	existingChargeId?: number;
 	externalServiceIdentifier: string;
 	chargeName: string;
 	datePurchased: string;
@@ -84,7 +83,7 @@ function mapToContractChargeResult(
 		outcome,
 		contractId: result.parentId,
 		chargeId: result.chargeId,
-		existingChargeId: result.existingChargeId,
+
 		externalServiceIdentifier,
 		chargeName: result.chargeName,
 		datePurchased: result.datePurchased,

--- a/nodes/Autotask/helpers/contract-creator.ts
+++ b/nodes/Autotask/helpers/contract-creator.ts
@@ -21,7 +21,6 @@ export interface IContractCreateResult {
 	outcome: ContractCreateOutcome;
 	companyID: string | number;
 	contractId?: number;
-	existingContractId?: number;
 	reason?: string;
 	matchedDedupFields?: string[];
 	fieldsUpdated?: string[];
@@ -161,7 +160,7 @@ export async function createContractIfNotExists(
 				return {
 					outcome: 'updated',
 					companyID,
-					existingContractId: duplicate.id as number,
+					contractId: duplicate.id as number,
 					matchedDedupFields: matchedFields,
 					fieldsUpdated: Object.keys(patch),
 					fieldsCompared: compared,
@@ -172,7 +171,7 @@ export async function createContractIfNotExists(
 					outcome: 'skipped',
 					reason: 'duplicate_no_changes',
 					companyID,
-					existingContractId: duplicate.id as number,
+					contractId: duplicate.id as number,
 					matchedDedupFields: matchedFields,
 					fieldsCompared: compared,
 					warnings: [...warnings, ...diffWarnings],
@@ -184,7 +183,7 @@ export async function createContractIfNotExists(
 			outcome: 'skipped',
 			companyID,
 			reason: 'duplicate_contract',
-			existingContractId: duplicate.id as number,
+			contractId: duplicate.id as number,
 			matchedDedupFields: matchedFields,
 			warnings,
 		};

--- a/nodes/Autotask/helpers/contract-creator.ts
+++ b/nodes/Autotask/helpers/contract-creator.ts
@@ -1,7 +1,8 @@
 import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
 import { autotaskApiRequest } from './http';
-import { compareDedupField, extractId, extractItems } from './dedup-utils';
+import { extractId, extractItems } from './dedup-utils';
 import { computeFieldDiffs, applyDuplicateUpdate } from './update-fields-on-duplicate';
+import { findDuplicate } from './entity-dedup';
 
 // ─── Interfaces ──────────────────────────────────────────────────────────────
 
@@ -30,14 +31,9 @@ export interface IContractCreateResult {
 
 // ─── Field type map ──────────────────────────────────────────────────────────
 
-/**
- * Known field types for contract dedup comparison.
- * Default is 'string' for any field not listed here.
- */
 const CONTRACT_FIELD_TYPE_MAP: Record<string, string> = {
 	contractName: 'string',
 	contractNumber: 'string',
-	externalServiceIdentifier: 'string',
 	contractType: 'integer',
 };
 
@@ -58,61 +54,20 @@ async function verifyCompanyExists(
 
 // ─── Step 2: Find duplicate contract ────────────────────────────────────────
 
-async function findDuplicateContract(
+function findDuplicateContract(
 	ctx: IExecuteFunctions,
 	companyID: string | number,
 	dedupFields: string[],
 	createFields: Record<string, unknown>,
 ): Promise<{ duplicate: IDataObject | null; matchedFields: string[] }> {
-	if (!dedupFields || dedupFields.length === 0) {
-		return { duplicate: null, matchedFields: [] };
-	}
-
-	// Server-side filter: always scope by companyID, narrow by first dedup field if present
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const apiFilter: any[] = [
-		{ field: 'companyID', op: 'eq', value: companyID },
-	];
-
-	const firstDedupField = dedupFields[0];
-	if (firstDedupField && createFields[firstDedupField] !== undefined) {
-		apiFilter.push({
-			field: firstDedupField,
-			op: 'eq',
-			value: createFields[firstDedupField],
-		});
-	}
-
-	const response = await autotaskApiRequest.call(
-		ctx, 'POST', 'Contracts/query', { filter: apiFilter },
-	);
-
-	const contracts = extractItems(response as IDataObject);
-
-	// Client-side precision match on ALL selected dedupFields
-	for (const contract of contracts) {
-		const matched: string[] = [];
-		let allMatch = true;
-
-		for (const field of dedupFields) {
-			const fieldType = CONTRACT_FIELD_TYPE_MAP[field] ?? 'string';
-			const inputValue = createFields[field];
-			const apiValue = contract[field];
-
-			if (compareDedupField(fieldType, apiValue, inputValue)) {
-				matched.push(field);
-			} else {
-				allMatch = false;
-				break;
-			}
-		}
-
-		if (allMatch && matched.length === dedupFields.length) {
-			return { duplicate: contract, matchedFields: matched };
-		}
-	}
-
-	return { duplicate: null, matchedFields: [] };
+	return findDuplicate(ctx, {
+		entityType: 'Contract',
+		queryEndpoint: 'Contracts/query',
+		scopeFilters: [{ field: 'companyID', op: 'eq', value: companyID }],
+		dedupFields,
+		createFields,
+		fieldTypeMap: CONTRACT_FIELD_TYPE_MAP,
+	});
 }
 
 // ─── Step 3: Create contract ─────────────────────────────────────────────────

--- a/nodes/Autotask/helpers/contract-service-creator.ts
+++ b/nodes/Autotask/helpers/contract-service-creator.ts
@@ -21,7 +21,6 @@ export interface IContractServiceCreateResult {
 	outcome: ContractServiceCreateOutcome;
 	contractId?: number;
 	contractServiceId?: number;
-	existingContractServiceId?: number;
 	serviceID?: number;
 	reason?: string;
 	matchedDedupFields?: string[];
@@ -217,7 +216,7 @@ export async function createContractServiceIfNotExists(
 				return {
 					outcome: 'updated',
 					contractId,
-					existingContractServiceId: duplicate.id as number,
+					contractServiceId: duplicate.id as number,
 					serviceID,
 					matchedDedupFields: matchedFields,
 					fieldsUpdated: Object.keys(patch),
@@ -229,7 +228,7 @@ export async function createContractServiceIfNotExists(
 					outcome: 'skipped',
 					reason: 'duplicate_no_changes',
 					contractId,
-					existingContractServiceId: duplicate.id as number,
+					contractServiceId: duplicate.id as number,
 					serviceID,
 					matchedDedupFields: matchedFields,
 					fieldsCompared: compared,
@@ -242,7 +241,7 @@ export async function createContractServiceIfNotExists(
 			outcome: 'skipped',
 			reason: 'duplicate_contract_service',
 			contractId,
-			existingContractServiceId: duplicate.id as number,
+			contractServiceId: duplicate.id as number,
 			serviceID,
 			matchedDedupFields: matchedFields,
 			warnings,

--- a/nodes/Autotask/helpers/contract-service-creator.ts
+++ b/nodes/Autotask/helpers/contract-service-creator.ts
@@ -1,7 +1,8 @@
 import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
 import { autotaskApiRequest } from './http';
-import { extractId, extractItems, compareDedupField } from './dedup-utils';
+import { extractId, extractItems } from './dedup-utils';
 import { computeFieldDiffs, applyDuplicateUpdate } from './update-fields-on-duplicate';
+import { findDuplicate } from './entity-dedup';
 
 // ─── Interfaces ──────────────────────────────────────────────────────────────
 
@@ -28,8 +29,6 @@ export interface IContractServiceCreateResult {
 	fieldsCompared?: string[];
 	warnings: string[];
 }
-
-// ─── Field type map ──────────────────────────────────────────────────────────
 
 const CONTRACT_SERVICE_FIELD_TYPE_MAP: Record<string, string> = {
 	serviceID: 'integer',
@@ -101,66 +100,20 @@ async function resolveContractId(
 
 // ─── Step 2: Find duplicate ContractService ──────────────────────────────────
 
-/**
- * Query ContractServices for existing records on the resolved contract.
- * Applies API-side filter for contractID (and serviceID when it is in dedupFields),
- * then performs client-side precision matching across all requested dedupFields.
- */
-async function findDuplicateContractService(
+function findDuplicateContractService(
 	ctx: IExecuteFunctions,
 	contractId: number,
 	dedupFields: string[],
 	createFields: Record<string, unknown>,
 ): Promise<{ duplicate: IDataObject | null; matchedFields: string[] }> {
-	if (!dedupFields || dedupFields.length === 0) {
-		return { duplicate: null, matchedFields: [] };
-	}
-
-	// API filter: always include contractID; add serviceID server-side when present in dedupFields
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const apiFilter: any[] = [
-		{ field: 'contractID', op: 'eq', value: contractId },
-	];
-
-	if (dedupFields.includes('serviceID') && createFields.serviceID !== undefined) {
-		apiFilter.push({ field: 'serviceID', op: 'eq', value: createFields.serviceID });
-	}
-
-	const response = await autotaskApiRequest.call(
-		ctx,
-		'POST',
-		'ContractServices/query',
-		{ filter: apiFilter },
-	);
-
-	const services = extractItems(response as IDataObject);
-
-	// Client-side precision match on ALL selected dedupFields
-	for (const service of services) {
-		const matched: string[] = [];
-		let allMatch = true;
-
-		for (const field of dedupFields) {
-			const inputValue = createFields[field];
-			const apiValue = service[field];
-
-			// serviceID is an integer reference field; all others default to string comparison
-			const fieldType = field === 'serviceID' ? 'integer' : 'string';
-
-			if (compareDedupField(fieldType, apiValue, inputValue)) {
-				matched.push(field);
-			} else {
-				allMatch = false;
-				break;
-			}
-		}
-
-		if (allMatch && matched.length === dedupFields.length) {
-			return { duplicate: service, matchedFields: matched };
-		}
-	}
-
-	return { duplicate: null, matchedFields: [] };
+	return findDuplicate(ctx, {
+		entityType: 'ContractService',
+		queryEndpoint: 'ContractServices/query',
+		scopeFilters: [{ field: 'contractID', op: 'eq', value: contractId }],
+		dedupFields,
+		createFields,
+		fieldTypeMap: CONTRACT_SERVICE_FIELD_TYPE_MAP,
+	});
 }
 
 // ─── Step 3: Create ContractService ──────────────────────────────────────────

--- a/nodes/Autotask/helpers/dedup-utils.ts
+++ b/nodes/Autotask/helpers/dedup-utils.ts
@@ -52,6 +52,21 @@ export function normaliseQuantity(value: number): number {
 	return Math.round(value * 10000) / 10000;
 }
 
+// ─── UDF-aware field reader ─────────────────────────────────────────────────
+
+/**
+ * Read a field value from an entity record.
+ * Standard fields are at the root; UDF fields live in userDefinedFields[].
+ * Tries root first, then falls back to userDefinedFields[] by name.
+ */
+export function getEntityFieldValue(entity: IDataObject, field: string): unknown {
+	if (field in entity) return entity[field];
+	// Autotask prevents UDF names from colliding with standard field names, so root-first is safe.
+	const udfs = entity.userDefinedFields as Array<{ name: string; value: unknown }> | undefined;
+	const lower = field.toLowerCase();
+	return udfs?.find(udf => udf.name.toLowerCase() === lower)?.value;
+}
+
 // ─── Response helpers ───────────────────────────────────────────────────────
 
 /** Extract the numeric ID from an Autotask API create/update response */

--- a/nodes/Autotask/helpers/entity-dedup.ts
+++ b/nodes/Autotask/helpers/entity-dedup.ts
@@ -3,6 +3,7 @@ import { autotaskApiRequest } from './http';
 import { compareDedupField, extractItems, getEntityFieldValue } from './dedup-utils';
 import { getFields } from './entity/api';
 import type { IAutotaskField } from '../types/base/entities';
+import type { IUdfFieldDefinition } from '../types/base/udf-types';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -19,9 +20,24 @@ export interface IFindDuplicateOptions {
 	createFields: Record<string, unknown>;
 	/**
 	 * Known field types for type-aware comparison (field name → type string).
-	 * Any field not listed defaults to 'string'.
+	 * Any field not listed defaults to UDF metadata lookup, then 'string'.
 	 */
 	fieldTypeMap?: Record<string, string>;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Map AutotaskDataType (string literal or UdfDataType numeric) to compareDedupField type string */
+function normaliseDedupType(dataType: unknown): string {
+	switch (String(dataType).toLowerCase()) {
+		case 'datetime': case '3': return 'datetime';
+		case 'date': return 'date';
+		case 'double': case 'decimal': case '2': return 'double';
+		case 'boolean': case '4': return 'boolean';
+		case 'long': return 'long';
+		case 'integer': return 'integer';
+		default: return 'string';
+	}
 }
 
 // ─── Core dedup logic ────────────────────────────────────────────────────────
@@ -29,13 +45,16 @@ export interface IFindDuplicateOptions {
 /**
  * Find a duplicate entity using server-side + client-side filtering.
  *
- * Server-side: scopeFilters always applied. The first dedupField is also pushed
- * to the API filter — standard fields use the normal filter shape, UDF fields use
- * { udf: true, field, op, value } (Autotask supports one UDF filter per query).
+ * Server-side: scopeFilters always applied. The first *queryable* dedup field is also
+ * pushed to the API filter — queryable standard fields use the normal filter shape, UDF
+ * fields use { udf: true, field, op, value } (Autotask supports one UDF filter per query).
+ * Non-queryable standard fields are skipped for server-side filtering to avoid hard API errors.
  * Remaining dedupFields are evaluated client-side only.
  *
- * Client-side: all dedupFields are compared using getEntityFieldValue(), which
- * reads standard fields from the record root and UDF fields from userDefinedFields[].
+ * Client-side: all dedupFields are compared using getEntityFieldValue(), which reads
+ * standard fields from the record root and UDF fields from userDefinedFields[].
+ * UDF fields whose types are not in fieldTypeMap are looked up via getFields() so that
+ * date/number/boolean UDFs receive type-aware normalisation instead of plain string compare.
  */
 export async function findDuplicate(
 	ctx: IExecuteFunctions,
@@ -50,18 +69,40 @@ export async function findDuplicate(
 	// Determine which fields are standard vs UDF
 	const standardApiFields = await getFields(entityType, ctx, { fieldType: 'standard' }) as IAutotaskField[];
 	const standardFieldNames = new Set(standardApiFields.map(f => f.name));
+	// P1: only queryable standard fields may be pushed into the API filter
+	const queryableStandardFieldNames = new Set(
+		standardApiFields.filter(f => f.isQueryable).map(f => f.name),
+	);
+
+	// P2: fetch UDF metadata for any UDF dedup fields to get type-aware comparison
+	const udfDedupFields = dedupFields.filter(f => !standardFieldNames.has(f));
+	const udfTypeOverrides: Record<string, string> = {};
+	if (udfDedupFields.length > 0) {
+		try {
+			const udfDefs = await getFields(entityType, ctx, { fieldType: 'udf' }) as IUdfFieldDefinition[];
+			const lowerNames = udfDedupFields.map(f => f.toLowerCase());
+			for (const udf of udfDefs) {
+				if (lowerNames.includes(udf.name.toLowerCase())) {
+					udfTypeOverrides[udf.name.toLowerCase()] = normaliseDedupType(udf.dataType);
+				}
+			}
+		} catch {
+			// UDF metadata unavailable — fall back to 'string' comparison for those fields
+		}
+	}
 
 	// Build API filter: scope + one dedup field for server-side narrowing.
-	// Prefer a standard field (exact match, no special syntax) over a UDF field.
-	// Fall back to the first UDF if no standard dedup field has a value.
+	// Prefer a queryable standard field (exact match, no special syntax) over a UDF field.
+	// Non-queryable standard fields are intentionally skipped to avoid API errors.
+	// Fall back to the first UDF if no queryable standard dedup field has a value.
 	// Autotask supports { field, udf: true } for UDF filters — one per query maximum.
 	const apiFilter: Array<Record<string, unknown>> = [...scopeFilters];
 	const preferredField =
-		dedupFields.find(f => standardFieldNames.has(f) && createFields[f] !== undefined) ??
+		dedupFields.find(f => queryableStandardFieldNames.has(f) && createFields[f] !== undefined) ??
 		dedupFields.find(f => !standardFieldNames.has(f) && createFields[f] !== undefined);
 
 	if (preferredField) {
-		if (standardFieldNames.has(preferredField)) {
+		if (queryableStandardFieldNames.has(preferredField)) {
 			apiFilter.push({ field: preferredField, op: 'eq', value: createFields[preferredField] });
 		} else {
 			apiFilter.push({ field: preferredField, udf: true, op: 'eq', value: createFields[preferredField] });
@@ -77,7 +118,7 @@ export async function findDuplicate(
 		let allMatch = true;
 
 		for (const field of dedupFields) {
-			const fieldType = fieldTypeMap[field] ?? 'string';
+			const fieldType = fieldTypeMap[field] ?? udfTypeOverrides[field.toLowerCase()] ?? 'string';
 			const inputValue = createFields[field];
 			const apiValue = getEntityFieldValue(entity, field);
 

--- a/nodes/Autotask/helpers/entity-dedup.ts
+++ b/nodes/Autotask/helpers/entity-dedup.ts
@@ -1,0 +1,98 @@
+import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
+import { autotaskApiRequest } from './http';
+import { compareDedupField, extractItems, getEntityFieldValue } from './dedup-utils';
+import { getFields } from './entity/api';
+import type { IAutotaskField } from '../types/base/entities';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface IFindDuplicateOptions {
+	/** Autotask entity name for standard-field lookup, e.g. 'Contract', 'ConfigurationItem' */
+	entityType: string;
+	/** Query endpoint, e.g. 'Contracts/query' */
+	queryEndpoint: string;
+	/** Filters always applied (scope), e.g. [{ field: 'companyID', op: 'eq', value: 42 }] */
+	scopeFilters: Array<{ field: string; op: string; value: unknown }>;
+	/** Fields to use for duplicate detection */
+	dedupFields: string[];
+	/** Values the caller wants to create */
+	createFields: Record<string, unknown>;
+	/**
+	 * Known field types for type-aware comparison (field name → type string).
+	 * Any field not listed defaults to 'string'.
+	 */
+	fieldTypeMap?: Record<string, string>;
+}
+
+// ─── Core dedup logic ────────────────────────────────────────────────────────
+
+/**
+ * Find a duplicate entity using server-side + client-side filtering.
+ *
+ * Server-side: scopeFilters always applied. The first dedupField is also pushed
+ * to the API filter — standard fields use the normal filter shape, UDF fields use
+ * { udf: true, field, op, value } (Autotask supports one UDF filter per query).
+ * Remaining dedupFields are evaluated client-side only.
+ *
+ * Client-side: all dedupFields are compared using getEntityFieldValue(), which
+ * reads standard fields from the record root and UDF fields from userDefinedFields[].
+ */
+export async function findDuplicate(
+	ctx: IExecuteFunctions,
+	options: IFindDuplicateOptions,
+): Promise<{ duplicate: IDataObject | null; matchedFields: string[] }> {
+	const { entityType, queryEndpoint, scopeFilters, dedupFields, createFields, fieldTypeMap = {} } = options;
+
+	if (!dedupFields || dedupFields.length === 0) {
+		return { duplicate: null, matchedFields: [] };
+	}
+
+	// Determine which fields are standard vs UDF
+	const standardApiFields = await getFields(entityType, ctx, { fieldType: 'standard' }) as IAutotaskField[];
+	const standardFieldNames = new Set(standardApiFields.map(f => f.name));
+
+	// Build API filter: scope + one dedup field for server-side narrowing.
+	// Prefer a standard field (exact match, no special syntax) over a UDF field.
+	// Fall back to the first UDF if no standard dedup field has a value.
+	// Autotask supports { field, udf: true } for UDF filters — one per query maximum.
+	const apiFilter: Array<Record<string, unknown>> = [...scopeFilters];
+	const preferredField =
+		dedupFields.find(f => standardFieldNames.has(f) && createFields[f] !== undefined) ??
+		dedupFields.find(f => !standardFieldNames.has(f) && createFields[f] !== undefined);
+
+	if (preferredField) {
+		if (standardFieldNames.has(preferredField)) {
+			apiFilter.push({ field: preferredField, op: 'eq', value: createFields[preferredField] });
+		} else {
+			apiFilter.push({ field: preferredField, udf: true, op: 'eq', value: createFields[preferredField] });
+		}
+	}
+
+	const response = await autotaskApiRequest.call(ctx, 'POST', queryEndpoint, { filter: apiFilter });
+	const entities = extractItems(response as IDataObject);
+
+	// Client-side precision match across all dedupFields (standard + UDF)
+	for (const entity of entities) {
+		const matched: string[] = [];
+		let allMatch = true;
+
+		for (const field of dedupFields) {
+			const fieldType = fieldTypeMap[field] ?? 'string';
+			const inputValue = createFields[field];
+			const apiValue = getEntityFieldValue(entity, field);
+
+			if (compareDedupField(fieldType, apiValue, inputValue)) {
+				matched.push(field);
+			} else {
+				allMatch = false;
+				break;
+			}
+		}
+
+		if (allMatch && matched.length === dedupFields.length) {
+			return { duplicate: entity, matchedFields: matched };
+		}
+	}
+
+	return { duplicate: null, matchedFields: [] };
+}

--- a/nodes/Autotask/helpers/entity-dedup.ts
+++ b/nodes/Autotask/helpers/entity-dedup.ts
@@ -71,6 +71,7 @@ export async function findDuplicate(
 	// scope filters + full client-side matching — no harder failure than before this helper existed.
 	let standardFieldNames = new Set<string>();
 	let queryableStandardFieldNames = new Set<string>();
+	let metadataAvailable = false;
 	try {
 		const standardApiFields = await getFields(entityType, ctx, { fieldType: 'standard' }) as IAutotaskField[];
 		standardFieldNames = new Set(standardApiFields.map(f => f.name));
@@ -78,13 +79,15 @@ export async function findDuplicate(
 		queryableStandardFieldNames = new Set(
 			standardApiFields.filter(f => f.isQueryable).map(f => f.name),
 		);
+		metadataAvailable = true;
 	} catch {
-		// Standard field metadata unavailable — treat all dedup fields as unclassified.
-		// Server-side narrowing is skipped; client-side comparison still runs.
+		// Standard field metadata unavailable — skip server-side dedup-field narrowing.
+		// Only scope filters applied; client-side comparison still runs across all results.
 	}
 
-	// P2: fetch UDF metadata for any UDF dedup fields to get type-aware comparison
-	const udfDedupFields = dedupFields.filter(f => !standardFieldNames.has(f));
+	// P2: fetch UDF metadata for any UDF dedup fields to get type-aware comparison.
+	// Only meaningful when metadata is available — without it, we cannot distinguish UDF from standard.
+	const udfDedupFields = metadataAvailable ? dedupFields.filter(f => !standardFieldNames.has(f)) : [];
 	const udfTypeOverrides: Record<string, string> = {};
 	if (udfDedupFields.length > 0) {
 		try {
@@ -101,14 +104,17 @@ export async function findDuplicate(
 	}
 
 	// Build API filter: scope + one dedup field for server-side narrowing.
+	// Skipped entirely when metadata is unavailable — UDF vs standard classification requires it,
+	// and pushing an unclassified field risks an incorrect udf:true flag or a non-queryable error.
 	// Prefer a queryable standard field (exact match, no special syntax) over a UDF field.
 	// Non-queryable standard fields are intentionally skipped to avoid API errors.
 	// Fall back to the first UDF if no queryable standard dedup field has a value.
 	// Autotask supports { field, udf: true } for UDF filters — one per query maximum.
 	const apiFilter: Array<Record<string, unknown>> = [...scopeFilters];
-	const preferredField =
-		dedupFields.find(f => queryableStandardFieldNames.has(f) && createFields[f] !== undefined) ??
-		dedupFields.find(f => !standardFieldNames.has(f) && createFields[f] !== undefined);
+	const preferredField = metadataAvailable
+		? (dedupFields.find(f => queryableStandardFieldNames.has(f) && createFields[f] !== undefined) ??
+		   dedupFields.find(f => !standardFieldNames.has(f) && createFields[f] !== undefined))
+		: undefined;
 
 	if (preferredField) {
 		if (queryableStandardFieldNames.has(preferredField)) {

--- a/nodes/Autotask/helpers/entity-dedup.ts
+++ b/nodes/Autotask/helpers/entity-dedup.ts
@@ -66,13 +66,22 @@ export async function findDuplicate(
 		return { duplicate: null, matchedFields: [] };
 	}
 
-	// Determine which fields are standard vs UDF
-	const standardApiFields = await getFields(entityType, ctx, { fieldType: 'standard' }) as IAutotaskField[];
-	const standardFieldNames = new Set(standardApiFields.map(f => f.name));
-	// P1: only queryable standard fields may be pushed into the API filter
-	const queryableStandardFieldNames = new Set(
-		standardApiFields.filter(f => f.isQueryable).map(f => f.name),
-	);
+	// Determine which fields are standard vs UDF.
+	// On failure, degrade gracefully: skip server-side dedup-field narrowing and rely on
+	// scope filters + full client-side matching — no harder failure than before this helper existed.
+	let standardFieldNames = new Set<string>();
+	let queryableStandardFieldNames = new Set<string>();
+	try {
+		const standardApiFields = await getFields(entityType, ctx, { fieldType: 'standard' }) as IAutotaskField[];
+		standardFieldNames = new Set(standardApiFields.map(f => f.name));
+		// P1: only queryable standard fields may be pushed into the API filter
+		queryableStandardFieldNames = new Set(
+			standardApiFields.filter(f => f.isQueryable).map(f => f.name),
+		);
+	} catch {
+		// Standard field metadata unavailable — treat all dedup fields as unclassified.
+		// Server-side narrowing is skipped; client-side comparison still runs.
+	}
 
 	// P2: fetch UDF metadata for any UDF dedup fields to get type-aware comparison
 	const udfDedupFields = dedupFields.filter(f => !standardFieldNames.has(f));

--- a/nodes/Autotask/helpers/expense-item-creator.ts
+++ b/nodes/Autotask/helpers/expense-item-creator.ts
@@ -1,7 +1,8 @@
 import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
 import { autotaskApiRequest } from './http';
-import { compareDedupField, extractId, extractItems } from './dedup-utils';
+import { extractId } from './dedup-utils';
 import { computeFieldDiffs, applyDuplicateUpdate } from './update-fields-on-duplicate';
+import { findDuplicate } from './entity-dedup';
 
 // ─── Interfaces ──────────────────────────────────────────────────────────────
 
@@ -48,10 +49,6 @@ const FIELD_TYPE_MAP: Record<string, string> = {
 	workType: 'integer',
 };
 
-function getFieldType(field: string): string {
-	return FIELD_TYPE_MAP[field] ?? 'string';
-}
-
 // ─── Main orchestrator ───────────────────────────────────────────────────────
 
 export async function createExpenseItemIfNotExists(
@@ -67,109 +64,75 @@ export async function createExpenseItemIfNotExists(
 		throw new Error('createFields.expenseReportID is required for expenseItem.createIfNotExists');
 	}
 
-	// Step 1: Build dedup query filters scoped to expense report
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const apiFilter: any[] = [
-		{ field: 'expenseReportID', op: 'eq', value: expenseReportID },
-	];
+	// Step 1: Find duplicate using central dedup logic (handles standard + UDF fields)
+	const { duplicate: entry, matchedFields: matched } = await findDuplicate(ctx, {
+		entityType: 'ExpenseItem',
+		queryEndpoint: 'ExpenseItems/query',
+		scopeFilters: [{ field: 'expenseReportID', op: 'eq', value: expenseReportID }],
+		dedupFields,
+		createFields,
+		fieldTypeMap: FIELD_TYPE_MAP,
+	});
 
-	// Add the first dedup field as a server-side filter for narrowing
-	if (dedupFields.length > 0) {
-		const firstField = dedupFields[0];
-		const inputValue = createFields[firstField];
-		if (inputValue !== undefined && inputValue !== null && firstField !== 'expenseReportID') {
-			apiFilter.push({ field: firstField, op: 'eq', value: inputValue });
+	if (entry) {
+		if (errorOnDuplicate) {
+			throw new Error(
+				`Duplicate expense item found (ID: ${entry.id}) for expenseReportID ${expenseReportID}. ` +
+				`Matched dedup fields: ${matched.join(', ')}. ` +
+				`Set errorOnDuplicate=false to skip instead of error.`,
+			);
 		}
-	}
 
-	// Step 2: Query existing expense items
-	let existingEntries: IDataObject[] = [];
-
-	if (dedupFields.length > 0) {
-		const response = await autotaskApiRequest.call(
-			ctx, 'POST', 'ExpenseItems/query', { filter: apiFilter },
-		);
-		existingEntries = extractItems(response as IDataObject);
-	}
-
-	// Step 3: Client-side match all dedupFields
-	for (const entry of existingEntries) {
-		const matched: string[] = [];
-		let allMatch = true;
-
-		for (const field of dedupFields) {
-			const fieldType = getFieldType(field);
-			const inputValue = createFields[field];
-			const apiValue = entry[field];
-
-			if (compareDedupField(fieldType, apiValue, inputValue)) {
-				matched.push(field);
+		const { updateFields } = options;
+		if (updateFields && updateFields.length > 0) {
+			const { patch, compared, skipped, warnings: diffWarnings } = computeFieldDiffs(
+				entry as Record<string, unknown>,
+				createFields,
+				updateFields,
+				FIELD_TYPE_MAP,
+			);
+			if (skipped.length > 0) {
+				diffWarnings.push(`updateFields requested for ${skipped.length} field(s) not present in createFields: ${skipped.join(', ')}`);
+			}
+			if (Object.keys(patch).length > 0) {
+				const { warnings: updateWarnings } = await applyDuplicateUpdate(ctx, {
+					resource: 'ExpenseItem',
+					duplicateId: entry.id as number,
+					parentId: Number(expenseReportID),
+					patch,
+					impersonationResourceId: options.impersonationResourceId,
+					proceedWithoutImpersonationIfDenied: options.proceedWithoutImpersonationIfDenied,
+				});
+				return {
+					outcome: 'updated',
+					expenseReportID,
+					existingExpenseItemId: entry.id as number,
+					matchedDedupFields: matched,
+					fieldsUpdated: Object.keys(patch),
+					fieldsCompared: compared,
+					warnings: [...warnings, ...diffWarnings, ...updateWarnings],
+				};
 			} else {
-				allMatch = false;
-				break;
+				return {
+					outcome: 'skipped',
+					reason: 'duplicate_no_changes',
+					expenseReportID,
+					existingExpenseItemId: entry.id as number,
+					matchedDedupFields: matched,
+					fieldsCompared: compared,
+					warnings: [...warnings, ...diffWarnings],
+				};
 			}
 		}
 
-		if (allMatch && matched.length === dedupFields.length) {
-			if (errorOnDuplicate) {
-				throw new Error(
-					`Duplicate expense item found (ID: ${entry.id}) for expenseReportID ${expenseReportID}. ` +
-					`Matched dedup fields: ${matched.join(', ')}. ` +
-					`Set errorOnDuplicate=false to skip instead of error.`,
-				);
-			}
-
-			const { updateFields } = options;
-			if (updateFields && updateFields.length > 0) {
-				const { patch, compared, skipped, warnings: diffWarnings } = computeFieldDiffs(
-					entry as Record<string, unknown>,
-					createFields,
-					updateFields,
-					FIELD_TYPE_MAP,
-				);
-				if (skipped.length > 0) {
-					diffWarnings.push(`updateFields requested for ${skipped.length} field(s) not present in createFields: ${skipped.join(', ')}`);
-				}
-				if (Object.keys(patch).length > 0) {
-					const { warnings: updateWarnings } = await applyDuplicateUpdate(ctx, {
-						resource: 'ExpenseItem',
-						duplicateId: entry.id as number,
-						parentId: Number(expenseReportID),
-						patch,
-						impersonationResourceId: options.impersonationResourceId,
-						proceedWithoutImpersonationIfDenied: options.proceedWithoutImpersonationIfDenied,
-					});
-					return {
-						outcome: 'updated',
-						expenseReportID,
-						existingExpenseItemId: entry.id as number,
-						matchedDedupFields: matched,
-						fieldsUpdated: Object.keys(patch),
-						fieldsCompared: compared,
-						warnings: [...warnings, ...diffWarnings, ...updateWarnings],
-					};
-				} else {
-					return {
-						outcome: 'skipped',
-						reason: 'duplicate_no_changes',
-						expenseReportID,
-						existingExpenseItemId: entry.id as number,
-						matchedDedupFields: matched,
-						fieldsCompared: compared,
-						warnings: [...warnings, ...diffWarnings],
-					};
-				}
-			}
-
-			return {
-				outcome: 'skipped',
-				expenseReportID,
-				existingExpenseItemId: entry.id as number,
-				reason: 'duplicate_expense_item',
-				matchedDedupFields: matched,
-				warnings,
-			};
-		}
+		return {
+			outcome: 'skipped',
+			expenseReportID,
+			existingExpenseItemId: entry.id as number,
+			reason: 'duplicate_expense_item',
+			matchedDedupFields: matched,
+			warnings,
+		};
 	}
 
 	// Step 4: Create via child endpoint — POST to /Expenses/{expenseReportID}/Items

--- a/nodes/Autotask/helpers/expense-item-creator.ts
+++ b/nodes/Autotask/helpers/expense-item-creator.ts
@@ -21,7 +21,6 @@ export interface IExpenseItemCreateResult {
 	outcome: ExpenseItemCreateOutcome;
 	expenseReportID: string | number;
 	expenseItemId?: number;
-	existingExpenseItemId?: number;
 	reason?: string;
 	matchedDedupFields?: string[];
 	fieldsUpdated?: string[];
@@ -106,7 +105,7 @@ export async function createExpenseItemIfNotExists(
 				return {
 					outcome: 'updated',
 					expenseReportID,
-					existingExpenseItemId: entry.id as number,
+					expenseItemId: entry.id as number,
 					matchedDedupFields: matched,
 					fieldsUpdated: Object.keys(patch),
 					fieldsCompared: compared,
@@ -117,7 +116,7 @@ export async function createExpenseItemIfNotExists(
 					outcome: 'skipped',
 					reason: 'duplicate_no_changes',
 					expenseReportID,
-					existingExpenseItemId: entry.id as number,
+					expenseItemId: entry.id as number,
 					matchedDedupFields: matched,
 					fieldsCompared: compared,
 					warnings: [...warnings, ...diffWarnings],
@@ -128,7 +127,7 @@ export async function createExpenseItemIfNotExists(
 		return {
 			outcome: 'skipped',
 			expenseReportID,
-			existingExpenseItemId: entry.id as number,
+			expenseItemId: entry.id as number,
 			reason: 'duplicate_expense_item',
 			matchedDedupFields: matched,
 			warnings,

--- a/nodes/Autotask/helpers/holiday-creator.ts
+++ b/nodes/Autotask/helpers/holiday-creator.ts
@@ -20,7 +20,6 @@ export interface IHolidayCreateResult {
 	outcome: HolidayCreateOutcome;
 	holidaySetId?: number;
 	holidayId?: number;
-	existingHolidayId?: number;
 	holidayDate?: string;
 	holidayName?: string;
 	reason?: string;
@@ -204,7 +203,7 @@ export async function createHolidayIfNotExists(
 				return {
 					outcome: 'updated',
 					holidaySetId,
-					existingHolidayId: duplicate.id as number,
+					holidayId: duplicate.id as number,
 					holidayDate,
 					holidayName,
 					matchedDedupFields: matchedFields,
@@ -217,7 +216,7 @@ export async function createHolidayIfNotExists(
 					outcome: 'skipped',
 					reason: 'duplicate_no_changes',
 					holidaySetId,
-					existingHolidayId: duplicate.id as number,
+					holidayId: duplicate.id as number,
 					holidayDate,
 					holidayName,
 					matchedDedupFields: matchedFields,
@@ -231,7 +230,7 @@ export async function createHolidayIfNotExists(
 			outcome: 'skipped',
 			reason: 'duplicate_holiday',
 			holidaySetId,
-			existingHolidayId: duplicate.id as number,
+			holidayId: duplicate.id as number,
 			holidayDate,
 			holidayName,
 			matchedDedupFields: matchedFields,

--- a/nodes/Autotask/helpers/holiday-set-creator.ts
+++ b/nodes/Autotask/helpers/holiday-set-creator.ts
@@ -19,7 +19,6 @@ export type HolidaySetCreateOutcome = 'created' | 'skipped' | 'updated';
 export interface IHolidaySetCreateResult {
 	outcome: HolidaySetCreateOutcome;
 	holidaySetId?: number;
-	existingHolidaySetId?: number;
 	holidaySetName?: string;
 	reason?: string;
 	matchedDedupFields?: string[];
@@ -167,7 +166,7 @@ export async function createHolidaySetIfNotExists(
 				});
 				return {
 					outcome: 'updated',
-					existingHolidaySetId: duplicate.id as number,
+					holidaySetId: duplicate.id as number,
 					holidaySetName: duplicate.holidaySetName as string,
 					matchedDedupFields: matchedFields,
 					fieldsUpdated: Object.keys(patch),
@@ -178,7 +177,7 @@ export async function createHolidaySetIfNotExists(
 				return {
 					outcome: 'skipped',
 					reason: 'duplicate_no_changes',
-					existingHolidaySetId: duplicate.id as number,
+					holidaySetId: duplicate.id as number,
 					holidaySetName: duplicate.holidaySetName as string,
 					matchedDedupFields: matchedFields,
 					fieldsCompared: compared,
@@ -190,7 +189,7 @@ export async function createHolidaySetIfNotExists(
 		return {
 			outcome: 'skipped',
 			reason: 'duplicate_holiday_set',
-			existingHolidaySetId: duplicate.id as number,
+			holidaySetId: duplicate.id as number,
 			holidaySetName: duplicate.holidaySetName as string,
 			matchedDedupFields: matchedFields,
 			warnings,

--- a/nodes/Autotask/helpers/opportunity-creator.ts
+++ b/nodes/Autotask/helpers/opportunity-creator.ts
@@ -1,7 +1,8 @@
 import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
 import { autotaskApiRequest } from './http';
-import { extractId, extractItems, compareDedupField } from './dedup-utils';
+import { extractId, extractItems } from './dedup-utils';
 import { computeFieldDiffs, applyDuplicateUpdate } from './update-fields-on-duplicate';
+import { findDuplicate } from './entity-dedup';
 
 // ─── Interfaces ──────────────────────────────────────────────────────────────
 
@@ -61,60 +62,20 @@ async function verifyCompanyExists(
 
 // ─── Step 1: Find duplicate opportunity ──────────────────────────────────────
 
-async function findDuplicateOpportunity(
+function findDuplicateOpportunity(
 	ctx: IExecuteFunctions,
 	companyId: number,
 	dedupFields: string[],
 	createFields: Record<string, unknown>,
 ): Promise<{ duplicate: IDataObject | null; matchedFields: string[] }> {
-	if (!dedupFields || dedupFields.length === 0) {
-		return { duplicate: null, matchedFields: [] };
-	}
-
-	// Always filter server-side by companyID to narrow the result set;
-	// also push the first dedup field for additional server-side narrowing
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const apiFilter: any[] = [
-		{ field: 'companyID', op: 'eq', value: companyId },
-	];
-
-	const firstDedupField = dedupFields[0];
-	if (firstDedupField && firstDedupField !== 'companyID' && createFields[firstDedupField] !== undefined) {
-		apiFilter.push({ field: firstDedupField, op: 'eq', value: createFields[firstDedupField] });
-	}
-
-	const response = await autotaskApiRequest.call(
-		ctx,
-		'POST',
-		'Opportunities/query',
-		{ filter: apiFilter },
-	);
-
-	const items = extractItems(response as IDataObject);
-
-	for (const item of items) {
-		const matched: string[] = [];
-		let allMatch = true;
-
-		for (const field of dedupFields) {
-			const inputValue = createFields[field];
-			const apiValue = item[field];
-			const fieldType = FIELD_TYPE_MAP[field] ?? 'string';
-
-			if (compareDedupField(fieldType, apiValue, inputValue)) {
-				matched.push(field);
-			} else {
-				allMatch = false;
-				break;
-			}
-		}
-
-		if (allMatch && matched.length === dedupFields.length) {
-			return { duplicate: item, matchedFields: matched };
-		}
-	}
-
-	return { duplicate: null, matchedFields: [] };
+	return findDuplicate(ctx, {
+		entityType: 'Opportunity',
+		queryEndpoint: 'Opportunities/query',
+		scopeFilters: [{ field: 'companyID', op: 'eq', value: companyId }],
+		dedupFields,
+		createFields,
+		fieldTypeMap: FIELD_TYPE_MAP,
+	});
 }
 
 // ─── Step 2: Create opportunity ───────────────────────────────────────────────

--- a/nodes/Autotask/helpers/opportunity-creator.ts
+++ b/nodes/Autotask/helpers/opportunity-creator.ts
@@ -21,7 +21,6 @@ export interface IOpportunityCreateResult {
 	outcome: OpportunityCreateOutcome;
 	companyId?: number;
 	opportunityId?: number;
-	existingId?: number;
 	title?: string;
 	reason?: string;
 	matchedDedupFields?: string[];
@@ -165,7 +164,7 @@ export async function createOpportunityIfNotExists(
 				return {
 					outcome: 'updated',
 					companyId,
-					existingId: duplicate.id as number,
+					opportunityId: duplicate.id as number,
 					title,
 					matchedDedupFields: matchedFields,
 					fieldsUpdated: Object.keys(patch),
@@ -177,7 +176,7 @@ export async function createOpportunityIfNotExists(
 					outcome: 'skipped',
 					reason: 'duplicate_no_changes',
 					companyId,
-					existingId: duplicate.id as number,
+					opportunityId: duplicate.id as number,
 					title,
 					matchedDedupFields: matchedFields,
 					fieldsCompared: compared,
@@ -190,7 +189,7 @@ export async function createOpportunityIfNotExists(
 			outcome: 'skipped',
 			reason: 'duplicate_opportunity',
 			companyId,
-			existingId: duplicate.id as number,
+			opportunityId: duplicate.id as number,
 			title,
 			matchedDedupFields: matchedFields,
 			warnings,

--- a/nodes/Autotask/helpers/project-charge-creator.ts
+++ b/nodes/Autotask/helpers/project-charge-creator.ts
@@ -16,7 +16,6 @@ export interface IProjectChargeCreateIfNotExistsResult {
 	outcome: ProjectChargeCreateIfNotExistsOutcome;
 	projectId?: number;
 	chargeId?: number;
-	existingChargeId?: number;
 	projectID: string | number;
 	chargeName: string;
 	datePurchased: string;
@@ -101,7 +100,7 @@ function mapToProjectChargeResult(
 		outcome,
 		projectId: result.parentId,
 		chargeId: result.chargeId,
-		existingChargeId: result.existingChargeId,
+
 		projectID,
 		chargeName: result.chargeName,
 		datePurchased: result.datePurchased,

--- a/nodes/Autotask/helpers/ticket-additional-ci-creator.ts
+++ b/nodes/Autotask/helpers/ticket-additional-ci-creator.ts
@@ -20,7 +20,6 @@ export interface ITicketAdditionalCICreateResult {
 	outcome: TicketAdditionalCICreateOutcome;
 	ticketId?: number;
 	ticketAdditionalConfigurationItemId?: number;
-	existingId?: number;
 	configurationItemID?: number;
 	reason?: string;
 	matchedDedupFields?: string[];
@@ -196,7 +195,7 @@ export async function createTicketAdditionalCIIfNotExists(
 				return {
 					outcome: 'updated',
 					ticketId,
-					existingId: duplicate.id as number,
+					ticketAdditionalConfigurationItemId: duplicate.id as number,
 					configurationItemID,
 					matchedDedupFields: matchedFields,
 					fieldsUpdated: Object.keys(patch),
@@ -208,7 +207,7 @@ export async function createTicketAdditionalCIIfNotExists(
 					outcome: 'skipped',
 					reason: 'duplicate_no_changes',
 					ticketId,
-					existingId: duplicate.id as number,
+					ticketAdditionalConfigurationItemId: duplicate.id as number,
 					configurationItemID,
 					matchedDedupFields: matchedFields,
 					fieldsCompared: compared,
@@ -221,7 +220,7 @@ export async function createTicketAdditionalCIIfNotExists(
 			outcome: 'skipped',
 			reason: 'duplicate_association',
 			ticketId,
-			existingId: duplicate.id as number,
+			ticketAdditionalConfigurationItemId: duplicate.id as number,
 			configurationItemID,
 			matchedDedupFields: matchedFields,
 			warnings,

--- a/nodes/Autotask/helpers/ticket-additional-contact-creator.ts
+++ b/nodes/Autotask/helpers/ticket-additional-contact-creator.ts
@@ -20,7 +20,6 @@ export interface ITicketAdditionalContactCreateResult {
 	outcome: TicketAdditionalContactCreateOutcome;
 	ticketId?: number;
 	ticketAdditionalContactId?: number;
-	existingId?: number;
 	contactID?: number;
 	reason?: string;
 	matchedDedupFields?: string[];
@@ -196,7 +195,7 @@ export async function createTicketAdditionalContactIfNotExists(
 				return {
 					outcome: 'updated',
 					ticketId,
-					existingId: duplicate.id as number,
+					ticketAdditionalContactId: duplicate.id as number,
 					contactID,
 					matchedDedupFields: matchedFields,
 					fieldsUpdated: Object.keys(patch),
@@ -208,7 +207,7 @@ export async function createTicketAdditionalContactIfNotExists(
 					outcome: 'skipped',
 					reason: 'duplicate_no_changes',
 					ticketId,
-					existingId: duplicate.id as number,
+					ticketAdditionalContactId: duplicate.id as number,
 					contactID,
 					matchedDedupFields: matchedFields,
 					fieldsCompared: compared,
@@ -221,7 +220,7 @@ export async function createTicketAdditionalContactIfNotExists(
 			outcome: 'skipped',
 			reason: 'duplicate_association',
 			ticketId,
-			existingId: duplicate.id as number,
+			ticketAdditionalContactId: duplicate.id as number,
 			contactID,
 			matchedDedupFields: matchedFields,
 			warnings,

--- a/nodes/Autotask/helpers/ticket-charge-creator.ts
+++ b/nodes/Autotask/helpers/ticket-charge-creator.ts
@@ -16,7 +16,6 @@ export interface ITicketChargeCreateIfNotExistsResult {
 	outcome: TicketChargeCreateIfNotExistsOutcome;
 	ticketId?: number;
 	chargeId?: number;
-	existingChargeId?: number;
 	ticketID: string | number;
 	chargeName: string;
 	datePurchased: string;
@@ -101,7 +100,7 @@ function mapToTicketChargeResult(
 		outcome,
 		ticketId: result.parentId,
 		chargeId: result.chargeId,
-		existingChargeId: result.existingChargeId,
+
 		ticketID,
 		chargeName: result.chargeName,
 		datePurchased: result.datePurchased,

--- a/nodes/Autotask/helpers/time-entry-creator.ts
+++ b/nodes/Autotask/helpers/time-entry-creator.ts
@@ -1,7 +1,8 @@
 import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
 import { autotaskApiRequest } from './http';
-import { compareDedupField, extractId, extractItems } from './dedup-utils';
+import { extractId } from './dedup-utils';
 import { computeFieldDiffs, applyDuplicateUpdate } from './update-fields-on-duplicate';
+import { findDuplicate } from './entity-dedup';
 
 // ─── Interfaces ──────────────────────────────────────────────────────────────
 
@@ -38,10 +39,6 @@ const FIELD_TYPE_MAP: Record<string, string> = {
 	summaryNotes: 'string',
 };
 
-function getFieldType(field: string): string {
-	return FIELD_TYPE_MAP[field] ?? 'string';
-}
-
 // ─── Main orchestrator ───────────────────────────────────────────────────────
 
 export async function createTimeEntryIfNotExists(
@@ -60,123 +57,88 @@ export async function createTimeEntryIfNotExists(
 	const ticketID = createFields.ticketID as number | undefined;
 	const taskID = createFields.taskID as number | undefined;
 
-	// Step 1: Build dedup query filters
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const apiFilter: any[] = [
+	// Step 1: Build scope filters (resourceID always; ticketID/taskID when present)
+	const scopeFilters: Array<{ field: string; op: string; value: unknown }> = [
 		{ field: 'resourceID', op: 'eq', value: resourceID },
 	];
+	if (ticketID !== undefined) scopeFilters.push({ field: 'ticketID', op: 'eq', value: ticketID });
+	if (taskID !== undefined) scopeFilters.push({ field: 'taskID', op: 'eq', value: taskID });
 
-	if (ticketID !== undefined) {
-		apiFilter.push({ field: 'ticketID', op: 'eq', value: ticketID });
-	}
+	// Step 2: Find duplicate using central dedup logic (handles standard + UDF fields)
+	const { duplicate: entry, matchedFields: matched } = await findDuplicate(ctx, {
+		entityType: 'TimeEntry',
+		queryEndpoint: 'TimeEntries/query',
+		scopeFilters,
+		dedupFields,
+		createFields,
+		fieldTypeMap: FIELD_TYPE_MAP,
+	});
 
-	if (taskID !== undefined) {
-		apiFilter.push({ field: 'taskID', op: 'eq', value: taskID });
-	}
-
-	// Add the first dedup field as a server-side filter for narrowing
-	if (dedupFields.length > 0) {
-		const firstField = dedupFields[0];
-		const inputValue = createFields[firstField];
-		if (inputValue !== undefined && inputValue !== null) {
-			apiFilter.push({ field: firstField, op: 'eq', value: inputValue });
+	if (entry) {
+		// Duplicate found
+		if (errorOnDuplicate) {
+			throw new Error(
+				`Duplicate time entry found (ID: ${entry.id}) for resourceID ${resourceID}. ` +
+				`Matched dedup fields: ${matched.join(', ')}. ` +
+				`Set errorOnDuplicate=false to skip instead of error.`,
+			);
 		}
-	}
 
-	// Step 2: Query existing time entries
-	let existingEntries: IDataObject[] = [];
-
-	if (dedupFields.length > 0) {
-		const response = await autotaskApiRequest.call(
-			ctx, 'POST', 'TimeEntries/query', { filter: apiFilter },
-		);
-		existingEntries = extractItems(response as IDataObject);
-	}
-
-	// Step 3: Client-side match all dedupFields
-	for (const entry of existingEntries) {
-		const matched: string[] = [];
-		let allMatch = true;
-
-		for (const field of dedupFields) {
-			const fieldType = getFieldType(field);
-			const inputValue = createFields[field];
-			const apiValue = entry[field];
-
-			if (compareDedupField(fieldType, apiValue, inputValue)) {
-				matched.push(field);
+		const { updateFields } = options;
+		if (updateFields && updateFields.length > 0) {
+			const { patch, compared, skipped, warnings: diffWarnings } = computeFieldDiffs(
+				entry as Record<string, unknown>,
+				createFields,
+				updateFields,
+				FIELD_TYPE_MAP,
+			);
+			if (skipped.length > 0) {
+				diffWarnings.push(`updateFields requested for ${skipped.length} field(s) not present in createFields: ${skipped.join(', ')}`);
+			}
+			if (Object.keys(patch).length > 0) {
+				const { warnings: updateWarnings } = await applyDuplicateUpdate(ctx, {
+					resource: 'TimeEntry',
+					duplicateId: entry.id as number,
+					patch,
+					impersonationResourceId: options.impersonationResourceId,
+					proceedWithoutImpersonationIfDenied: options.proceedWithoutImpersonationIfDenied,
+				});
+				return {
+					outcome: 'updated',
+					resourceID,
+					ticketID,
+					taskID,
+					existingTimeEntryId: entry.id as number,
+					matchedDedupFields: matched,
+					fieldsUpdated: Object.keys(patch),
+					fieldsCompared: compared,
+					warnings: [...warnings, ...diffWarnings, ...updateWarnings],
+				};
 			} else {
-				allMatch = false;
-				break;
+				return {
+					outcome: 'skipped',
+					reason: 'duplicate_no_changes',
+					resourceID,
+					ticketID,
+					taskID,
+					existingTimeEntryId: entry.id as number,
+					matchedDedupFields: matched,
+					fieldsCompared: compared,
+					warnings: [...warnings, ...diffWarnings],
+				};
 			}
 		}
 
-		if (allMatch && matched.length === dedupFields.length) {
-			// Duplicate found
-			if (errorOnDuplicate) {
-				throw new Error(
-					`Duplicate time entry found (ID: ${entry.id}) for resourceID ${resourceID}. ` +
-					`Matched dedup fields: ${matched.join(', ')}. ` +
-					`Set errorOnDuplicate=false to skip instead of error.`,
-				);
-			}
-
-			const { updateFields } = options;
-			if (updateFields && updateFields.length > 0) {
-				const { patch, compared, skipped, warnings: diffWarnings } = computeFieldDiffs(
-					entry as Record<string, unknown>,
-					createFields,
-					updateFields,
-					FIELD_TYPE_MAP,
-				);
-				if (skipped.length > 0) {
-					diffWarnings.push(`updateFields requested for ${skipped.length} field(s) not present in createFields: ${skipped.join(', ')}`);
-				}
-				if (Object.keys(patch).length > 0) {
-					const { warnings: updateWarnings } = await applyDuplicateUpdate(ctx, {
-						resource: 'TimeEntry',
-						duplicateId: entry.id as number,
-						patch,
-						impersonationResourceId: options.impersonationResourceId,
-						proceedWithoutImpersonationIfDenied: options.proceedWithoutImpersonationIfDenied,
-					});
-					return {
-						outcome: 'updated',
-						resourceID,
-						ticketID,
-						taskID,
-						existingTimeEntryId: entry.id as number,
-						matchedDedupFields: matched,
-						fieldsUpdated: Object.keys(patch),
-						fieldsCompared: compared,
-						warnings: [...warnings, ...diffWarnings, ...updateWarnings],
-					};
-				} else {
-					return {
-						outcome: 'skipped',
-						reason: 'duplicate_no_changes',
-						resourceID,
-						ticketID,
-						taskID,
-						existingTimeEntryId: entry.id as number,
-						matchedDedupFields: matched,
-						fieldsCompared: compared,
-						warnings: [...warnings, ...diffWarnings],
-					};
-				}
-			}
-
-			return {
-				outcome: 'skipped',
-				resourceID,
-				ticketID,
-				taskID,
-				existingTimeEntryId: entry.id as number,
-				reason: 'duplicate_time_entry',
-				matchedDedupFields: matched,
-				warnings,
-			};
-		}
+		return {
+			outcome: 'skipped',
+			resourceID,
+			ticketID,
+			taskID,
+			existingTimeEntryId: entry.id as number,
+			reason: 'duplicate_time_entry',
+			matchedDedupFields: matched,
+			warnings,
+		};
 	}
 
 	// Step 4: Build create body and POST

--- a/nodes/Autotask/helpers/time-entry-creator.ts
+++ b/nodes/Autotask/helpers/time-entry-creator.ts
@@ -23,7 +23,6 @@ export interface ITimeEntryCreateResult {
 	ticketID?: number;
 	taskID?: number;
 	timeEntryId?: number;
-	existingTimeEntryId?: number;
 	reason?: string;
 	matchedDedupFields?: string[];
 	fieldsUpdated?: string[];
@@ -108,7 +107,7 @@ export async function createTimeEntryIfNotExists(
 					resourceID,
 					ticketID,
 					taskID,
-					existingTimeEntryId: entry.id as number,
+					timeEntryId: entry.id as number,
 					matchedDedupFields: matched,
 					fieldsUpdated: Object.keys(patch),
 					fieldsCompared: compared,
@@ -121,7 +120,7 @@ export async function createTimeEntryIfNotExists(
 					resourceID,
 					ticketID,
 					taskID,
-					existingTimeEntryId: entry.id as number,
+					timeEntryId: entry.id as number,
 					matchedDedupFields: matched,
 					fieldsCompared: compared,
 					warnings: [...warnings, ...diffWarnings],
@@ -134,7 +133,7 @@ export async function createTimeEntryIfNotExists(
 			resourceID,
 			ticketID,
 			taskID,
-			existingTimeEntryId: entry.id as number,
+			timeEntryId: entry.id as number,
 			reason: 'duplicate_time_entry',
 			matchedDedupFields: matched,
 			warnings,

--- a/nodes/Autotask/helpers/update-fields-on-duplicate.ts
+++ b/nodes/Autotask/helpers/update-fields-on-duplicate.ts
@@ -1,8 +1,10 @@
 import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
 import { autotaskApiRequest, buildEntityUrl, buildChildEntityUrl } from './http';
-import { compareDedupField } from './dedup-utils';
+import { compareDedupField, getEntityFieldValue } from './dedup-utils';
 import { getEntityMetadata } from '../constants/entities';
 import { OperationType } from '../types/base/entity-types';
+import { getFields } from './entity/api';
+import type { IUdfFieldDefinition } from '../types/base/udf-types';
 
 // ─── computeFieldDiffs ────────────────────────────────────────────────────────
 
@@ -46,7 +48,7 @@ export function computeFieldDiffs(
 		}
 
 		const fieldType = fieldTypeMap[field] ?? 'string';
-		const apiValue = duplicateRow[field];
+		const apiValue = getEntityFieldValue(duplicateRow as IDataObject, field);
 		const inputValue = desiredFields[field];
 
 		const isMatch = compareDedupField(fieldType, apiValue, inputValue);
@@ -121,10 +123,30 @@ export async function applyDuplicateUpdate(
 	// (which throws for unknown entities) before we have a chance to fall back.
 	const metadata = getEntityMetadata(resource);
 
+	// Split patch into standard fields and UDF fields.
+	// UDF fields must be sent as userDefinedFields[{name, value}]; sending them flat causes 500.
+	let patchStandard: IDataObject = { ...(patch as IDataObject) };
+	let udfEntries: Array<{ name: string; value: unknown }> = [];
+
+	if (metadata?.hasUserDefinedFields) {
+		const udfDefs = await getFields(resource, context, { fieldType: 'udf' }) as IUdfFieldDefinition[];
+		if (udfDefs.length > 0) {
+			const udfNameSet = new Set(udfDefs.map(u => u.name.toLowerCase()));
+			const udfKeys = Object.keys(patch).filter(k => udfNameSet.has(k.toLowerCase()));
+			if (udfKeys.length > 0) {
+				udfEntries = udfKeys.map(k => ({ name: k, value: (patch as IDataObject)[k] }));
+				patchStandard = Object.fromEntries(
+					Object.entries(patch as IDataObject).filter(([k]) => !udfKeys.includes(k)),
+				);
+			}
+		}
+	}
+
 	// Build PATCH body — always include `id`
 	const body: IDataObject = {
 		id: duplicateId,
-		...(patch as IDataObject),
+		...patchStandard,
+		...(udfEntries.length > 0 ? { userDefinedFields: udfEntries } : {}),
 	};
 
 	// Determine the endpoint

--- a/nodes/Autotask/helpers/update-fields-on-duplicate.ts
+++ b/nodes/Autotask/helpers/update-fields-on-duplicate.ts
@@ -129,16 +129,25 @@ export async function applyDuplicateUpdate(
 	let udfEntries: Array<{ name: string; value: unknown }> = [];
 
 	if (metadata?.hasUserDefinedFields) {
-		const udfDefs = await getFields(resource, context, { fieldType: 'udf' }) as IUdfFieldDefinition[];
-		if (udfDefs.length > 0) {
-			const udfNameSet = new Set(udfDefs.map(u => u.name.toLowerCase()));
-			const udfKeys = Object.keys(patch).filter(k => udfNameSet.has(k.toLowerCase()));
-			if (udfKeys.length > 0) {
-				udfEntries = udfKeys.map(k => ({ name: k, value: (patch as IDataObject)[k] }));
-				patchStandard = Object.fromEntries(
-					Object.entries(patch as IDataObject).filter(([k]) => !udfKeys.includes(k)),
-				);
+		try {
+			const udfDefs = await getFields(resource, context, { fieldType: 'udf' }) as IUdfFieldDefinition[];
+			if (udfDefs.length > 0) {
+				const udfNameSet = new Set(udfDefs.map(u => u.name.toLowerCase()));
+				const udfKeys = Object.keys(patch).filter(k => udfNameSet.has(k.toLowerCase()));
+				if (udfKeys.length > 0) {
+					udfEntries = udfKeys.map(k => ({ name: k, value: (patch as IDataObject)[k] }));
+					patchStandard = Object.fromEntries(
+						Object.entries(patch as IDataObject).filter(([k]) => !udfKeys.includes(k)),
+					);
+				}
 			}
+		} catch {
+			// UDF metadata unavailable — send all patch fields as standard root fields.
+			// If any are genuine UDF fields, Autotask will return a field-not-found error
+			// on the PATCH, which is more actionable than throwing before the request.
+			warnings.push(
+				`applyDuplicateUpdate: could not fetch UDF definitions for '${resource}' — patch sent without UDF splitting. If the patch contains UDF fields, the PATCH may fail.`,
+			);
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.12.6",
+  "version": "2.13.0",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

- UDF field names in `dedupFields` caused Autotask 500 ("Unable to find \<field\> in the Entity") — they were sent as standard API filter fields
- New `helpers/entity-dedup.ts` centralises duplicate detection for all `createIfNotExists` operations; calls `getFields()` at runtime to classify standard vs UDF fields
- UDF dedup fields use `{ field, udf: true, op, value }` filter syntax server-side (one-per-query limit respected); all fields compared client-side via `getEntityFieldValue()` reading both root and `userDefinedFields[]`
- `applyDuplicateUpdate` fixed to send UDF patch fields as `userDefinedFields: [{name, value}]` — flat root caused Autotask 500
- All per-creator inline dedup loops replaced with `findDuplicate()` calls: `contract`, `configurationItem`, `opportunity`, `expenseItem`, `timeEntry`, `contractService`, `contractCharge`, `ticketCharge`, `projectCharge`

## Test plan

- [ ] `contract.createIfNotExists` with a UDF field in `dedupFields` — no 500, correct duplicate detection
- [ ] Same with a mix of standard + UDF dedup fields — standard field used for server-side filter, UDF compared client-side
- [ ] `updateFields` containing a UDF field — PATCH body includes `userDefinedFields:[{name,value}]`, not flat root
- [ ] Duplicate found, no changes → `skipped` outcome
- [ ] No duplicate → `created` outcome
- [ ] All other `createIfNotExists` entities (configurationItem, opportunity, expenseItem, timeEntry, contractService, charges) — smoke test dedup still works