### PR TITLE
fix: v2.19.6 — update-op friction fixes (describeOp required fields, leak detection, parent-ID error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.19.6] - 2026-05-22
+
+### Fixed
+- **Update `describeOperation` output surfaces create-required fields**: `buildUpdateDescription()` now accepts `writeFields` and appends a compact "Fields required on create (PATCH preserves existing value if omitted)" note when required fields exist. LLMs calling `describeOperation` with `targetOperation='update'` see the relevant field names upfront, eliminating the need for a `describeFields` round-trip to discover parent anchor fields like `companyID`.
+- **Write-field leak detection fires even when filters are present**: The pre-flight check for top-level write-field params on `getMany`/`count`/`getPosted`/`getUnposted` previously required no filters to be present. Write-field params are always wrong on read ops regardless of filter state. Widened the check to fire unconditionally; message branches: "remove top-level X" when filters exist vs "use filter_field=X" when no filter was provided.
+- **"Invalid parent ID type for Company" errors now name the field**: `formatApiError` has a new pattern that matches the internal `base-operation.ts` "Invalid parent ID type for \<Entity\>" message, cross-references the resource's `parentIdField` via `getEntityMetadata()`, and returns a `MISSING_REQUIRED_FIELDS` error naming the exact field (e.g. `companyID`) rather than falling through to the generic `API_ERROR` with no actionable context.
+
 ## [2.19.5] - 2026-05-21
 
 ### Fixed

--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -249,7 +249,7 @@ export function buildUpdateDescription(
 	const requiredOnCreate = writeFields.filter((f) => f.required);
 	const createFieldsNote =
 		requiredOnCreate.length > 0
-			? `Fields required on create (PATCH preserves existing value if omitted — only supply if changing): ${buildRequiredFieldsSummary(writeFields)} `
+			? `Fields required on create (PATCH preserves existing value if omitted — only supply if changing): ${buildRequiredFieldsSummary(writeFields).replace(/^Required fields: /i, '')} `
 			: '';
 	return (
 		ref +

--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -241,16 +241,23 @@ export function buildCreateDescription(
 export function buildUpdateDescription(
 	resourceLabel: string,
 	resourceName: string,
+	writeFields: FieldMeta[],
 	referenceUtc?: string,
 ): string {
 	const ref = referenceUtc ? dateTimeReferenceSnippet(referenceUtc) : '';
 	const extraHint = RESOURCE_EXTRA_HINTS[resourceName] ?? '';
+	const requiredOnCreate = writeFields.filter((f) => f.required);
+	const createFieldsNote =
+		requiredOnCreate.length > 0
+			? `Fields required on create (PATCH preserves existing value if omitted — only supply if changing): ${buildRequiredFieldsSummary(writeFields)} `
+			: '';
 	return (
 		ref +
 		`Update an existing ${resourceLabel} record by numeric ID. ` +
 		`PREREQUISITE: you need the numeric ID. If you only have a name or text, call autotask_${resourceName} with operation 'getMany' with a filter to find the record and get its 'id' first. ` +
 		`Only provide fields to change (PATCH-style behaviour). ` +
 		`Do not assume PUT-style replacement where omitted fields become null. ` +
+		createFieldsNote +
 		`Picklist and reference fields accept human-readable names — auto-resolved to IDs. ` +
 		`Date-time values must be ISO-8601 and UTC-safe (for example 2026-02-14T03:15:00Z). ` +
 		`Confirm field values with user before executing when acting autonomously. ` +
@@ -1226,7 +1233,7 @@ function getOperationPurpose(
 		case 'create':
 			return buildCreateDescription(resourceLabel, resource, writeFields);
 		case 'update':
-			return buildUpdateDescription(resourceLabel, resource);
+			return buildUpdateDescription(resourceLabel, resource, writeFields);
 		case 'delete':
 			return buildDeleteDescription(resourceLabel, resource);
 		case 'whoAmI':

--- a/nodes/Autotask/ai-tools/error-formatter.ts
+++ b/nodes/Autotask/ai-tools/error-formatter.ts
@@ -1,3 +1,5 @@
+import { getEntityMetadata } from '../constants/entities';
+
 // ---------------------------------------------------------------------------
 // Error type constants
 // ---------------------------------------------------------------------------
@@ -213,6 +215,22 @@ export function formatApiError(
 			message,
 			`Use autotask_${resource} with operation 'getMany' and a filter to locate a valid record ID, then retry.`,
 		);
+	}
+
+	const parentMatch = message.match(/Invalid parent ID type for (\w+)/i);
+	if (parentMatch) {
+		const parentField = getEntityMetadata(resource)?.parentIdField;
+		if (parentField) {
+			return wrapError(
+				resource,
+				operation,
+				ERROR_TYPES.MISSING_REQUIRED_FIELDS,
+				`Missing required parent ID '${parentField}' on ${resource}.${operation} (parent entity: ${parentMatch[1]}).`,
+				`Provide '${parentField}' as a top-level field with a valid numeric ID. Call autotask_${resource} with operation 'describeFields' with mode 'write' to confirm required fields.`,
+				{ missingFields: [parentField] },
+				['describeFields'],
+			);
+		}
 	}
 
 	return wrapError(

--- a/nodes/Autotask/ai-tools/tool-executor.ts
+++ b/nodes/Autotask/ai-tools/tool-executor.ts
@@ -853,17 +853,21 @@ export async function executeAiTool(
 		);
 		if (
 			isGenericListLeakCheckOp &&
-			Object.keys(fieldValues).length > 0 &&
-			!hasFiltersJson &&
-			!hasFlatFilter1 &&
-			!hasFlatFilter2
+			Object.keys(fieldValues).length > 0
 		) {
 			const leakedFields = Object.keys(fieldValues);
-			const firstField = leakedFields[0];
-			const firstValue = String(fieldValues[firstField]);
-			filterErrors.push(
-				`Operation '${effectiveOperation}' received top-level write-field params (${leakedFields.join(', ')}) without any filter. Top-level fields apply to create/update only. For read filters use filter_field='${firstField}', filter_op='eq', filter_value='${firstValue}' (or filtersJson for advanced filters).`,
-			);
+			const hasAnyFilter = hasFiltersJson || hasFlatFilter1 || hasFlatFilter2;
+			if (hasAnyFilter) {
+				filterErrors.push(
+					`Operation '${effectiveOperation}' received top-level write-field params (${leakedFields.join(', ')}) alongside filter params. Top-level fields apply to create/update only — remove them. To add a second filter use filter_field_2/filter_op_2/filter_value_2.`,
+				);
+			} else {
+				const firstField = leakedFields[0];
+				const firstValue = String(fieldValues[firstField]);
+				filterErrors.push(
+					`Operation '${effectiveOperation}' received top-level write-field params (${leakedFields.join(', ')}) without any filter. Top-level fields apply to create/update only. For read filters use filter_field='${firstField}', filter_op='eq', filter_value='${firstValue}' (or filtersJson for advanced filters).`,
+				);
+			}
 		}
 
 		if (filterErrors.length > 0) {

--- a/nodes/Autotask/ai-tools/tool-executor.ts
+++ b/nodes/Autotask/ai-tools/tool-executor.ts
@@ -859,7 +859,7 @@ export async function executeAiTool(
 			const hasAnyFilter = hasFiltersJson || hasFlatFilter1 || hasFlatFilter2;
 			if (hasAnyFilter) {
 				filterErrors.push(
-					`Operation '${effectiveOperation}' received top-level write-field params (${leakedFields.join(', ')}) alongside filter params. Top-level fields apply to create/update only — remove them. To add a second filter use filter_field_2/filter_op_2/filter_value_2.`,
+					`Operation '${effectiveOperation}' received top-level write-field params (${leakedFields.join(', ')}) alongside filter params. Top-level fields apply to create/update only — remove them.${!hasFlatFilter2 ? ' To add a second filter use filter_field_2/filter_op_2/filter_value_2.' : ''}`,
 				);
 			} else {
 				const firstField = leakedFields[0];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.19.5",
+  "version": "2.19.6",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

- **`buildUpdateDescription` now surfaces create-required fields** in `describeOperation` output. LLMs calling `describeOperation targetOperation='update'` see e.g. `companyID (ref→Company), firstName (string)` upfront with a PATCH-preservation note — eliminates the `describeFields` round-trip to discover parent anchors.
- **Write-field leak detection widened**: pre-flight check on `getMany`/`count`/`getPosted`/`getUnposted` now fires even when filters are present (previously gated on no-filter-only). Message branches: "remove top-level X" when filters exist vs "use filter_field=X" when none.
- **"Invalid parent ID type for \<Entity\>" errors now name the field**: `formatApiError` matches the internal `base-operation.ts` pattern, cross-references `getEntityMetadata(resource)?.parentIdField`, and returns `MISSING_REQUIRED_FIELDS` with the exact field name (e.g. `companyID`) instead of falling through to generic `API_ERROR`.

## Motivation

Session review of Autotask MCP `contact.update` calls identified four friction points. All stem from the update-operation path having incomplete validation/description coverage relative to create. Improvement A (required-field pre-flight for update) was evaluated and rejected — it would revert v2.19.3 which correctly scoped required-field enforcement to create-only per PATCH semantics. Two Opus QA passes validated B+C+D.

## Test Plan
- [ ] `pnpm build` exits 0 ✅
- [ ] `describeOperation targetOperation='update'` on a resource with required fields (e.g. `contact`) includes the create-required fields note
- [ ] `contact.getMany` with a top-level `companyID` param AND a `filter_field` → returns `INVALID_FILTER_CONSTRAINT` with "remove them" message
- [ ] `contact.getMany` with a top-level `companyID` param and NO filters → original "use filter_field=X" message unchanged
- [ ] `contact.update` missing `companyID` (triggering "Invalid parent ID type for Company") → `MISSING_REQUIRED_FIELDS` error naming `companyID`