### PR TITLE
feat: createIfNotExists full field echo + dedup/update annotation (v2.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the n8n-nodes-autotask project will be documented in this
 
 ### Changed
 - **`createIfNotExists` — `record{}` now included in `created` and `updated` responses (all entities):** All 14 compound `createIfNotExists` handlers now return a `record{}` containing every entity field supplied by the caller, plus the entity `id`. Previously only a subset of hardcoded fields was surfaced (e.g. `chargeName`, `datePurchased` for charges; only `contractId`/`companyID` for contract). Fix is in the single dispatch point (`compound-operations.ts` → `handleCreateIfNotExists`); no per-helper changes required. `skipped` outcome is unchanged (no entity was written).
+- **`createIfNotExists` — `dedupFields` and `updateFields` now included in response:** All `createIfNotExists` responses include `dedupFields` (always) and `updateFields` (when supplied by caller) alongside `record{}`, `matchedDedupFields`, and `fieldsUpdated`. Callers can see which fields drove duplicate detection and which were checked for update drift.
 
 ## [2.14.2] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.15.0] - 2026-05-05
+
+### Changed
+- **`createIfNotExists` — `record{}` now included in `created` and `updated` responses (all entities):** All 14 compound `createIfNotExists` handlers now return a `record{}` containing every entity field supplied by the caller, plus the entity `id`. Previously only a subset of hardcoded fields was surfaced (e.g. `chargeName`, `datePurchased` for charges; only `contractId`/`companyID` for contract). Fix is in the single dispatch point (`compound-operations.ts` → `handleCreateIfNotExists`); no per-helper changes required. `skipped` outcome is unchanged (no entity was written).
+
 ## [2.14.2] - 2026-05-04
 
 ### Fixed

--- a/nodes/Autotask/ai-tools/operation-handlers/compound-operations.ts
+++ b/nodes/Autotask/ai-tools/operation-handlers/compound-operations.ts
@@ -176,6 +176,15 @@ export async function handleCreateIfNotExists(state: ExecutorState): Promise<str
 		compoundData.fieldsCompared = compoundResult.fieldsCompared;
 	if (compoundContext !== undefined) compoundData.context = compoundContext;
 
+	// Echo all supplied entity fields as record{} for created/updated outcomes.
+	// createFields contains only actual entity fields — buildFieldValues already
+	// strips dedupFields, errorOnDuplicate, updateFields, and all metadata keys.
+	if (compoundResult.outcome === 'created' || compoundResult.outcome === 'updated') {
+		const record: Record<string, unknown> = { ...createFields };
+		if (compoundId !== undefined) record.id = compoundId;
+		compoundData.record = record;
+	}
+
 	const compoundJson = JSON.stringify(
 		buildCompoundResponse(
 			resource,

--- a/nodes/Autotask/ai-tools/operation-handlers/compound-operations.ts
+++ b/nodes/Autotask/ai-tools/operation-handlers/compound-operations.ts
@@ -181,8 +181,14 @@ export async function handleCreateIfNotExists(state: ExecutorState): Promise<str
 	// Echo all supplied entity fields as record{} for created/updated outcomes.
 	// createFields contains only actual entity fields — buildFieldValues already
 	// strips dedupFields, errorOnDuplicate, updateFields, and all metadata keys.
+	// recordExcludeFields strips helper-only inputs (e.g. materialCode → billingCodeID)
+	// that the helper resolves internally and never writes to the API as-is.
 	if (compoundResult.outcome === 'created' || compoundResult.outcome === 'updated') {
-		const record: Record<string, unknown> = { ...createFields };
+		const excludeSet = new Set(registryEntry.recordExcludeFields ?? []);
+		const record: Record<string, unknown> = {};
+		for (const [k, v] of Object.entries(createFields)) {
+			if (!excludeSet.has(k)) record[k] = v;
+		}
 		if (compoundId !== undefined) record.id = compoundId;
 		compoundData.record = record;
 	}

--- a/nodes/Autotask/ai-tools/operation-handlers/compound-operations.ts
+++ b/nodes/Autotask/ai-tools/operation-handlers/compound-operations.ts
@@ -168,6 +168,8 @@ export async function handleCreateIfNotExists(state: ExecutorState): Promise<str
 			compoundData.existingId = compoundId;
 		}
 	}
+	compoundData.dedupFields = dedupFields;
+	if (updateFields.length > 0) compoundData.updateFields = updateFields;
 	if (compoundResult.matchedDedupFields !== undefined)
 		compoundData.matchedDedupFields = compoundResult.matchedDedupFields;
 	if (compoundResult.fieldsUpdated !== undefined)

--- a/nodes/Autotask/ai-tools/response-builder.ts
+++ b/nodes/Autotask/ai-tools/response-builder.ts
@@ -479,7 +479,7 @@ export function buildCompoundResponse(
 	};
 	if (canonicalId !== undefined) response.id = canonicalId;
 	if (record) response.record = record;
-	if (dedupFields !== undefined && dedupFields.length > 0) response.dedupFields = dedupFields;
+	if (dedupFields !== undefined) response.dedupFields = dedupFields;
 	if (updateFields !== undefined && updateFields.length > 0) response.updateFields = updateFields;
 	if (matchedDedupFields !== undefined) response.matchedDedupFields = matchedDedupFields;
 	if (fieldsCompared !== undefined) response.fieldsCompared = fieldsCompared;

--- a/nodes/Autotask/ai-tools/response-builder.ts
+++ b/nodes/Autotask/ai-tools/response-builder.ts
@@ -445,6 +445,8 @@ export function buildCompoundResponse(
 		id?: number | string;
 		existingId?: number | string;
 		record?: Record<string, unknown>;
+		dedupFields?: string[];
+		updateFields?: string[];
 		matchedDedupFields?: string[];
 		fieldsUpdated?: Record<string, { from: unknown; to: unknown }>;
 		fieldsCompared?: string[];
@@ -452,7 +454,7 @@ export function buildCompoundResponse(
 	},
 	context: ToolResponseContext = {},
 ): Record<string, unknown> {
-	const { outcome, id, existingId, record, matchedDedupFields, fieldsUpdated, fieldsCompared } =
+	const { outcome, id, existingId, record, dedupFields, updateFields, matchedDedupFields, fieldsUpdated, fieldsCompared } =
 		compoundData;
 	const canonicalId = id ?? existingId;
 	let summary: string;
@@ -477,6 +479,8 @@ export function buildCompoundResponse(
 	};
 	if (canonicalId !== undefined) response.id = canonicalId;
 	if (record) response.record = record;
+	if (dedupFields !== undefined && dedupFields.length > 0) response.dedupFields = dedupFields;
+	if (updateFields !== undefined && updateFields.length > 0) response.updateFields = updateFields;
 	if (matchedDedupFields !== undefined) response.matchedDedupFields = matchedDedupFields;
 	if (fieldsCompared !== undefined) response.fieldsCompared = fieldsCompared;
 	if (fieldsUpdated !== undefined) response.fieldsUpdated = fieldsUpdated;

--- a/nodes/Autotask/constants/compound-registry.ts
+++ b/nodes/Autotask/constants/compound-registry.ts
@@ -23,6 +23,9 @@ export interface CompoundRegistryEntry {
 	defaultDedupFields: string[];
 	/** Field in the result containing the entity's numeric ID (all outcomes: created/skipped/updated). */
 	entityIdField: string;
+	/** Helper-only fields present in createFields that are never written to the API as-is and must be
+	 *  excluded from the record{} echo (e.g. materialCode is resolved to billingCodeID by the helper). */
+	recordExcludeFields?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -44,7 +47,7 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['name', 'datePurchased'],
 		entityIdField: 'chargeId',
-
+		recordExcludeFields: ['materialCode'],
 	},
 	ticketCharge: {
 		getHandler: () =>
@@ -53,7 +56,7 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['name', 'datePurchased'],
 		entityIdField: 'chargeId',
-
+		recordExcludeFields: ['materialCode'],
 	},
 	projectCharge: {
 		getHandler: () =>
@@ -62,6 +65,7 @@ export const COMPOUND_REGISTRY: Record<string, CompoundRegistryEntry> = {
 			),
 		defaultDedupFields: ['name', 'datePurchased'],
 		entityIdField: 'chargeId',
+		recordExcludeFields: ['materialCode'],
 
 	},
 	configurationItems: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.14.2",
+  "version": "2.15.0",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

- All 14 `createIfNotExists` compound handlers now return `record{}` containing every entity field supplied by the caller (plus entity `id`) for `created` and `updated` outcomes — previously only a hardcoded subset was surfaced
- `dedupFields` (always) and `updateFields` (when supplied) now included in the response so callers can see which fields drove duplicate detection and update drift checking
- `buildCompoundResponse` type extended to accept and propagate `dedupFields` and `updateFields`
- Fix is entirely in the single dispatch point (`handleCreateIfNotExists` in `compound-operations.ts`) and `response-builder.ts` — no per-helper changes required

## Response shape (created/updated)

```json
{
  "summary": "contractCharge created (ID: 123).",
  "outcome": "created",
  "id": 123,
  "record": { "name": "Labour", "datePurchased": "2026-05-05", "unitPrice": 150, "contractID": 42, "id": 123 },
  "dedupFields": ["name", "datePurchased"],
  "updateFields": ["unitPrice"],
  "matchedDedupFields": ["name", "datePurchased"],
  "fieldsUpdated": { "unitPrice": { "from": 100, "to": 150 } }
}
```

## Test plan

- [ ] `createIfNotExists` on a new entity → `record{}` contains all supplied fields + `id`; `dedupFields` present
- [ ] `createIfNotExists` on duplicate with `updateFields` → `outcome: updated`, `record{}` present, `updateFields` present, `fieldsUpdated` shows diff
- [ ] `createIfNotExists` on duplicate without `updateFields` → `outcome: skipped`, no `record{}`, no `updateFields`
- [ ] Verify across at least: `contractCharge`, `timeEntry`, `configurationItems`, `contract`
- [ ] Build passes (`pnpm build`)