### PR TITLE
feat: createIfNotExists standard node full response shape (v2.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.16.0] - 2026-05-05
+
+### Changed
+- **`createIfNotExists` — standard node path now matches AI tools response shape (all 14 entities):** Standard node path previously returned raw helper result (`chargeName`, `chargeId`, etc. as flat fields). Now returns the same structured shape as the AI tools path: `record{}` containing all supplied entity fields + entity `id`, `dedupFields`, `updateFields` (when non-empty), `matchedDedupFields`, `fieldsUpdated`, `fieldsCompared`, `context` (parent scope), `warnings`. Implemented via shared `helpers/compound-response-formatter.ts` — no per-helper duplication.
+
 ## [2.15.0] - 2026-05-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
-## [2.16.0] - 2026-05-05
+## [2.15.1] - 2026-05-05
 
 ### Changed
 - **`createIfNotExists` — standard node path now matches AI tools response shape (all 14 entities):** Standard node path previously returned raw helper result (`chargeName`, `chargeId`, etc. as flat fields). Now returns the same structured shape as the AI tools path: `record{}` containing all supplied entity fields + entity `id`, `dedupFields`, `updateFields` (when non-empty), `matchedDedupFields`, `fieldsUpdated`, `fieldsCompared`, `context` (parent scope), `warnings`. Implemented via shared `helpers/compound-response-formatter.ts` — no per-helper duplication.

--- a/nodes/Autotask/ai-tools/operation-handlers/compound-operations.ts
+++ b/nodes/Autotask/ai-tools/operation-handlers/compound-operations.ts
@@ -41,9 +41,9 @@ function buildCompoundContext(resource: string, result: Record<string, unknown>)
 		case 'expenseItem':
 			return { expenseReportID: result.expenseReportID };
 		case 'ticketAdditionalConfigurationItem':
-			return result.ticketID !== undefined ? { ticketID: result.ticketID } : undefined;
+			return result.ticketId !== undefined ? { ticketID: result.ticketId } : undefined;
 		case 'ticketAdditionalContact':
-			return result.ticketID !== undefined ? { ticketID: result.ticketID } : undefined;
+			return result.ticketId !== undefined ? { ticketID: result.ticketId } : undefined;
 		case 'changeRequestLink': {
 			const ctx: Record<string, unknown> = {};
 			if (result.changeRequestTicketID !== undefined)

--- a/nodes/Autotask/ai-tools/response-builder.ts
+++ b/nodes/Autotask/ai-tools/response-builder.ts
@@ -454,7 +454,7 @@ export function buildCompoundResponse(
 	},
 	context: ToolResponseContext = {},
 ): Record<string, unknown> {
-	const { outcome, id, existingId, record, dedupFields, updateFields, matchedDedupFields, fieldsUpdated, fieldsCompared } =
+	const { outcome, id, existingId, record, dedupFields, updateFields, matchedDedupFields, fieldsUpdated, fieldsCompared, context: entityContext } =
 		compoundData;
 	const canonicalId = id ?? existingId;
 	let summary: string;
@@ -484,6 +484,7 @@ export function buildCompoundResponse(
 	if (matchedDedupFields !== undefined) response.matchedDedupFields = matchedDedupFields;
 	if (fieldsCompared !== undefined) response.fieldsCompared = fieldsCompared;
 	if (fieldsUpdated !== undefined) response.fieldsUpdated = fieldsUpdated;
+	if (entityContext !== undefined) response.context = entityContext;
 	return response;
 }
 

--- a/nodes/Autotask/helpers/compound-response-formatter.ts
+++ b/nodes/Autotask/helpers/compound-response-formatter.ts
@@ -33,9 +33,9 @@ export function buildCompoundContextFromResult(
 		case 'expenseItem':
 			return { expenseReportID: result.expenseReportID };
 		case 'ticketAdditionalConfigurationItem':
-			return result.ticketID !== undefined ? { ticketID: result.ticketID } : undefined;
+			return result.ticketId !== undefined ? { ticketID: result.ticketId } : undefined;
 		case 'ticketAdditionalContact':
-			return result.ticketID !== undefined ? { ticketID: result.ticketID } : undefined;
+			return result.ticketId !== undefined ? { ticketID: result.ticketId } : undefined;
 		case 'changeRequestLink': {
 			const ctx: Record<string, unknown> = {};
 			if (result.changeRequestTicketID !== undefined)

--- a/nodes/Autotask/helpers/compound-response-formatter.ts
+++ b/nodes/Autotask/helpers/compound-response-formatter.ts
@@ -1,0 +1,123 @@
+import type { IDataObject } from 'n8n-workflow';
+import { COMPOUND_REGISTRY } from '../constants/compound-registry';
+
+/**
+ * Build the parent/scope context block from a raw compound helper result.
+ * Mirrors buildCompoundContext in ai-tools/operation-handlers/compound-operations.ts.
+ */
+export function buildCompoundContextFromResult(
+	resource: string,
+	result: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+	switch (resource) {
+		case 'contractCharge':
+			return result.contractId !== undefined ? { contractId: result.contractId } : undefined;
+		case 'ticketCharge':
+			return { ticketId: result.ticketId, ticketID: result.ticketID };
+		case 'projectCharge':
+			return result.projectId !== undefined ? { projectId: result.projectId } : undefined;
+		case 'configurationItems':
+			return { companyID: result.companyID };
+		case 'timeEntry': {
+			const ctx: Record<string, unknown> = { resourceID: result.resourceID };
+			if (result.ticketID !== undefined) ctx.ticketID = result.ticketID;
+			if (result.taskID !== undefined) ctx.taskID = result.taskID;
+			return ctx;
+		}
+		case 'contractService':
+			return result.contractId !== undefined ? { contractId: result.contractId } : undefined;
+		case 'contract':
+			return { companyID: result.companyID };
+		case 'opportunity':
+			return undefined;
+		case 'expenseItem':
+			return { expenseReportID: result.expenseReportID };
+		case 'ticketAdditionalConfigurationItem':
+			return result.ticketID !== undefined ? { ticketID: result.ticketID } : undefined;
+		case 'ticketAdditionalContact':
+			return result.ticketID !== undefined ? { ticketID: result.ticketID } : undefined;
+		case 'changeRequestLink': {
+			const ctx: Record<string, unknown> = {};
+			if (result.changeRequestTicketID !== undefined)
+				ctx.changeRequestTicketID = result.changeRequestTicketID;
+			if (result.problemOrIncidentTicketID !== undefined)
+				ctx.problemOrIncidentTicketID = result.problemOrIncidentTicketID;
+			return Object.keys(ctx).length > 0 ? ctx : undefined;
+		}
+		case 'holidaySet':
+			return undefined;
+		case 'holiday':
+			return result.holidaySetId !== undefined ? { holidaySetId: result.holidaySetId } : undefined;
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Format a raw compound helper result into the standard createIfNotExists response
+ * shape for the standard node path (Autotask.node.ts → resource execute.ts).
+ *
+ * Produces the same structure as the AI tools path (handleCreateIfNotExists in
+ * compound-operations.ts) minus AI-specific fields (resolvedLabels, pendingConfirmations,
+ * summary, operation — those are not meaningful in the standard workflow node context).
+ *
+ * Fields included:
+ *   outcome, id/existingId, record{} (created/updated only), dedupFields,
+ *   updateFields (when non-empty), matchedDedupFields, fieldsUpdated,
+ *   fieldsCompared, context, warnings
+ */
+export function formatCompoundResponse(
+	resource: string,
+	result: Record<string, unknown>,
+	createFields: Record<string, unknown>,
+	dedupFields: string[],
+	updateFields: string[],
+): IDataObject {
+	const registryEntry = COMPOUND_REGISTRY[resource];
+	const entityIdField = registryEntry?.entityIdField;
+	const entityId = entityIdField
+		? (result[entityIdField] as number | undefined)
+		: ((result.id ?? result.itemId) as number | undefined);
+
+	const outcome = result.outcome as string;
+
+	const response: IDataObject = { outcome };
+
+	if (entityId !== undefined) {
+		if (outcome === 'created') {
+			response.id = entityId;
+		} else {
+			response.existingId = entityId;
+		}
+	}
+
+	// Echo all supplied entity fields as record{} for created/updated outcomes.
+	// recordExcludeFields strips helper-only inputs (e.g. materialCode → billingCodeID)
+	// that the helper resolves internally and never writes to the API as-is.
+	if (outcome === 'created' || outcome === 'updated') {
+		const excludeSet = new Set(registryEntry?.recordExcludeFields ?? []);
+		const record: IDataObject = {};
+		for (const [k, v] of Object.entries(createFields)) {
+			if (!excludeSet.has(k)) record[k] = v as IDataObject[string];
+		}
+		if (entityId !== undefined) record.id = entityId;
+		response.record = record;
+	}
+
+	response.dedupFields = dedupFields;
+	if (updateFields.length > 0) response.updateFields = updateFields;
+
+	if (result.matchedDedupFields !== undefined)
+		response.matchedDedupFields = result.matchedDedupFields as IDataObject[string];
+	if (result.fieldsCompared !== undefined)
+		response.fieldsCompared = result.fieldsCompared as IDataObject[string];
+	if (result.fieldsUpdated !== undefined)
+		response.fieldsUpdated = result.fieldsUpdated as IDataObject[string];
+
+	const context = buildCompoundContextFromResult(resource, result);
+	if (context !== undefined) response.context = context as IDataObject[string];
+
+	response.warnings = (result.warnings as string[]) ?? [];
+
+	return response;
+}

--- a/nodes/Autotask/resources/changeRequestLinks/execute.ts
+++ b/nodes/Autotask/resources/changeRequestLinks/execute.ts
@@ -2,6 +2,7 @@ import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-wor
 import { NodeOperationError } from 'n8n-workflow';
 import type { IAutotaskEntity } from '../../types';
 import { CreateOperation, GetOperation, GetManyOperation, CountOperation, DeleteOperation } from '../../operations/base';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 
 const ENTITY_TYPE = 'changeRequestLink';
 
@@ -58,12 +59,15 @@ export async function executeChangeRequestLinkOperation(
 						const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
 						createFields = fieldsToMap?.value ?? {};
 					} catch { /* fieldsToMap may not be available */ }
+					const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+					const updateFields: string[] = [];
+					const errorOnDuplicate = this.getNodeParameter('errorOnDuplicate', i, false) as boolean;
 					const result = await createChangeRequestLinkIfNotExists(this, i, {
 						createFields,
-						dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-						errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
+						dedupFields,
+						errorOnDuplicate,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('changeRequestLink', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 

--- a/nodes/Autotask/resources/configurationItems/execute.ts
+++ b/nodes/Autotask/resources/configurationItems/execute.ts
@@ -1,4 +1,5 @@
-import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 import type { IAutotaskEntity } from '../../types';
 import {
   CreateOperation,
@@ -76,13 +77,15 @@ export async function executeConfigurationItemOperation(
             const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
             createFields = fieldsToMap?.value ?? {};
           } catch { /* fieldsToMap may not be available */ }
+          const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+          const updateFields = this.getNodeParameter('updateFields', i, []) as string[];
           const result = await createConfigurationItemIfNotExists(this, i, {
             createFields,
-            dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-            updateFields: this.getNodeParameter('updateFields', i, []) as string[],
+            dedupFields,
+            updateFields,
             errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
           });
-          returnData.push({ json: result as unknown as IDataObject });
+          returnData.push({ json: formatCompoundResponse('configurationItems', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
           break;
         }
 

--- a/nodes/Autotask/resources/contractCharges/execute.ts
+++ b/nodes/Autotask/resources/contractCharges/execute.ts
@@ -1,5 +1,6 @@
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import type { IAutotaskEntity } from '../../types';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 import {
 	CreateOperation,
 	UpdateOperation,
@@ -101,13 +102,15 @@ export async function executeContractChargeOperation(
 						const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
 						createFields = fieldsToMap?.value ?? {};
 					} catch { /* fieldsToMap may not be available */ }
+					const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+					const updateFields = this.getNodeParameter('updateFields', i, []) as string[];
 					const result = await createContractChargeIfNotExists(this, i, {
 						createFields,
-						dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-						updateFields: this.getNodeParameter('updateFields', i, []) as string[],
+						dedupFields,
+						updateFields,
 						errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('contractCharge', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 				default:

--- a/nodes/Autotask/resources/contractServices/execute.ts
+++ b/nodes/Autotask/resources/contractServices/execute.ts
@@ -1,4 +1,5 @@
-import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 import type { IAutotaskEntity } from '../../types';
 import {
 	CreateOperation,
@@ -89,13 +90,15 @@ export async function executeContractServiceOperation(
 						const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
 						createFields = fieldsToMap?.value ?? {};
 					} catch { /* fieldsToMap may not be available */ }
+					const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+					const updateFields = this.getNodeParameter('updateFields', i, []) as string[];
 					const result = await createContractServiceIfNotExists(this, i, {
 						createFields,
-						dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-						updateFields: this.getNodeParameter('updateFields', i, []) as string[],
+						dedupFields,
+						updateFields,
 						errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('contractService', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 

--- a/nodes/Autotask/resources/contracts/execute.ts
+++ b/nodes/Autotask/resources/contracts/execute.ts
@@ -1,4 +1,5 @@
-import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 import type { IAutotaskEntity } from '../../types';
 import {
 	CreateOperation,
@@ -64,13 +65,15 @@ export async function executeContractOperation(
 						const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
 						createFields = fieldsToMap?.value ?? {};
 					} catch { /* fieldsToMap may not be available */ }
+					const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+					const updateFields = this.getNodeParameter('updateFields', i, []) as string[];
 					const result = await createContractIfNotExists(this, i, {
 						createFields,
-						dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-						updateFields: this.getNodeParameter('updateFields', i, []) as string[],
+						dedupFields,
+						updateFields,
 						errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('contract', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 

--- a/nodes/Autotask/resources/expenseItems/execute.ts
+++ b/nodes/Autotask/resources/expenseItems/execute.ts
@@ -1,5 +1,6 @@
-import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import type { IAutotaskEntity } from '../../types';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 import {
 	CreateOperation,
 	UpdateOperation,
@@ -64,13 +65,15 @@ export async function executeExpenseItemOperation(
 						const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
 						createFields = fieldsToMap?.value ?? {};
 					} catch { /* fieldsToMap may not be available */ }
+					const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+					const updateFields = this.getNodeParameter('updateFields', i, []) as string[];
 					const result = await createExpenseItemIfNotExists(this, i, {
 						createFields,
-						dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-						updateFields: this.getNodeParameter('updateFields', i, []) as string[],
+						dedupFields,
+						updateFields,
 						errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('expenseItem', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 				default:

--- a/nodes/Autotask/resources/holidaySets/execute.ts
+++ b/nodes/Autotask/resources/holidaySets/execute.ts
@@ -9,6 +9,7 @@ import {
 	CountOperation,
 } from '../../operations/base';
 import { createHolidaySetIfNotExists } from '../../helpers/holiday-set-creator';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 
 const ENTITY_TYPE = 'holidaySet';
 
@@ -90,7 +91,7 @@ export async function executeHolidaySetOperation(
 						errorOnDuplicate,
 						updateFields,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('holidaySet', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 

--- a/nodes/Autotask/resources/holidays/execute.ts
+++ b/nodes/Autotask/resources/holidays/execute.ts
@@ -9,6 +9,7 @@ import {
 	DeleteOperation,
 } from '../../operations/base';
 import { createHolidayIfNotExists } from '../../helpers/holiday-creator';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 
 const ENTITY_TYPE = 'holiday';
 
@@ -90,7 +91,7 @@ export async function executeHolidayOperation(
 						errorOnDuplicate,
 						updateFields,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('holiday', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 

--- a/nodes/Autotask/resources/opportunities/execute.ts
+++ b/nodes/Autotask/resources/opportunities/execute.ts
@@ -1,5 +1,6 @@
-import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import type { IAutotaskEntity } from '../../types';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 import {
 	CreateOperation,
 	UpdateOperation,
@@ -33,13 +34,15 @@ export async function executeOpportunityOperation(
 						const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
 						createFields = fieldsToMap?.value ?? {};
 					} catch { /* fieldsToMap may not be available */ }
+					const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+					const updateFields = this.getNodeParameter('updateFields', i, []) as string[];
 					const result = await createOpportunityIfNotExists(this, i, {
 						createFields,
-						dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-						updateFields: this.getNodeParameter('updateFields', i, []) as string[],
+						dedupFields,
+						updateFields,
 						errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('opportunity', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 				case 'update': {

--- a/nodes/Autotask/resources/projectCharges/execute.ts
+++ b/nodes/Autotask/resources/projectCharges/execute.ts
@@ -1,5 +1,6 @@
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import type { IAutotaskEntity } from '../../types';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 import {
 	CreateOperation,
 	UpdateOperation,
@@ -75,13 +76,15 @@ export async function executeProjectChargeOperation(
 						const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
 						createFields = fieldsToMap?.value ?? {};
 					} catch { /* fieldsToMap may not be available */ }
+					const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+					const updateFields = this.getNodeParameter('updateFields', i, []) as string[];
 					const result = await createProjectChargeIfNotExists(this, i, {
 						createFields,
-						dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-						updateFields: this.getNodeParameter('updateFields', i, []) as string[],
+						dedupFields,
+						updateFields,
 						errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('projectCharge', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 

--- a/nodes/Autotask/resources/ticketAdditionalConfigurationItems/execute.ts
+++ b/nodes/Autotask/resources/ticketAdditionalConfigurationItems/execute.ts
@@ -1,6 +1,7 @@
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import type { IAutotaskEntity } from '../../types';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 import {
 	CreateOperation,
 	GetOperation,
@@ -69,13 +70,16 @@ export async function executeTicketAdditionalConfigurationItemOperation(
 						const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
 						createFields = fieldsToMap?.value ?? {};
 					} catch { /* fieldsToMap may not be available */ }
+					const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+					const updateFields = this.getNodeParameter('updateFields', i, []) as string[];
+					const errorOnDuplicate = this.getNodeParameter('errorOnDuplicate', i, false) as boolean;
 					const result = await createTicketAdditionalCIIfNotExists(this, i, {
 						createFields,
-						dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-						updateFields: this.getNodeParameter('updateFields', i, []) as string[],
-						errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
+						dedupFields,
+						updateFields,
+						errorOnDuplicate,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('ticketAdditionalConfigurationItem', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 

--- a/nodes/Autotask/resources/ticketAdditionalContacts/execute.ts
+++ b/nodes/Autotask/resources/ticketAdditionalContacts/execute.ts
@@ -1,6 +1,7 @@
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import type { IAutotaskEntity } from '../../types';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 import {
 	CreateOperation,
 	GetOperation,
@@ -69,13 +70,16 @@ export async function executeTicketAdditionalContactOperation(
 						const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
 						createFields = fieldsToMap?.value ?? {};
 					} catch { /* fieldsToMap may not be available */ }
+					const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+					const updateFields = this.getNodeParameter('updateFields', i, []) as string[];
+					const errorOnDuplicate = this.getNodeParameter('errorOnDuplicate', i, false) as boolean;
 					const result = await createTicketAdditionalContactIfNotExists(this, i, {
 						createFields,
-						dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-						updateFields: this.getNodeParameter('updateFields', i, []) as string[],
-						errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
+						dedupFields,
+						updateFields,
+						errorOnDuplicate,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('ticketAdditionalContact', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 

--- a/nodes/Autotask/resources/ticketCharges/execute.ts
+++ b/nodes/Autotask/resources/ticketCharges/execute.ts
@@ -1,6 +1,7 @@
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import type { IAutotaskEntity } from '../../types';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 import {
 	CreateOperation,
 	UpdateOperation,
@@ -121,13 +122,15 @@ export async function executeTicketChargeOperation(
 						const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
 						createFields = fieldsToMap?.value ?? {};
 					} catch { /* fieldsToMap may not be available */ }
+					const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+					const updateFields = this.getNodeParameter('updateFields', i, []) as string[];
 					const result = await createTicketChargeIfNotExists(this, i, {
 						createFields,
-						dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-						updateFields: this.getNodeParameter('updateFields', i, []) as string[],
+						dedupFields,
+						updateFields,
 						errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('ticketCharge', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 

--- a/nodes/Autotask/resources/timeEntries/execute.ts
+++ b/nodes/Autotask/resources/timeEntries/execute.ts
@@ -1,5 +1,6 @@
 import type { IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import type { IAutotaskEntity, IQueryResponse } from '../../types';
+import { formatCompoundResponse } from '../../helpers/compound-response-formatter';
 import {
 	CreateOperation,
 	UpdateOperation,
@@ -814,13 +815,15 @@ export async function executeTimeEntryOperation(
 						const fieldsToMap = this.getNodeParameter('fieldsToMap', i, { value: {} }) as { value: Record<string, unknown> | null };
 						createFields = fieldsToMap?.value ?? {};
 					} catch { /* fieldsToMap may not be available */ }
+					const dedupFields = this.getNodeParameter('dedupFields', i, []) as string[];
+					const updateFields = this.getNodeParameter('updateFields', i, []) as string[];
 					const result = await createTimeEntryIfNotExists(this, i, {
 						createFields,
-						dedupFields: this.getNodeParameter('dedupFields', i, []) as string[],
-						updateFields: this.getNodeParameter('updateFields', i, []) as string[],
+						dedupFields,
+						updateFields,
 						errorOnDuplicate: this.getNodeParameter('errorOnDuplicate', i, false) as boolean,
 					});
-					returnData.push({ json: result as unknown as IDataObject });
+					returnData.push({ json: formatCompoundResponse('timeEntry', result as unknown as Record<string, unknown>, createFields, dedupFields, updateFields) });
 					break;
 				}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.16.0",
+  "version": "2.15.1",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

- Standard node path for all 14 `createIfNotExists` entities now returns the same structured response as the AI tools path
- Previously returned raw helper result (`chargeName`, `chargeId`, `datePurchased` etc. as flat fields with no `record{}`)
- New shape: `record{}` (all supplied fields + `id`), `dedupFields`, `updateFields`, `matchedDedupFields`, `fieldsUpdated`, `fieldsCompared`, `context{}`, `warnings`
- Implemented via new shared `helpers/compound-response-formatter.ts` — uses `COMPOUND_REGISTRY` for `entityIdField` and `recordExcludeFields` (e.g. `materialCode` stripped for charge entities)
- Mirrors context logic from `compound-operations.ts` (`buildCompoundContextFromResult`)
- **Bug fixes from Opus QA:** AI tools path now correctly surfaces `context{}` (was computed but silently dropped in `buildCompoundResponse`); `ticketAdditionalConfigurationItem`/`ticketAdditionalContact` context now reads `ticketId` (correct helper field name) not `ticketID`

## Entities covered

contractCharge, ticketCharge, projectCharge, configurationItems, timeEntry, contractService, contract, opportunity, expenseItem, ticketAdditionalConfigurationItem, ticketAdditionalContact, changeRequestLink, holidaySet, holiday

## Test plan

- [ ] `contractCharge.createIfNotExists` (created) → output has `record{}`, `dedupFields`, `context.contractId`
- [ ] `contractCharge.createIfNotExists` (skipped) → no `record{}`, has `existingId`, `matchedDedupFields`
- [ ] `contractCharge.createIfNotExists` (updated) → `record{}` present, `fieldsUpdated` shows diff
- [ ] `timeEntry.createIfNotExists` → `context` has `resourceID`, optional `ticketID`/`taskID`
- [ ] `ticketAdditionalConfigurationItem.createIfNotExists` → `context.ticketID` populated
- [ ] AI tools path response includes `context{}` (was missing before)
- [ ] `materialCode` NOT present in `record{}` for charge entities
- [ ] Build passes (`pnpm build`)