### PR TITLE
feat: per-user Autotask credential injection via X-Autotask-* MCP headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,11 @@ pnpm-lock.yaml
 
 # testing
 /coverage
-/tests/
+# Ignore tests/ contents except tracked source files.
+# git cannot re-include files inside an ignored directory with negation alone,
+# so we ignore specific leaf patterns instead of the whole /tests/ directory.
+/tests/node_modules/
+/tests/.env.test
 
 # next.js
 /.next/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,29 @@ export default [
 		},
 	},
 	{
+		// McpServer.ts dynamically resolves @modelcontextprotocol/sdk at runtime via createRequire
+		// — same justification as runtime.ts. SDK types are intentionally `any` at the boundary.
+		files: ['nodes/Autotask/mcp-trigger/McpServer.ts'],
+		rules: {
+			'@typescript-eslint/no-require-imports': 'off',
+			'@typescript-eslint/no-explicit-any': 'off',
+		},
+	},
+	{
+		// AutotaskMcpTrigger handles HTTP req/res from express, MCP SDK transports, and connected tools
+		// — the surface is intentionally untyped at the boundary.
+		// webhook-lifecycle-complete applies to third-party webhook registration (GitHub, Slack, etc.) —
+		// not applicable to a self-hosted MCP webhook where n8n itself manages the lifecycle.
+		files: ['nodes/Autotask/AutotaskMcpTrigger.node.ts'],
+		rules: {
+			'@typescript-eslint/no-explicit-any': 'off',
+			'@n8n/community-nodes/webhook-lifecycle-complete': 'off',
+			// Trigger node has no execute() — usableAsTool would be meaningless and the TS type
+			// only accepts `true | undefined` (cannot set explicit false to satisfy this rule).
+			'@n8n/community-nodes/node-usable-as-tool': 'off',
+		},
+	},
+	{
 		// credential-masking deals with arbitrary error/object shapes — any is correct here
 		files: ['nodes/Autotask/helpers/security/credential-masking.ts'],
 		rules: {

--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -46,6 +46,8 @@ import {
 	traceExecutor,
 	traceToolBuild,
 } from './ai-tools/debug-trace';
+import { autotaskCredentialStore, probeCredentialIdentity } from './helpers/credential-store';
+import { buildCredentialProxy } from './helpers/credential-proxy';
 
 const EXCLUDED_RESOURCES = ['aiHelper', 'apiThreshold'];
 const TOOL_BUILD_CACHE_TTL_MS = 90_000;
@@ -358,6 +360,17 @@ export class AutotaskAiTools implements INodeType {
 					'Whether to enable mutating tools (create, createIfNotExists, moveToCompany, moveConfigurationItem, transferOwnership, update, delete). Disabled = read-only.',
 			},
 			{
+				displayName: 'Accept Injected Credentials',
+				name: 'acceptInjectedCredentials',
+				type: 'boolean',
+				default: false,
+				description:
+					'When enabled, accepts per-user Autotask credentials injected by the Autotask MCP Trigger. ' +
+					'Requires the connected trigger to have "Inject Autotask Credentials" enabled. ' +
+					'Note: changing this toggle requires saving and re-activating the workflow.',
+				noDataExpression: true,
+			},
+			{
 				displayName: 'Tool Description Appendix',
 				name: 'toolDescriptionAppendix',
 				type: 'string',
@@ -437,6 +450,11 @@ export class AutotaskAiTools implements INodeType {
 		const referenceUtc = getReferenceUtcNow();
 		const supportsImpersonation = isNodeResourceImpersonationSupported(resource);
 		const credentialIdentity = await resolveCredentialIdentity(this);
+		const acceptInjectedCredentials = this.getNodeParameter(
+			'acceptInjectedCredentials',
+			itemIndex,
+			false,
+		) as boolean;
 		// Trace tool-construction decisions to understand what the AI can see.
 		traceToolBuild({
 			phase: 'supplyData-start',
@@ -604,6 +622,41 @@ export class AutotaskAiTools implements INodeType {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			schema: schema as any,
 			func: async (rawParams: Record<string, unknown>) => {
+				// Read override credentials from AsyncLocalStorage (injected by AutotaskMcpTrigger).
+				// ALS is populated only on the supplyData()->func() path (MCP Trigger).
+				// The execute() path has no ALS context — autotaskCredentialStore.getStore() returns undefined there.
+				const overrideCreds = autotaskCredentialStore.getStore();
+
+				let effectiveContext: ISupplyDataFunctions = supplyDataContext;
+				let effectiveMetadata = metadata;
+				let effectiveCredentialIdentity = credentialIdentity;
+
+				if (acceptInjectedCredentials && overrideCreds) {
+					effectiveContext = buildCredentialProxy(supplyDataContext, overrideCreds);
+					// Use probeCredentialIdentity rather than re-implementing the hash inline — it
+					// applies the same zone normalisation as the probe cache, so identity values
+					// stay consistent across the probe path and the func() cache key.
+					effectiveCredentialIdentity = probeCredentialIdentity(overrideCreds);
+					// Re-fetch metadata under the override credential — different Autotask security
+					// levels surface different readable/writable fields. Using the configured user's
+					// field set for a restricted override user would silently allow the LLM to attempt
+					// fields the override user cannot access.
+					//
+					// Verify CacheService isolation here: helpers in this code path call
+					// `context.getCredentials('autotaskApi')` and `CacheService.getInstance(credentialsId)`.
+					// Because the proxy returns the override creds for that getCredentials call, the
+					// derived `credentialsId` will be the override user's — producing a separate
+					// CacheService instance from the configured user's. No code change needed; this
+					// is what makes the proxy approach work without threading override params downstream.
+					effectiveMetadata = await resolveMetadataForTool(
+						effectiveContext,
+						resource,
+						effectiveOps,
+						effectiveCredentialIdentity,
+						itemIndex,
+					);
+				}
+
 				const operation = rawParams.operation as string;
 				if (!operation || !allAllowedOps.includes(operation)) {
 					if (operation && isWriteOperation(operation) && !allowWriteOperations) {
@@ -628,13 +681,13 @@ export class AutotaskAiTools implements INodeType {
 					);
 				}
 				return executeAiTool(
-					supplyDataContext as unknown as IExecuteFunctions,
+					effectiveContext as unknown as IExecuteFunctions,
 					resource,
 					operation,
 					rawParams as unknown as ToolExecutorParams,
 					{
-						readFields: metadata.readFields,
-						writeFields: metadata.writeFields,
+						readFields: effectiveMetadata.readFields,
+						writeFields: effectiveMetadata.writeFields,
 						allAllowedOps,
 					},
 				);
@@ -670,6 +723,16 @@ export class AutotaskAiTools implements INodeType {
 	 */
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
+		// Defensive guard: ALS store should never be populated on the execute() path.
+		// If it is, something unexpected has happened — log and ignore rather than using
+		// the override, to prevent cross-path credential leakage.
+		const unexpectedOverride = autotaskCredentialStore.getStore();
+		if (unexpectedOverride) {
+			console.warn(
+				'[AutotaskAiTools] execute(): autotaskCredentialStore unexpectedly populated — ' +
+				'override credentials are not supported on the Agent V3 execute() path. Ignoring.',
+			);
+		}
 		const resource = this.getNodeParameter('resource', 0) as string;
 		const operations = this.getNodeParameter('operations', 0) as string[];
 		const allowWriteOperations = this.getNodeParameter('allowWriteOperations', 0, false) as boolean;

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -223,6 +223,42 @@ export class AutotaskMcpTrigger implements INodeType {
                     return { noWebhookResponse: true };
                 }
             }
+            if (
+                effectiveInjectCredentials &&
+                typeof normalisedHeaders['x-autotask-username'] === 'string'
+            ) {
+                try {
+                    const parents = this.getParentNodes(this.getNode().name, {
+                        includeNodeParameters: true,
+                        connectionType: NodeConnectionTypes.AiTool,
+                    }) as Array<{ name?: string; type?: string; parameters?: Record<string, unknown> }>;
+                    const autotaskAiTools = parents.filter((c) => c.type === 'n8n-nodes-autotask.autotaskAiTools');
+                    const rejecting = autotaskAiTools.filter(
+                        (c) => !(c.parameters && c.parameters['acceptInjectedCredentials'] === true),
+                    );
+                    if (rejecting.length > 0) {
+                        const names = rejecting.map((n) => n.name ?? '(unnamed)').join(', ');
+                        if (authentication === 'autotaskCredentials') {
+                            res.status(403).json({
+                                error: 'Workflow misconfiguration: the following connected AutotaskAiTools node(s) do not have ' +
+                                    '"Accept Injected Credentials" enabled. When per-user authentication is active, all connected ' +
+                                    'tool nodes must opt in — otherwise callers run tools under the workflow-owner credential. ' +
+                                    `Enable "Accept Injected Credentials" on: ${names}`,
+                            });
+                            return { noWebhookResponse: true };
+                        }
+                        console.warn(
+                            `[AutotaskMcpTrigger] X-Autotask-* headers received but the following connected AutotaskAiTools node(s) ` +
+                            `do not have "Accept Injected Credentials" enabled — those tools will use the workflow-owner credentials, ` +
+                            `not the caller's injected credentials. Enable "Accept Injected Credentials" on those nodes if injection ` +
+                            `should be enforced end-to-end: ${names}`,
+                        );
+                    }
+                } catch {
+                    // getParentNodes may be unavailable in some n8n contexts (older versions).
+                    // This check is advisory only — do not fail the request.
+                }
+            }
             await requestHeaderStore.run(normalisedHeaders, async () => {
                 await session.transport.handlePostMessage(req, res, (req as { body?: unknown }).body);
             });
@@ -357,8 +393,16 @@ export class AutotaskMcpTrigger implements INodeType {
                     );
                 }
             } catch {
-                // getParentNodes may be unavailable in some n8n contexts (older versions).
-                // This check is advisory only — do not fail the request.
+                if (authentication === 'autotaskCredentials') {
+                    res.status(503).json({
+                        error: 'Unable to verify connected tool configuration. ' +
+                            'getParentNodes() failed — cannot confirm AutotaskAiTools nodes have ' +
+                            '"Accept Injected Credentials" enabled. ' +
+                            'Check n8n version compatibility or disable per-user authentication on this trigger.',
+                    });
+                    return { noWebhookResponse: true };
+                }
+                // In injection-only mode the check is advisory — proceed without it.
             }
         }
 

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -197,6 +197,38 @@ export class AutotaskMcpTrigger implements INodeType {
             });
         };
 
+        // SSE POST short-circuit — route directly to existing transport without
+        // loading tools or building an McpServer. The McpServer for this session was
+        // already constructed on the SSE setup GET; tool loading here would needlessly
+        // trigger supplyData() API calls on every tool invocation.
+        if (isSseTransport && webhookName === 'default' && req.method === 'POST') {
+            const sessionId = (req.query?.sessionId as string | undefined) ?? '';
+            const sessionKey = sessionId ? `${nodeId}:${sessionId}` : '';
+            const session = sessionKey ? sseSessions.get(sessionKey) : undefined;
+            if (!session) {
+                res.status(404).json({ error: 'No active SSE session for sessionId' });
+                return { noWebhookResponse: true };
+            }
+            await requestHeaderStore.run(normalisedHeaders, async () => {
+                await session.transport.handlePostMessage(req, res, (req as { body?: unknown }).body);
+            });
+            return { noWebhookResponse: true };
+        }
+
+        // SSE DELETE short-circuit — close + delete session without loading tools.
+        if (isSseTransport && req.method === 'DELETE') {
+            const sessionId = (req.query?.sessionId as string | undefined) ?? '';
+            const sessionKey = sessionId ? `${nodeId}:${sessionId}` : '';
+            if (sessionKey && sseSessions.has(sessionKey)) {
+                const { transport, server } = sseSessions.get(sessionKey)!;
+                try { await transport.close?.(); } catch { /* ignore */ }
+                try { await server.close?.(); } catch { /* ignore */ }
+                sseSessions.delete(sessionKey);
+            }
+            res.status(204).end();
+            return { noWebhookResponse: true };
+        }
+
         // Queue-mode check. In queue mode ALS cannot cross process boundaries so
         // injected credentials are silently unavailable in workers.
         // - With authentication='autotaskCredentials': reject hard (503) — the caller's
@@ -222,11 +254,14 @@ export class AutotaskMcpTrigger implements INodeType {
             }
         }
 
-        // Enforce webhook-level authentication BEFORE loading connected tools.
-        // Loading tools triggers supplyData() on each AutotaskAiTools node, which
-        // can include Autotask API metadata calls — unauthenticated callers must not
-        // consume that quota or cause that work.
-        if (authentication === 'autotaskCredentials') {
+        // Enforce webhook-level authentication BEFORE loading connected tools — only
+        // for Streamable HTTP. For SSE, the auth gate would reject the GET setup
+        // when MCP clients send X-Autotask-* headers only on POST /messages tool
+        // calls (not on the SSE setup GET). The McpServer already validates
+        // credentials per tools/call via requestHeaderStore + ALS, so the
+        // webhook-level gate is only meaningful for Streamable HTTP where each
+        // POST is a complete session.
+        if (!isSseTransport && authentication === 'autotaskCredentials') {
             const parsed = parseAndValidateHeaders(normalisedHeaders);
             if (parsed.type === 'none') {
                 res.status(401).json({ error: 'Authentication required: X-Autotask-Username, X-Autotask-Secret, X-Autotask-IntegrationCode, and X-Autotask-Zone headers are required.' });
@@ -365,36 +400,6 @@ export class AutotaskMcpTrigger implements INodeType {
                             res.on('close', cleanup);
                         }
                     });
-                    return { noWebhookResponse: true };
-                }
-
-                if (webhookName === 'default' && req.method === 'POST') {
-                    // SSE message — route to the existing transport.
-                    // Key is scoped to this node (nodeId:sessionId) so sessions from other
-                    // trigger instances cannot be cross-routed.
-                    const sessionId = (req.query?.sessionId as string | undefined) ?? '';
-                    const sessionKey = sessionId ? `${nodeId}:${sessionId}` : '';
-                    const session = sessionKey ? sseSessions.get(sessionKey) : undefined;
-                    if (!session) {
-                        res.status(404).json({ error: 'No active SSE session for sessionId' });
-                        return { noWebhookResponse: true };
-                    }
-                    await requestHeaderStore.run(normalisedHeaders, async () => {
-                        await mcpServer.handleSsePostMessage(session.transport, req, res, (req as { body?: unknown }).body);
-                    });
-                    return { noWebhookResponse: true };
-                }
-
-                if (req.method === 'DELETE') {
-                    const sessionId = (req.query?.sessionId as string | undefined) ?? '';
-                    const sessionKey = sessionId ? `${nodeId}:${sessionId}` : '';
-                    if (sessionKey && sseSessions.has(sessionKey)) {
-                        const { transport, server } = sseSessions.get(sessionKey)!;
-                        try { await transport.close?.(); } catch { /* ignore */ }
-                        try { await server.close?.(); } catch { /* ignore */ }
-                        sseSessions.delete(sessionKey);
-                    }
-                    res.status(204).end();
                     return { noWebhookResponse: true };
                 }
 

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -169,13 +169,20 @@ export class AutotaskMcpTrigger implements INodeType {
 
         const authentication = this.getNodeParameter('authentication', 'none') as string;
 
+        // When per-user auth is active, injection must also be active — otherwise the
+        // credentials used to pass the auth gate (X-Autotask-* headers) are validated
+        // but then ignored, and tool calls run under the workflow-owner credential.
+        // That is a privilege-escalation path: an external caller with any valid Autotask
+        // credential gains access to a potentially higher-privileged account.
+        const effectiveInjectCredentials = injectAutotaskCredentials || authentication === 'autotaskCredentials';
+
         // Node ID is stable per workflow node — used to scope SSE sessions so two
         // trigger instances with different paths cannot share session entries.
         const nodeId = this.getNode().id;
 
         // Queue-mode incompatibility check (runtime warning, not a hard fail —
         // operators can still use the node without injection).
-        if (injectAutotaskCredentials && process.env.EXECUTIONS_MODE === 'queue') {
+        if (effectiveInjectCredentials && process.env.EXECUTIONS_MODE === 'queue') {
             console.warn(
                 '[AutotaskMcpTrigger] "Inject Autotask Credentials" is enabled but n8n is running in queue mode. ' +
                 'AsyncLocalStorage cannot cross process boundaries — injection will not work in workers.',
@@ -209,7 +216,7 @@ export class AutotaskMcpTrigger implements INodeType {
         // enabled. We can only inspect node parameters via getChildNodes(); the
         // tools array itself does not expose the source node parameters.
         if (
-            injectAutotaskCredentials &&
+            effectiveInjectCredentials &&
             typeof normalisedHeaders['x-autotask-username'] === 'string'
         ) {
             try {
@@ -286,7 +293,7 @@ export class AutotaskMcpTrigger implements INodeType {
             mcpServer = new AutotaskMcpServer({
                 serverInfo: { name: 'autotask-mcp-trigger', version: '1.0.0' },
                 tools,
-                injectAutotaskCredentials,
+                injectAutotaskCredentials: effectiveInjectCredentials,
                 httpRequest: httpRequestFn,
             });
         } catch (err) {

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -55,7 +55,15 @@ const MCP_SSE_MESSAGES_PATH = 'messages';
 // the n8n webhook perspective (the MCP SDK transport handles its own
 // streaming response on the same request).
 // ---------------------------------------------------------------------------
+const MAX_SSE_SESSIONS = 256;
 const sseSessions = new Map<string, { transport: any; server: any }>();
+
+async function evictOldestSseSession(): Promise<void> {
+    const [oldestId, oldest] = sseSessions.entries().next().value as [string, { transport: any; server: any }];
+    sseSessions.delete(oldestId);
+    try { await oldest.transport?.close?.(); } catch { /* ignore */ }
+    try { await oldest.server?.close?.(); } catch { /* ignore */ }
+}
 
 export class AutotaskMcpTrigger implements INodeType {
     description: INodeTypeDescription = {
@@ -265,6 +273,9 @@ export class AutotaskMcpTrigger implements INodeType {
                         const { transport, server } = await mcpServer.openSseConnection(messageEndpoint, res);
                         const sessionId = transport.sessionId as string | undefined;
                         if (sessionId) {
+                            if (sseSessions.size >= MAX_SSE_SESSIONS) {
+                                await evictOldestSseSession();
+                            }
                             sseSessions.set(sessionId, { transport, server });
                             const cleanup = async () => {
                                 sseSessions.delete(sessionId);

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -255,8 +255,16 @@ export class AutotaskMcpTrigger implements INodeType {
                         );
                     }
                 } catch {
-                    // getParentNodes may be unavailable in some n8n contexts (older versions).
-                    // This check is advisory only — do not fail the request.
+                    if (authentication === 'autotaskCredentials') {
+                        res.status(503).json({
+                            error: 'Unable to verify connected tool configuration. ' +
+                                'getParentNodes() failed — cannot confirm AutotaskAiTools nodes have ' +
+                                '"Accept Injected Credentials" enabled. ' +
+                                'Check n8n version compatibility or disable per-user authentication on this trigger.',
+                        });
+                        return { noWebhookResponse: true };
+                    }
+                    // In injection-only mode the check is advisory — proceed without it.
                 }
             }
             await requestHeaderStore.run(normalisedHeaders, async () => {

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -1,0 +1,128 @@
+/**
+ * AutotaskMcpTrigger — Spike stub (Task 1: Fork Feasibility)
+ *
+ * This is a minimal TypeScript stub that proves the fork architecture compiles
+ * inside the n8n-nodes-autotask package. It does NOT yet implement per-user
+ * credential injection (that comes in subsequent tasks).
+ *
+ * Source reference: packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+ * Fetched from n8n-io/n8n main branch (n8n-workflow@2.21.1).
+ *
+ * MANUAL VERIFICATION REQUIRED before this stub is production-ready:
+ *   Step 5:   Test that tools/list returns the correct tool list via a live MCP endpoint.
+ *   Step 5b:  Verify ALS context propagates through the webhook call chain (smoke test
+ *             with AsyncLocalStorage.getStore() inside the tool executor).
+ */
+
+import type {
+	INodeType,
+	INodeTypeDescription,
+	IWebhookFunctions,
+	IWebhookResponseData,
+} from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
+
+const MCP_SSE_SETUP_PATH = 'sse';
+const MCP_SSE_MESSAGES_PATH = 'messages';
+
+export class AutotaskMcpTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Autotask MCP Trigger',
+		name: 'autotaskMcpTrigger',
+		icon: 'file:autotask.svg',
+		group: ['trigger'] as const,
+		version: [1, 1.1, 2],
+		description: 'Autotask MCP Trigger with per-user credential injection (spike stub)',
+		activationMessage:
+			'You can now connect your MCP Clients to the URL, using SSE or Streamable HTTP transports.',
+		defaults: {
+			name: 'Autotask MCP Trigger',
+		},
+		inputs: [
+			{
+				type: NodeConnectionTypes.AiTool,
+				displayName: 'Tools',
+			},
+		],
+		outputs: [],
+		credentials: [
+			{
+				name: 'autotaskApi',
+				required: false,
+				displayOptions: {
+					show: {
+						authentication: ['autotaskCredentials'],
+					},
+				},
+			},
+		],
+		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{ name: 'None', value: 'none' },
+					{ name: 'Autotask Credentials (Per-User)', value: 'autotaskCredentials' },
+				],
+				default: 'none',
+				description: 'The way to authenticate inbound MCP requests',
+			},
+			{
+				displayName: 'Path',
+				name: 'path',
+				type: 'string',
+				default: '',
+				placeholder: 'autotask-mcp',
+				required: true,
+				description: 'The base path for this Autotask MCP server',
+			},
+		],
+		webhooks: [
+			{
+				name: 'setup',
+				httpMethod: 'GET',
+				responseMode: 'onReceived',
+				isFullPath: true,
+				path: `={{$parameter["path"]}}{{parseFloat($nodeVersion)<2 ? '/${MCP_SSE_SETUP_PATH}' : ''}}`,
+			},
+			{
+				name: 'default',
+				httpMethod: 'POST',
+				responseMode: 'onReceived',
+				isFullPath: true,
+				path: `={{$parameter["path"]}}{{parseFloat($nodeVersion)<2 ? '/${MCP_SSE_MESSAGES_PATH}' : ''}}`,
+			},
+			{
+				name: 'default',
+				httpMethod: 'DELETE',
+				responseMode: 'onReceived',
+				isFullPath: true,
+				path: '={{$parameter["path"]}}',
+			},
+		],
+	};
+
+	/**
+	 * Stub webhook handler.
+	 *
+	 * TODO (subsequent tasks): Replace this with full McpServer delegation + ALS injection.
+	 *
+	 * The production implementation will:
+	 *   1. Extract per-request Autotask credentials from the HTTP Authorization header (or
+	 *      query param) and validate them.
+	 *   2. Inject those credentials into an AsyncLocalStorage store so that downstream
+	 *      EntityValueHelper / CacheService calls use the caller's credential identity rather
+	 *      than the workflow-owner's stored credential.
+	 *   3. Delegate to McpServer (imported at runtime via require to avoid module-resolution
+	 *      issues) for the actual SSE / Streamable HTTP transport handling.
+	 */
+	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		const resp = this.getResponseObject();
+		resp.status(501).json({
+			error: 'AutotaskMcpTrigger spike stub — not yet implemented',
+			message: 'Per-user credential injection will be implemented in subsequent tasks.',
+		});
+		return { noWebhookResponse: true };
+	}
+}

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -37,8 +37,9 @@ import type {
 import { NodeConnectionTypes } from 'n8n-workflow';
 import {
     requestHeaderStore,
+    probeCredentials,
 } from './helpers/credential-store';
-import { normaliseIncomingHeaders } from './helpers/credential-proxy';
+import { normaliseIncomingHeaders, parseAndValidateHeaders } from './helpers/credential-proxy';
 import { AutotaskMcpServer, type N8nLikeTool } from './mcp-trigger/McpServer';
 
 const MCP_SSE_SETUP_PATH = 'sse';
@@ -166,6 +167,12 @@ export class AutotaskMcpTrigger implements INodeType {
             false,
         ) as boolean;
 
+        const authentication = this.getNodeParameter('authentication', 'none') as string;
+
+        // Node ID is stable per workflow node — used to scope SSE sessions so two
+        // trigger instances with different paths cannot share session entries.
+        const nodeId = this.getNode().id;
+
         // Queue-mode incompatibility check (runtime warning, not a hard fail —
         // operators can still use the node without injection).
         if (injectAutotaskCredentials && process.env.EXECUTIONS_MODE === 'queue') {
@@ -248,6 +255,32 @@ export class AutotaskMcpTrigger implements INodeType {
             });
         };
 
+        // Enforce webhook-level authentication before any MCP processing.
+        // When authentication='autotaskCredentials', the caller MUST provide valid
+        // X-Autotask-* headers — absent or invalid headers are rejected with 401.
+        if (authentication === 'autotaskCredentials') {
+            const parsed = parseAndValidateHeaders(normalisedHeaders);
+            if (parsed.type === 'none') {
+                res.status(401).json({ error: 'Authentication required: X-Autotask-Username, X-Autotask-Secret, X-Autotask-IntegrationCode, and X-Autotask-Zone headers are required.' });
+                return { noWebhookResponse: true };
+            }
+            if (parsed.type === 'error') {
+                res.status(401).json({ error: `Authentication failed: ${parsed.message}` });
+                return { noWebhookResponse: true };
+            }
+            // Probe the credentials — returns true on network errors (fail-open).
+            let probeOk = true;
+            try {
+                probeOk = await probeCredentials(parsed.creds, httpRequestFn);
+            } catch {
+                probeOk = true;
+            }
+            if (!probeOk) {
+                res.status(401).json({ error: 'Authentication failed: Autotask rejected the provided credentials (401/403). Verify X-Autotask-* header values.' });
+                return { noWebhookResponse: true };
+            }
+        }
+
         let mcpServer: AutotaskMcpServer;
         try {
             mcpServer = new AutotaskMcpServer({
@@ -281,12 +314,13 @@ export class AutotaskMcpTrigger implements INodeType {
                         const { transport, server } = await mcpServer.openSseConnection(messageEndpoint, res);
                         const sessionId = transport.sessionId as string | undefined;
                         if (sessionId) {
+                            const sessionKey = `${nodeId}:${sessionId}`;
                             if (sseSessions.size >= MAX_SSE_SESSIONS) {
                                 await evictOldestSseSession();
                             }
-                            sseSessions.set(sessionId, { transport, server });
+                            sseSessions.set(sessionKey, { transport, server });
                             const cleanup = async () => {
-                                sseSessions.delete(sessionId);
+                                sseSessions.delete(sessionKey);
                                 try { await server.close?.(); } catch { /* ignore */ }
                             };
                             transport.onclose = cleanup;
@@ -298,8 +332,11 @@ export class AutotaskMcpTrigger implements INodeType {
 
                 if (webhookName === 'default' && req.method === 'POST') {
                     // SSE message — route to the existing transport.
+                    // Key is scoped to this node (nodeId:sessionId) so sessions from other
+                    // trigger instances cannot be cross-routed.
                     const sessionId = (req.query?.sessionId as string | undefined) ?? '';
-                    const session = sessionId ? sseSessions.get(sessionId) : undefined;
+                    const sessionKey = sessionId ? `${nodeId}:${sessionId}` : '';
+                    const session = sessionKey ? sseSessions.get(sessionKey) : undefined;
                     if (!session) {
                         res.status(404).json({ error: 'No active SSE session for sessionId' });
                         return { noWebhookResponse: true };
@@ -312,11 +349,12 @@ export class AutotaskMcpTrigger implements INodeType {
 
                 if (req.method === 'DELETE') {
                     const sessionId = (req.query?.sessionId as string | undefined) ?? '';
-                    if (sessionId && sseSessions.has(sessionId)) {
-                        const { transport, server } = sseSessions.get(sessionId)!;
+                    const sessionKey = sessionId ? `${nodeId}:${sessionId}` : '';
+                    if (sessionKey && sseSessions.has(sessionKey)) {
+                        const { transport, server } = sseSessions.get(sessionKey)!;
                         try { await transport.close?.(); } catch { /* ignore */ }
                         try { await server.close?.(); } catch { /* ignore */ }
-                        sseSessions.delete(sessionId);
+                        sseSessions.delete(sessionKey);
                     }
                     res.status(204).end();
                     return { noWebhookResponse: true };

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -1,128 +1,325 @@
 /**
- * AutotaskMcpTrigger — Spike stub (Task 1: Fork Feasibility)
+ * AutotaskMcpTrigger — n8n MCP Trigger fork that optionally injects per-user
+ * Autotask credentials extracted from incoming X-Autotask-* HTTP headers into
+ * connected AutotaskAiTools tool calls.
  *
- * This is a minimal TypeScript stub that proves the fork architecture compiles
- * inside the n8n-nodes-autotask package. It does NOT yet implement per-user
- * credential injection (that comes in subsequent tasks).
+ * Source reference (architectural model):
+ *   packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
  *
- * Source reference: packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
- * Fetched from n8n-io/n8n main branch (n8n-workflow@2.21.1).
+ * Webhook layout:
+ *   v1 / v1.1 (SSE — deprecated)
+ *     GET  /{path}/sse        → open SSE connection (webhook name 'setup')
+ *     POST /{path}/messages   → client → server message (webhook name 'default')
+ *   v2 (Streamable HTTP — preferred)
+ *     POST   /{path}          → all client → server messages
+ *     DELETE /{path}          → session cleanup
+ *     GET    /{path}          → reserved (SSE setup path collapses into base path)
  *
- * MANUAL VERIFICATION REQUIRED before this stub is production-ready:
- *   Step 5:   Test that tools/list returns the correct tool list via a live MCP endpoint.
- *   Step 5b:  Verify ALS context propagates through the webhook call chain (smoke test
- *             with AsyncLocalStorage.getStore() inside the tool executor).
+ * Credential injection (per-request):
+ *   The webhook handler normalises incoming HTTP headers and — when injection
+ *   is enabled — runs the SDK's transport.handleRequest(...) inside an
+ *   AsyncLocalStorage context populated from those headers. The connected
+ *   AutotaskAiTools node reads the override credentials from the same ALS
+ *   inside its tool's func() and routes Autotask API calls through them.
+ *
+ *   Important: ALS does NOT cross process boundaries. Running n8n in queue
+ *   mode (EXECUTIONS_MODE=queue) means the webhook process and the worker
+ *   process are different — the ALS context will be empty in the worker.
+ *   We warn at activation time when this combination is detected.
  */
 
 import type {
-	INodeType,
-	INodeTypeDescription,
-	IWebhookFunctions,
-	IWebhookResponseData,
+    INodeType,
+    INodeTypeDescription,
+    IWebhookFunctions,
+    IWebhookResponseData,
 } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
+import {
+    requestHeaderStore,
+} from './helpers/credential-store';
+import { normaliseIncomingHeaders } from './helpers/credential-proxy';
+import { AutotaskMcpServer, type N8nLikeTool } from './mcp-trigger/McpServer';
 
 const MCP_SSE_SETUP_PATH = 'sse';
 const MCP_SSE_MESSAGES_PATH = 'messages';
 
-export class AutotaskMcpTrigger implements INodeType {
-	description: INodeTypeDescription = {
-		displayName: 'Autotask MCP Trigger',
-		name: 'autotaskMcpTrigger',
-		icon: 'file:autotask.svg',
-		group: ['trigger'] as const,
-		version: [1, 1.1, 2],
-		description: 'Autotask MCP Trigger with per-user credential injection (spike stub)',
-		activationMessage:
-			'You can now connect your MCP Clients to the URL, using SSE or Streamable HTTP transports.',
-		defaults: {
-			name: 'Autotask MCP Trigger',
-		},
-		inputs: [
-			{
-				type: NodeConnectionTypes.AiTool,
-				displayName: 'Tools',
-			},
-		],
-		outputs: [],
-		credentials: [
-			{
-				name: 'autotaskApi',
-				required: false,
-				displayOptions: {
-					show: {
-						authentication: ['autotaskCredentials'],
-					},
-				},
-			},
-		],
-		properties: [
-			{
-				displayName: 'Authentication',
-				name: 'authentication',
-				type: 'options',
-				options: [
-					{ name: 'None', value: 'none' },
-					{ name: 'Autotask Credentials (Per-User)', value: 'autotaskCredentials' },
-				],
-				default: 'none',
-				description: 'The way to authenticate inbound MCP requests',
-			},
-			{
-				displayName: 'Path',
-				name: 'path',
-				type: 'string',
-				default: '',
-				placeholder: 'autotask-mcp',
-				required: true,
-				description: 'The base path for this Autotask MCP server',
-			},
-		],
-		webhooks: [
-			{
-				name: 'setup',
-				httpMethod: 'GET',
-				responseMode: 'onReceived',
-				isFullPath: true,
-				path: `={{$parameter["path"]}}{{parseFloat($nodeVersion)<2 ? '/${MCP_SSE_SETUP_PATH}' : ''}}`,
-			},
-			{
-				name: 'default',
-				httpMethod: 'POST',
-				responseMode: 'onReceived',
-				isFullPath: true,
-				path: `={{$parameter["path"]}}{{parseFloat($nodeVersion)<2 ? '/${MCP_SSE_MESSAGES_PATH}' : ''}}`,
-			},
-			{
-				name: 'default',
-				httpMethod: 'DELETE',
-				responseMode: 'onReceived',
-				isFullPath: true,
-				path: '={{$parameter["path"]}}',
-			},
-		],
-	};
+// ---------------------------------------------------------------------------
+// Module-scope SSE session map.
+//
+// SSE is a long-lived connection. When the client posts a message we need to
+// route it back to the open transport for the same session. The transport's
+// own session ID is used as the map key.
+//
+// Streamable HTTP (v2+) does NOT need this — each request is stateless from
+// the n8n webhook perspective (the MCP SDK transport handles its own
+// streaming response on the same request).
+// ---------------------------------------------------------------------------
+const sseSessions = new Map<string, any>();
 
-	/**
-	 * Stub webhook handler.
-	 *
-	 * TODO (subsequent tasks): Replace this with full McpServer delegation + ALS injection.
-	 *
-	 * The production implementation will:
-	 *   1. Extract per-request Autotask credentials from the HTTP Authorization header (or
-	 *      query param) and validate them.
-	 *   2. Inject those credentials into an AsyncLocalStorage store so that downstream
-	 *      EntityValueHelper / CacheService calls use the caller's credential identity rather
-	 *      than the workflow-owner's stored credential.
-	 *   3. Delegate to McpServer (imported at runtime via require to avoid module-resolution
-	 *      issues) for the actual SSE / Streamable HTTP transport handling.
-	 */
-	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
-		const resp = this.getResponseObject();
-		resp.status(501).json({
-			error: 'AutotaskMcpTrigger spike stub — not yet implemented',
-			message: 'Per-user credential injection will be implemented in subsequent tasks.',
-		});
-		return { noWebhookResponse: true };
-	}
+export class AutotaskMcpTrigger implements INodeType {
+    description: INodeTypeDescription = {
+        displayName: 'Autotask MCP Trigger',
+        name: 'autotaskMcpTrigger',
+        icon: 'file:autotask.svg',
+        group: ['trigger'] as const,
+        version: [1, 1.1, 2],
+        description: 'Autotask MCP Trigger with optional per-user credential injection from X-Autotask-* headers',
+        subtitle: '={{$parameter["path"] ? "/" + $parameter["path"] : "MCP"}}',
+        activationMessage:
+            'You can now connect your MCP Clients to the URL, using SSE or Streamable HTTP transports.',
+        defaults: {
+            name: 'Autotask MCP Trigger',
+        },
+        inputs: [
+            {
+                type: NodeConnectionTypes.AiTool,
+                displayName: 'Tools',
+            },
+        ],
+        outputs: [],
+        credentials: [
+            {
+                name: 'autotaskApi',
+                required: false,
+                displayOptions: {
+                    show: {
+                        authentication: ['autotaskCredentials'],
+                    },
+                },
+            },
+        ],
+        properties: [
+            {
+                displayName: 'Authentication',
+                name: 'authentication',
+                type: 'options',
+                options: [
+                    { name: 'None', value: 'none' },
+                    { name: 'Autotask Credentials (Per-User)', value: 'autotaskCredentials' },
+                ],
+                default: 'none',
+                description: 'The way to authenticate inbound MCP requests',
+            },
+            {
+                displayName: 'Path',
+                name: 'path',
+                type: 'string',
+                default: '',
+                placeholder: 'autotask-mcp',
+                required: true,
+                description: 'The base path for this Autotask MCP server',
+            },
+            {
+                displayName: 'Inject Autotask Credentials',
+                name: 'injectAutotaskCredentials',
+                type: 'boolean',
+                default: false,
+                description: 'Whether to extract Autotask credentials from incoming X-Autotask-* HTTP headers and inject them into tool calls. Requires the connected AutotaskAiTools node to have "Accept Injected Credentials" enabled. NOT supported in queue mode.',
+                noDataExpression: true,
+            },
+        ],
+        webhooks: [
+            {
+                name: 'setup',
+                httpMethod: 'GET',
+                responseMode: 'onReceived',
+                isFullPath: true,
+                path: `={{$parameter["path"]}}{{parseFloat($nodeVersion)<2 ? '/${MCP_SSE_SETUP_PATH}' : ''}}`,
+            },
+            {
+                name: 'default',
+                httpMethod: 'POST',
+                responseMode: 'onReceived',
+                isFullPath: true,
+                path: `={{$parameter["path"]}}{{parseFloat($nodeVersion)<2 ? '/${MCP_SSE_MESSAGES_PATH}' : ''}}`,
+            },
+            {
+                name: 'default',
+                httpMethod: 'DELETE',
+                responseMode: 'onReceived',
+                isFullPath: true,
+                path: '={{$parameter["path"]}}',
+            },
+        ],
+    };
+
+    async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+        const req = this.getRequestObject();
+        const res = this.getResponseObject();
+        const webhookName = this.getWebhookName();
+        const nodeVersion = this.getNode().typeVersion ?? 1;
+        const isSseTransport = nodeVersion < 2;
+
+        const injectAutotaskCredentials = this.getNodeParameter(
+            'injectAutotaskCredentials',
+            false,
+        ) as boolean;
+
+        // Queue-mode incompatibility check (runtime warning, not a hard fail —
+        // operators can still use the node without injection).
+        if (injectAutotaskCredentials && process.env.EXECUTIONS_MODE === 'queue') {
+            console.warn(
+                '[AutotaskMcpTrigger] "Inject Autotask Credentials" is enabled but n8n is running in queue mode. ' +
+                'AsyncLocalStorage cannot cross process boundaries — injection will not work in workers.',
+            );
+        }
+
+        // Normalise headers once, then propagate via ALS.
+        const normalisedHeaders = normaliseIncomingHeaders(req.headers);
+
+        // Fetch the connected AI tools. supplyData() runs on each AutotaskAiTools
+        // node and returns its DynamicStructuredTool. We treat the result as an
+        // array of objects with name/description/schema/invoke (the n8n public
+        // shape of supplied tools).
+        let tools: N8nLikeTool[] = [];
+        try {
+            const supplied = await this.getInputConnectionData(NodeConnectionTypes.AiTool, 0);
+            if (Array.isArray(supplied)) {
+                tools = supplied as N8nLikeTool[];
+            } else if (supplied && typeof supplied === 'object') {
+                tools = [supplied as N8nLikeTool];
+            }
+        } catch (err) {
+            console.warn(
+                '[AutotaskMcpTrigger] Failed to fetch AI tools from input connection: ' +
+                (err instanceof Error ? err.message : String(err)),
+            );
+        }
+
+        // If injection is enabled and the client actually sent a username header,
+        // verify each connected AutotaskAiTools node has acceptInjectedCredentials
+        // enabled. We can only inspect node parameters via getChildNodes(); the
+        // tools array itself does not expose the source node parameters.
+        if (
+            injectAutotaskCredentials &&
+            typeof normalisedHeaders['x-autotask-username'] === 'string'
+        ) {
+            try {
+                const children = this.getChildNodes(this.getNode().name, {
+                    includeNodeParameters: true,
+                }) as Array<{ name?: string; type?: string; parameters?: Record<string, unknown> }>;
+                const autotaskAiTools = children.filter((c) => c.type === 'n8n-nodes-autotask.autotaskAiTools');
+                const rejecting = autotaskAiTools.filter(
+                    (c) => !(c.parameters && c.parameters['acceptInjectedCredentials'] === true),
+                );
+                if (rejecting.length > 0) {
+                    console.warn(
+                        `[AutotaskMcpTrigger] X-Autotask-* headers received but the following connected AutotaskAiTools node(s) ` +
+                        `do not have "Accept Injected Credentials" enabled — those tools will continue using the workflow-owner credentials: ` +
+                        `${rejecting.map((n) => n.name ?? '(unnamed)').join(', ')}`,
+                    );
+                }
+            } catch {
+                // getChildNodes may be unavailable in some n8n contexts (older versions).
+                // This check is advisory only — do not fail the request.
+            }
+        }
+
+        // Build the MCP server. We use a per-request wrapper around helpers.httpRequest
+        // for the credential probe so the probe runs inside n8n's normal HTTP stack
+        // (proxy support, TLS config, etc.).
+        const helpers = this.helpers;
+        const httpRequestFn = async (opts: {
+            method: string;
+            url: string;
+            headers: Record<string, string>;
+        }) => {
+            return helpers.httpRequest({
+                method: opts.method as 'GET',
+                url: opts.url,
+                headers: opts.headers,
+            });
+        };
+
+        let mcpServer: AutotaskMcpServer;
+        try {
+            mcpServer = new AutotaskMcpServer({
+                serverInfo: { name: 'autotask-mcp-trigger', version: '1.0.0' },
+                tools,
+                injectAutotaskCredentials,
+                httpRequest: httpRequestFn,
+            });
+        } catch (err) {
+            console.error(
+                '[AutotaskMcpTrigger] Failed to initialise MCP server: ' +
+                (err instanceof Error ? err.message : String(err)),
+            );
+            res.status(500).json({
+                error: 'AutotaskMcpTrigger: MCP SDK unavailable. n8n must be running with @modelcontextprotocol/sdk available.',
+            });
+            return { noWebhookResponse: true };
+        }
+
+        // ---------------------------------------------------------------------
+        // Dispatch by webhook + version.
+        // ---------------------------------------------------------------------
+
+        try {
+            if (isSseTransport) {
+                if (webhookName === 'setup' && req.method === 'GET') {
+                    // SSE setup — open a long-lived connection.
+                    const basePath = this.getNodeParameter('path', '') as string;
+                    const messageEndpoint = `/${basePath.replace(/^\/+/, '').replace(/\/+$/, '')}/${MCP_SSE_MESSAGES_PATH}`;
+                    await requestHeaderStore.run(normalisedHeaders, async () => {
+                        const transport = await mcpServer.openSseConnection(messageEndpoint, res);
+                        const sessionId = transport.sessionId as string | undefined;
+                        if (sessionId) {
+                            sseSessions.set(sessionId, transport);
+                            const cleanup = () => sseSessions.delete(sessionId);
+                            transport.onclose = cleanup;
+                            res.on('close', cleanup);
+                        }
+                    });
+                    return { noWebhookResponse: true };
+                }
+
+                if (webhookName === 'default' && req.method === 'POST') {
+                    // SSE message — route to the existing transport.
+                    const sessionId = (req.query?.sessionId as string | undefined) ?? '';
+                    const transport = sessionId ? sseSessions.get(sessionId) : undefined;
+                    if (!transport) {
+                        res.status(404).json({ error: 'No active SSE session for sessionId' });
+                        return { noWebhookResponse: true };
+                    }
+                    await requestHeaderStore.run(normalisedHeaders, async () => {
+                        await mcpServer.handleSsePostMessage(transport, req, res, (req as { body?: unknown }).body);
+                    });
+                    return { noWebhookResponse: true };
+                }
+
+                if (req.method === 'DELETE') {
+                    const sessionId = (req.query?.sessionId as string | undefined) ?? '';
+                    if (sessionId && sseSessions.has(sessionId)) {
+                        const transport = sseSessions.get(sessionId);
+                        try { await transport.close?.(); } catch { /* ignore */ }
+                        sseSessions.delete(sessionId);
+                    }
+                    res.status(204).end();
+                    return { noWebhookResponse: true };
+                }
+
+                res.status(405).json({ error: `Method ${req.method} not allowed for SSE transport` });
+                return { noWebhookResponse: true };
+            }
+
+            // ---- Streamable HTTP (v2+) ----
+            await requestHeaderStore.run(normalisedHeaders, async () => {
+                await mcpServer.handleStreamableHttpRequest(req, res, (req as { body?: unknown }).body);
+            });
+            return { noWebhookResponse: true };
+        } catch (err) {
+            console.error(
+                '[AutotaskMcpTrigger] webhook handler error: ' +
+                (err instanceof Error ? err.stack ?? err.message : String(err)),
+            );
+            if (!res.headersSent) {
+                res.status(500).json({
+                    error: 'AutotaskMcpTrigger: internal error',
+                    message: err instanceof Error ? err.message : String(err),
+                });
+            }
+            return { noWebhookResponse: true };
+        }
+    }
 }

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -55,7 +55,7 @@ const MCP_SSE_MESSAGES_PATH = 'messages';
 // the n8n webhook perspective (the MCP SDK transport handles its own
 // streaming response on the same request).
 // ---------------------------------------------------------------------------
-const sseSessions = new Map<string, any>();
+const sseSessions = new Map<string, { transport: any; server: any }>();
 
 export class AutotaskMcpTrigger implements INodeType {
     description: INodeTypeDescription = {
@@ -262,11 +262,14 @@ export class AutotaskMcpTrigger implements INodeType {
                     const basePath = this.getNodeParameter('path', '') as string;
                     const messageEndpoint = `/${basePath.replace(/^\/+/, '').replace(/\/+$/, '')}/${MCP_SSE_MESSAGES_PATH}`;
                     await requestHeaderStore.run(normalisedHeaders, async () => {
-                        const transport = await mcpServer.openSseConnection(messageEndpoint, res);
+                        const { transport, server } = await mcpServer.openSseConnection(messageEndpoint, res);
                         const sessionId = transport.sessionId as string | undefined;
                         if (sessionId) {
-                            sseSessions.set(sessionId, transport);
-                            const cleanup = () => sseSessions.delete(sessionId);
+                            sseSessions.set(sessionId, { transport, server });
+                            const cleanup = async () => {
+                                sseSessions.delete(sessionId);
+                                try { await server.close?.(); } catch { /* ignore */ }
+                            };
                             transport.onclose = cleanup;
                             res.on('close', cleanup);
                         }
@@ -277,13 +280,13 @@ export class AutotaskMcpTrigger implements INodeType {
                 if (webhookName === 'default' && req.method === 'POST') {
                     // SSE message — route to the existing transport.
                     const sessionId = (req.query?.sessionId as string | undefined) ?? '';
-                    const transport = sessionId ? sseSessions.get(sessionId) : undefined;
-                    if (!transport) {
+                    const session = sessionId ? sseSessions.get(sessionId) : undefined;
+                    if (!session) {
                         res.status(404).json({ error: 'No active SSE session for sessionId' });
                         return { noWebhookResponse: true };
                     }
                     await requestHeaderStore.run(normalisedHeaders, async () => {
-                        await mcpServer.handleSsePostMessage(transport, req, res, (req as { body?: unknown }).body);
+                        await mcpServer.handleSsePostMessage(session.transport, req, res, (req as { body?: unknown }).body);
                     });
                     return { noWebhookResponse: true };
                 }
@@ -291,8 +294,9 @@ export class AutotaskMcpTrigger implements INodeType {
                 if (req.method === 'DELETE') {
                     const sessionId = (req.query?.sessionId as string | undefined) ?? '';
                     if (sessionId && sseSessions.has(sessionId)) {
-                        const transport = sseSessions.get(sessionId);
+                        const { transport, server } = sseSessions.get(sessionId)!;
                         try { await transport.close?.(); } catch { /* ignore */ }
+                        try { await server.close?.(); } catch { /* ignore */ }
                         sseSessions.delete(sessionId);
                     }
                     res.status(204).end();

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -284,16 +284,26 @@ export class AutotaskMcpTrigger implements INodeType {
                     (c) => !(c.parameters && c.parameters['acceptInjectedCredentials'] === true),
                 );
                 if (rejecting.length > 0) {
-                    // Injection is opt-in per tool node. Tools without acceptInjectedCredentials=true
-                    // intentionally fall through to the workflow-owner credentials — this lets operators
-                    // mix injected-credential tools with fixed-credential tools in the same workflow.
-                    // If you want all tools to enforce injection, enable acceptInjectedCredentials on each node.
+                    const names = rejecting.map((n) => n.name ?? '(unnamed)').join(', ');
+                    if (authentication === 'autotaskCredentials') {
+                        // Hard reject: caller passed the auth gate with their Autotask credentials,
+                        // but these tool nodes would silently fall back to the workflow-owner credential.
+                        // That is a privilege-escalation path — fail closed.
+                        res.status(403).json({
+                            error: 'Workflow misconfiguration: the following connected AutotaskAiTools node(s) do not have ' +
+                                '"Accept Injected Credentials" enabled. When per-user authentication is active, all connected ' +
+                                'tool nodes must opt in — otherwise callers run tools under the workflow-owner credential. ' +
+                                `Enable "Accept Injected Credentials" on: ${names}`,
+                        });
+                        return { noWebhookResponse: true };
+                    }
+                    // Injection-only mode (no auth gate): warn. Caller is already using the workflow-owner
+                    // credential context; the fall-through is a usability issue, not a security regression.
                     console.warn(
                         `[AutotaskMcpTrigger] X-Autotask-* headers received but the following connected AutotaskAiTools node(s) ` +
                         `do not have "Accept Injected Credentials" enabled — those tools will use the workflow-owner credentials, ` +
                         `not the caller's injected credentials. Enable "Accept Injected Credentials" on those nodes if injection ` +
-                        `should be enforced end-to-end: ` +
-                        `${rejecting.map((n) => n.name ?? '(unnamed)').join(', ')}`,
+                        `should be enforced end-to-end: ${names}`,
                     );
                 }
             } catch {

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -315,8 +315,14 @@ export class AutotaskMcpTrigger implements INodeType {
             if (isSseTransport) {
                 if (webhookName === 'setup' && req.method === 'GET') {
                     // SSE setup — open a long-lived connection.
-                    const basePath = this.getNodeParameter('path', '') as string;
-                    const messageEndpoint = `/${basePath.replace(/^\/+/, '').replace(/\/+$/, '')}/${MCP_SSE_MESSAGES_PATH}`;
+                    // Derive messageEndpoint from the actual incoming request path so that
+                    // any n8n webhook prefix or reverse-proxy prefix is preserved in the
+                    // `event: endpoint` value sent to clients. Building it from the raw
+                    // node parameter loses those prefixes and clients would POST to the wrong URL.
+                    const incomingPath = (req.url ?? '').split('?')[0];
+                    const messageEndpoint = incomingPath.endsWith(`/${MCP_SSE_SETUP_PATH}`)
+                        ? incomingPath.slice(0, -MCP_SSE_SETUP_PATH.length) + MCP_SSE_MESSAGES_PATH
+                        : `/${(this.getNodeParameter('path', '') as string).replace(/^\/+/, '').replace(/\/+$/, '')}/${MCP_SSE_MESSAGES_PATH}`;
                     await requestHeaderStore.run(normalisedHeaders, async () => {
                         const { transport, server } = await mcpServer.openSseConnection(messageEndpoint, res);
                         const sessionId = transport.sessionId as string | undefined;

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -180,22 +180,78 @@ export class AutotaskMcpTrigger implements INodeType {
         // trigger instances with different paths cannot share session entries.
         const nodeId = this.getNode().id;
 
-        // Queue-mode incompatibility check (runtime warning, not a hard fail —
-        // operators can still use the node without injection).
-        if (effectiveInjectCredentials && process.env.EXECUTIONS_MODE === 'queue') {
-            console.warn(
-                '[AutotaskMcpTrigger] "Inject Autotask Credentials" is enabled but n8n is running in queue mode. ' +
-                'AsyncLocalStorage cannot cross process boundaries — injection will not work in workers.',
-            );
-        }
-
-        // Normalise headers once, then propagate via ALS.
+        // Normalise headers once — needed for auth gate which must run before tool loading.
         const normalisedHeaders = normaliseIncomingHeaders(req.headers);
 
+        // Build httpRequestFn early — needed by the auth probe below.
+        const helpers = this.helpers;
+        const httpRequestFn = async (opts: {
+            method: string;
+            url: string;
+            headers: Record<string, string>;
+        }) => {
+            return helpers.httpRequest({
+                method: opts.method as 'GET',
+                url: opts.url,
+                headers: opts.headers,
+            });
+        };
+
+        // Queue-mode check. In queue mode ALS cannot cross process boundaries so
+        // injected credentials are silently unavailable in workers.
+        // - With authentication='autotaskCredentials': reject hard (503) — the caller's
+        //   credentials would pass the auth gate but tool calls would run under the
+        //   workflow-owner credential, breaking per-caller isolation.
+        // - With injection-only (no auth gate): warn only — tools fall back to
+        //   workflow-owner creds, which is a usability issue but not a security regression.
+        if (process.env.EXECUTIONS_MODE === 'queue') {
+            if (authentication === 'autotaskCredentials') {
+                res.status(503).json({
+                    error: 'Per-user Autotask credential authentication is not supported in queue mode. ' +
+                        'AsyncLocalStorage cannot cross process boundaries — injected credentials would ' +
+                        'be unavailable in workers, causing tool calls to run under the workflow-owner credential. ' +
+                        'Switch n8n to regular (non-queue) mode or disable per-user authentication on this trigger.',
+                });
+                return { noWebhookResponse: true };
+            }
+            if (effectiveInjectCredentials) {
+                console.warn(
+                    '[AutotaskMcpTrigger] "Inject Autotask Credentials" is enabled but n8n is running in queue mode. ' +
+                    'AsyncLocalStorage cannot cross process boundaries — injection will not work in workers.',
+                );
+            }
+        }
+
+        // Enforce webhook-level authentication BEFORE loading connected tools.
+        // Loading tools triggers supplyData() on each AutotaskAiTools node, which
+        // can include Autotask API metadata calls — unauthenticated callers must not
+        // consume that quota or cause that work.
+        if (authentication === 'autotaskCredentials') {
+            const parsed = parseAndValidateHeaders(normalisedHeaders);
+            if (parsed.type === 'none') {
+                res.status(401).json({ error: 'Authentication required: X-Autotask-Username, X-Autotask-Secret, X-Autotask-IntegrationCode, and X-Autotask-Zone headers are required.' });
+                return { noWebhookResponse: true };
+            }
+            if (parsed.type === 'error') {
+                res.status(401).json({ error: `Authentication failed: ${parsed.message}` });
+                return { noWebhookResponse: true };
+            }
+            // Probe the credentials — returns true on network errors (fail-open).
+            let probeOk = true;
+            try {
+                probeOk = await probeCredentials(parsed.creds, httpRequestFn);
+            } catch {
+                probeOk = true;
+            }
+            if (!probeOk) {
+                res.status(401).json({ error: 'Authentication failed: Autotask rejected the provided credentials (401/403). Verify X-Autotask-* header values.' });
+                return { noWebhookResponse: true };
+            }
+        }
+
         // Fetch the connected AI tools. supplyData() runs on each AutotaskAiTools
-        // node and returns its DynamicStructuredTool. We treat the result as an
-        // array of objects with name/description/schema/invoke (the n8n public
-        // shape of supplied tools).
+        // node and returns its DynamicStructuredTool. This happens AFTER the auth gate
+        // so unauthenticated callers do not trigger API/metadata work.
         let tools: N8nLikeTool[] = [];
         try {
             const supplied = await this.getInputConnectionData(NodeConnectionTypes.AiTool, 0);
@@ -243,48 +299,6 @@ export class AutotaskMcpTrigger implements INodeType {
             } catch {
                 // getChildNodes may be unavailable in some n8n contexts (older versions).
                 // This check is advisory only — do not fail the request.
-            }
-        }
-
-        // Build the MCP server. We use a per-request wrapper around helpers.httpRequest
-        // for the credential probe so the probe runs inside n8n's normal HTTP stack
-        // (proxy support, TLS config, etc.).
-        const helpers = this.helpers;
-        const httpRequestFn = async (opts: {
-            method: string;
-            url: string;
-            headers: Record<string, string>;
-        }) => {
-            return helpers.httpRequest({
-                method: opts.method as 'GET',
-                url: opts.url,
-                headers: opts.headers,
-            });
-        };
-
-        // Enforce webhook-level authentication before any MCP processing.
-        // When authentication='autotaskCredentials', the caller MUST provide valid
-        // X-Autotask-* headers — absent or invalid headers are rejected with 401.
-        if (authentication === 'autotaskCredentials') {
-            const parsed = parseAndValidateHeaders(normalisedHeaders);
-            if (parsed.type === 'none') {
-                res.status(401).json({ error: 'Authentication required: X-Autotask-Username, X-Autotask-Secret, X-Autotask-IntegrationCode, and X-Autotask-Zone headers are required.' });
-                return { noWebhookResponse: true };
-            }
-            if (parsed.type === 'error') {
-                res.status(401).json({ error: `Authentication failed: ${parsed.message}` });
-                return { noWebhookResponse: true };
-            }
-            // Probe the credentials — returns true on network errors (fail-open).
-            let probeOk = true;
-            try {
-                probeOk = await probeCredentials(parsed.creds, httpRequestFn);
-            } catch {
-                probeOk = true;
-            }
-            if (!probeOk) {
-                res.status(401).json({ error: 'Authentication failed: Autotask rejected the provided credentials (401/403). Verify X-Autotask-* header values.' });
-                return { noWebhookResponse: true };
             }
         }
 

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -59,7 +59,9 @@ const MAX_SSE_SESSIONS = 256;
 const sseSessions = new Map<string, { transport: any; server: any }>();
 
 async function evictOldestSseSession(): Promise<void> {
-    const [oldestId, oldest] = sseSessions.entries().next().value as [string, { transport: any; server: any }];
+    const entry = sseSessions.entries().next().value as [string, { transport: any; server: any }] | undefined;
+    if (!entry) return;
+    const [oldestId, oldest] = entry;
     sseSessions.delete(oldestId);
     try { await oldest.transport?.close?.(); } catch { /* ignore */ }
     try { await oldest.server?.close?.(); } catch { /* ignore */ }
@@ -212,9 +214,15 @@ export class AutotaskMcpTrigger implements INodeType {
                     (c) => !(c.parameters && c.parameters['acceptInjectedCredentials'] === true),
                 );
                 if (rejecting.length > 0) {
+                    // Injection is opt-in per tool node. Tools without acceptInjectedCredentials=true
+                    // intentionally fall through to the workflow-owner credentials — this lets operators
+                    // mix injected-credential tools with fixed-credential tools in the same workflow.
+                    // If you want all tools to enforce injection, enable acceptInjectedCredentials on each node.
                     console.warn(
                         `[AutotaskMcpTrigger] X-Autotask-* headers received but the following connected AutotaskAiTools node(s) ` +
-                        `do not have "Accept Injected Credentials" enabled — those tools will continue using the workflow-owner credentials: ` +
+                        `do not have "Accept Injected Credentials" enabled — those tools will use the workflow-owner credentials, ` +
+                        `not the caller's injected credentials. Enable "Accept Injected Credentials" on those nodes if injection ` +
+                        `should be enforced end-to-end: ` +
                         `${rejecting.map((n) => n.name ?? '(unnamed)').join(', ')}`,
                     );
                 }

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -269,17 +269,18 @@ export class AutotaskMcpTrigger implements INodeType {
 
         // If injection is enabled and the client actually sent a username header,
         // verify each connected AutotaskAiTools node has acceptInjectedCredentials
-        // enabled. We can only inspect node parameters via getChildNodes(); the
-        // tools array itself does not expose the source node parameters.
+        // enabled. AutotaskAiTools nodes connect to the trigger's AiTool INPUT, making
+        // them parent nodes — getParentNodes() is the correct direction, not getChildNodes().
         if (
             effectiveInjectCredentials &&
             typeof normalisedHeaders['x-autotask-username'] === 'string'
         ) {
             try {
-                const children = this.getChildNodes(this.getNode().name, {
+                const parents = this.getParentNodes(this.getNode().name, {
                     includeNodeParameters: true,
+                    connectionType: NodeConnectionTypes.AiTool,
                 }) as Array<{ name?: string; type?: string; parameters?: Record<string, unknown> }>;
-                const autotaskAiTools = children.filter((c) => c.type === 'n8n-nodes-autotask.autotaskAiTools');
+                const autotaskAiTools = parents.filter((c) => c.type === 'n8n-nodes-autotask.autotaskAiTools');
                 const rejecting = autotaskAiTools.filter(
                     (c) => !(c.parameters && c.parameters['acceptInjectedCredentials'] === true),
                 );
@@ -307,7 +308,7 @@ export class AutotaskMcpTrigger implements INodeType {
                     );
                 }
             } catch {
-                // getChildNodes may be unavailable in some n8n contexts (older versions).
+                // getParentNodes may be unavailable in some n8n contexts (older versions).
                 // This check is advisory only — do not fail the request.
             }
         }

--- a/nodes/Autotask/AutotaskMcpTrigger.node.ts
+++ b/nodes/Autotask/AutotaskMcpTrigger.node.ts
@@ -209,6 +209,20 @@ export class AutotaskMcpTrigger implements INodeType {
                 res.status(404).json({ error: 'No active SSE session for sessionId' });
                 return { noWebhookResponse: true };
             }
+            // Enforce header-level auth on SSE POST when configured, so unauthenticated
+            // clients cannot reach tools/list or initialize on an open session.
+            // Full credential probe happens inside McpServer.setupHandlers per tools/call.
+            if (authentication === 'autotaskCredentials') {
+                const parsed = parseAndValidateHeaders(normalisedHeaders);
+                if (parsed.type === 'none') {
+                    res.status(401).json({ error: 'Authentication required: X-Autotask-Username, X-Autotask-Secret, X-Autotask-IntegrationCode, and X-Autotask-Zone headers are required.' });
+                    return { noWebhookResponse: true };
+                }
+                if (parsed.type === 'error') {
+                    res.status(401).json({ error: `Authentication failed: ${parsed.message}` });
+                    return { noWebhookResponse: true };
+                }
+            }
             await requestHeaderStore.run(normalisedHeaders, async () => {
                 await session.transport.handlePostMessage(req, res, (req as { body?: unknown }).body);
             });

--- a/nodes/Autotask/ai-tools/debug-trace.ts
+++ b/nodes/Autotask/ai-tools/debug-trace.ts
@@ -1,6 +1,8 @@
 import { mkdir, appendFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import type { FieldMeta } from '../helpers/aiHelper';
+import { autotaskCredentialStore } from '../helpers/credential-store';
+import { createOverrideScrubber } from '../helpers/security/credential-masking';
 
 /** Matches Autotask API credential default `cacheDirectory` (`./cache/autotask`). */
 const DEFAULT_DEBUG_LOG_DIR = resolve(process.cwd(), 'cache', 'autotask');
@@ -52,7 +54,10 @@ export interface AiTraceEvent {
 export function writeAiTrace(event: Omit<AiTraceEvent, 'ts'>): void {
 	if (!AI_TOOL_DEBUG_ENABLED) return;
 	try {
-		const line = `${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`;
+		const overrideCreds = autotaskCredentialStore.getStore();
+		const scrub = createOverrideScrubber(overrideCreds);
+		const rawLine = `${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`;
+		const line = scrub(rawLine);
 		const filePath = getAiToolDebugFilePath();
 		mkdir(dirname(filePath), { recursive: true })
 			.then(() => appendFile(filePath, line, 'utf8'))

--- a/nodes/Autotask/helpers/credential-proxy.ts
+++ b/nodes/Autotask/helpers/credential-proxy.ts
@@ -1,5 +1,5 @@
 import type { IncomingHttpHeaders } from 'node:http';
-import type { ISupplyDataFunctions, ICredentialDataDecryptedObject } from 'n8n-workflow';
+import type { ISupplyDataFunctions } from 'n8n-workflow';
 import { normaliseZone, type OverrideAutotaskCredentials } from './credential-store';
 
 // Zone URL must be HTTPS and match known Autotask domain patterns.
@@ -71,31 +71,28 @@ export function parseAndValidateHeaders(headers: Record<string, string | undefin
     };
 }
 
-export function mapToN8nCredentialShape(
-    override: Readonly<OverrideAutotaskCredentials>,
-): ICredentialDataDecryptedObject {
-    return Object.freeze({
-        Username: override.Username,
-        Secret: override.Secret,
-        APIIntegrationcode: override.APIIntegrationcode,
-        zone: override.zone,
-    }) as unknown as ICredentialDataDecryptedObject;
-}
-
 export function buildCredentialProxy(
     context: ISupplyDataFunctions,
     override: Readonly<OverrideAutotaskCredentials>,
 ): ISupplyDataFunctions {
-    const credShape = mapToN8nCredentialShape(override);
     return new Proxy(context, {
         get(target, prop, _receiver) {
             if (prop === 'getCredentials') {
-                // Forward all arguments (including itemIndex) to preserve n8n's per-item credential semantics.
                 // Override only 'autotaskApi'; delegate all other credential names to the original context.
-                return (...args: Parameters<typeof target.getCredentials>) =>
-                    args[0] === 'autotaskApi'
-                        ? Promise.resolve(credShape)
-                        : target.getCredentials(...args);
+                // For 'autotaskApi': merge override auth fields into the original credentials so that
+                // non-auth settings (cacheEnabled, cacheTTL, etc.) continue to work under injection.
+                return (...args: Parameters<typeof target.getCredentials>) => {
+                    if (args[0] !== 'autotaskApi') return target.getCredentials(...args);
+                    return target.getCredentials('autotaskApi', args[1]).then(
+                        (originalCreds) => Object.freeze({
+                            ...originalCreds,
+                            Username: override.Username,
+                            Secret: override.Secret,
+                            APIIntegrationcode: override.APIIntegrationcode,
+                            zone: override.zone,
+                        }),
+                    );
+                };
             }
             // Bind to target (not proxy) to preserve this-binding for class methods with private fields.
             const value = Reflect.get(target, prop, target);

--- a/nodes/Autotask/helpers/credential-proxy.ts
+++ b/nodes/Autotask/helpers/credential-proxy.ts
@@ -1,0 +1,105 @@
+import type { IncomingHttpHeaders } from 'node:http';
+import type { ISupplyDataFunctions, ICredentialDataDecryptedObject } from 'n8n-workflow';
+import { normaliseZone, type OverrideAutotaskCredentials } from './credential-store';
+
+// Zone URL must be HTTPS and match known Autotask domain patterns.
+const ZONE_ALLOWLIST = /^https:\/\/webservices\d+\.autotask\.(net|com|com\.au|co\.uk)\/atservicesrest$/i;
+
+// Reject control characters (0x00-0x1F, 0x7F DEL); max 1024 chars. Unicode allowed.
+// Permits non-ASCII names (e.g. josé@example.com) and Unicode passwords while still
+// blocking header-injection vectors (CR/LF/NUL).
+const SAFE_HEADER_VALUE = /^[^\x00-\x1F\x7F]{1,1024}$/;
+
+const HEADER_NAMES = [
+    'x-autotask-username',
+    'x-autotask-secret',
+    'x-autotask-integrationcode',
+    'x-autotask-zone',
+] as const;
+
+export type HeaderParseResult =
+    | { type: 'none' }
+    | { type: 'ok'; creds: Readonly<OverrideAutotaskCredentials> }
+    | { type: 'error'; message: string };
+
+/**
+ * Normalise raw Node HTTP IncomingHttpHeaders into a lowercase `Record<string,string>`.
+ * - Lowercases all keys (HTTP headers are case-insensitive).
+ * - Collapses array values (e.g. duplicate Set-Cookie style) by taking the first entry.
+ * - Skips undefined values.
+ */
+export function normaliseIncomingHeaders(raw: IncomingHttpHeaders): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(raw)) {
+        if (v === undefined) continue;
+        out[k.toLowerCase()] = Array.isArray(v) ? v[0] : v;
+    }
+    return out;
+}
+
+export function parseAndValidateHeaders(headers: Record<string, string | undefined>): HeaderParseResult {
+    const values = HEADER_NAMES.map(h => headers[h]);
+    const presentCount = values.filter(Boolean).length;
+
+    if (presentCount === 0) return { type: 'none' };
+    if (presentCount < HEADER_NAMES.length) {
+        const missing = HEADER_NAMES.filter(h => !headers[h]).join(', ');
+        return { type: 'error', message: `Missing required X-Autotask-* headers: ${missing}` };
+    }
+
+    const [username, secret, integrationCode, zoneRaw] = values as [string, string, string, string];
+
+    for (const [header, value] of [
+        ['x-autotask-username', username],
+        ['x-autotask-secret', secret],
+        ['x-autotask-integrationcode', integrationCode],
+        ['x-autotask-zone', zoneRaw],
+    ] as const) {
+        if (!SAFE_HEADER_VALUE.test(value)) {
+            return { type: 'error', message: `Invalid characters or length in ${header}` };
+        }
+    }
+
+    const zone = normaliseZone(zoneRaw);
+    if (!ZONE_ALLOWLIST.test(zone)) {
+        return { type: 'error', message: `Invalid X-Autotask-Zone value: must be https://webservicesN.autotask.(net|com|com.au|co.uk)/atservicesrest` };
+    }
+
+    return {
+        type: 'ok',
+        creds: Object.freeze({ Username: username, Secret: secret, APIIntegrationcode: integrationCode, zone }),
+    };
+}
+
+export function mapToN8nCredentialShape(
+    override: Readonly<OverrideAutotaskCredentials>,
+): ICredentialDataDecryptedObject {
+    return Object.freeze({
+        Username: override.Username,
+        Secret: override.Secret,
+        APIIntegrationcode: override.APIIntegrationcode,
+        zone: override.zone,
+    }) as unknown as ICredentialDataDecryptedObject;
+}
+
+export function buildCredentialProxy(
+    context: ISupplyDataFunctions,
+    override: Readonly<OverrideAutotaskCredentials>,
+): ISupplyDataFunctions {
+    const credShape = mapToN8nCredentialShape(override);
+    return new Proxy(context, {
+        get(target, prop, _receiver) {
+            if (prop === 'getCredentials') {
+                // Forward all arguments (including itemIndex) to preserve n8n's per-item credential semantics.
+                // Override only 'autotaskApi'; delegate all other credential names to the original context.
+                return (...args: Parameters<typeof target.getCredentials>) =>
+                    args[0] === 'autotaskApi'
+                        ? Promise.resolve(credShape)
+                        : target.getCredentials(...args);
+            }
+            // Bind to target (not proxy) to preserve this-binding for class methods with private fields.
+            const value = Reflect.get(target, prop, target);
+            return typeof value === 'function' ? value.bind(target) : value;
+        },
+    });
+}

--- a/nodes/Autotask/helpers/credential-store.ts
+++ b/nodes/Autotask/helpers/credential-store.ts
@@ -80,8 +80,12 @@ export function setProbeCache(identity: string, ok: boolean): void {
  * Do NOT call for fresh probe failures — probeCredentials() handles those.
  */
 export function invalidateProbeCache(identity: string): void {
+    const existed = probeCache.has(identity);
     probeCache.delete(identity);
-    setProbeCache(identity, false);
+    // Only re-insert negative entry if it was present; if it already expired, nothing to invalidate.
+    if (existed) {
+        probeCache.set(identity, { ok: false, expiresAt: Date.now() + PROBE_NEGATIVE_TTL_MS });
+    }
 }
 
 /**

--- a/nodes/Autotask/helpers/credential-store.ts
+++ b/nodes/Autotask/helpers/credential-store.ts
@@ -1,0 +1,134 @@
+// nodes/Autotask/helpers/credential-store.ts
+import { AsyncLocalStorage } from 'async_hooks';
+import { hashCachePayload } from './cache/service';
+
+export interface OverrideAutotaskCredentials {
+    readonly Username: string;
+    readonly Secret: string;
+    readonly APIIntegrationcode: string;
+    readonly zone: string; // always normalised: trailing slash stripped
+}
+
+// --- ALS: credentials ---
+// globalThis symbol guarantees singleton across require.cache invalidation and npm-link symlinks.
+const STORE_KEY = Symbol.for('n8n-nodes-autotask.credentialStore.v1');
+export const autotaskCredentialStore: AsyncLocalStorage<Readonly<OverrideAutotaskCredentials>> =
+    (globalThis as Record<symbol, unknown>)[STORE_KEY] as AsyncLocalStorage<Readonly<OverrideAutotaskCredentials>> ??
+    (() => {
+        const store = new AsyncLocalStorage<Readonly<OverrideAutotaskCredentials>>();
+        (globalThis as Record<symbol, unknown>)[STORE_KEY] = store;
+        return store;
+    })();
+
+// --- ALS: request headers ---
+// Separate ALS for the current HTTP request's headers. Necessary because
+// concurrent MCP requests share the same McpServer instance — a shared instance
+// property would race. Each `tools/call` runs inside its own ALS context.
+const HEADERS_STORE_KEY = Symbol.for('n8n-nodes-autotask.requestHeaderStore.v1');
+export const requestHeaderStore: AsyncLocalStorage<Record<string, string>> =
+    (globalThis as Record<symbol, unknown>)[HEADERS_STORE_KEY] as AsyncLocalStorage<Record<string, string>> ??
+    (() => {
+        const store = new AsyncLocalStorage<Record<string, string>>();
+        (globalThis as Record<symbol, unknown>)[HEADERS_STORE_KEY] = store;
+        return store;
+    })();
+
+export function normaliseZone(url: string): string {
+    return url.replace(/\/+$/, '');
+}
+
+// Includes Secret so two users sharing a username but with different passwords get distinct keys.
+export function probeCredentialIdentity(creds: Readonly<OverrideAutotaskCredentials>): string {
+    return hashCachePayload({
+        username: creds.Username,
+        integrationCode: creds.APIIntegrationcode,
+        secret: creds.Secret,
+        zone: normaliseZone(creds.zone),
+    }).slice(0, 16);
+}
+
+// --- Probe cache ---
+
+const PROBE_POSITIVE_TTL_MS = 60_000;
+const PROBE_NEGATIVE_TTL_MS = 5_000;
+const PROBE_MAX_ENTRIES = 256;
+
+interface ProbeCacheEntry { ok: boolean; expiresAt: number }
+const probeCache = new Map<string, ProbeCacheEntry>();
+const probeInFlight = new Map<string, Promise<boolean>>();
+
+export function getProbeCache(identity: string): boolean | undefined {
+    const entry = probeCache.get(identity);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) { probeCache.delete(identity); return undefined; }
+    return entry.ok;
+}
+
+export function setProbeCache(identity: string, ok: boolean): void {
+    if (probeCache.size >= PROBE_MAX_ENTRIES) {
+        // FIFO eviction: remove oldest-inserted entry when cap is reached.
+        const oldest = probeCache.keys().next().value;
+        if (oldest !== undefined) probeCache.delete(oldest);
+    }
+    probeCache.set(identity, { ok, expiresAt: Date.now() + (ok ? PROBE_POSITIVE_TTL_MS : PROBE_NEGATIVE_TTL_MS) });
+}
+
+/**
+ * Invalidate a positive probe cache entry and immediately insert a negative entry.
+ * Use ONLY for execution-time 401/403 events — when a previously-positive
+ * credential is rejected by Autotask during a real tool call.
+ * Do NOT call for fresh probe failures — probeCredentials() handles those.
+ */
+export function invalidateProbeCache(identity: string): void {
+    probeCache.delete(identity);
+    setProbeCache(identity, false);
+}
+
+/**
+ * Probes Autotask credentials. In-flight coalesces concurrent calls for the same identity.
+ * - true  = valid (2xx), cached positively for 60s
+ * - false = rejected (401/403), cached negatively for 5s
+ * - true  = network error — NOT cached, so next call retries
+ */
+export async function probeCredentials(
+    creds: Readonly<OverrideAutotaskCredentials>,
+    httpRequest: (opts: { method: string; url: string; headers: Record<string, string> }) => Promise<unknown>,
+): Promise<boolean> {
+    const identity = probeCredentialIdentity(creds);
+    const cached = getProbeCache(identity);
+    if (cached !== undefined) return cached;
+
+    const inFlight = probeInFlight.get(identity);
+    if (inFlight) return inFlight;
+
+    const promise = (async () => {
+        try {
+            await httpRequest({
+                method: 'GET',
+                url: `${normaliseZone(creds.zone)}/V1.0/Companies/entityInformation`,
+                headers: {
+                    ApiIntegrationcode: creds.APIIntegrationcode,
+                    UserName: creds.Username,
+                    Secret: creds.Secret,
+                },
+            });
+            setProbeCache(identity, true);
+            return true;
+        } catch (err: unknown) {
+            const status = (err as { response?: { status?: number }; statusCode?: number })?.response?.status
+                ?? (err as { statusCode?: number })?.statusCode
+                ?? 0;
+            if (status === 401 || status === 403) {
+                setProbeCache(identity, false);
+                return false;
+            }
+            // Network errors: do NOT cache — transient outage must not lock users out.
+            return true;
+        } finally {
+            probeInFlight.delete(identity);
+        }
+    })();
+
+    probeInFlight.set(identity, promise);
+    return promise;
+}

--- a/nodes/Autotask/helpers/http/initRateTracker.ts
+++ b/nodes/Autotask/helpers/http/initRateTracker.ts
@@ -1,6 +1,8 @@
 import type { IExecuteFunctions, IHookFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
 import { rateTracker } from './rateLimit';
 import { fetchThresholdInformation } from './request';
+import { autotaskCredentialStore } from '../credential-store';
+import { sanitizeErrorForLogging, createOverrideScrubber } from '../security/credential-masking';
 
 let lastInitTime = 0;
 const INIT_COOLDOWN_MS = 300_000; // 5 minutes
@@ -31,9 +33,10 @@ export async function initializeRateTracker(
 
 				return result;
 			} catch (error) {
-				// Import sanitization function to mask credentials in error logs
-				const { sanitizeErrorForLogging } = await import('../security/credential-masking');
-				console.error('[RateTracker] Error in threshold fetcher:', sanitizeErrorForLogging(error));
+				const scrub = createOverrideScrubber(autotaskCredentialStore.getStore());
+				const sanitized = sanitizeErrorForLogging(error);
+				if (typeof sanitized.message === 'string') sanitized.message = scrub(sanitized.message);
+				console.error('[RateTracker] Error in threshold fetcher:', sanitized);
 				return null;
 			}
 		});
@@ -41,7 +44,10 @@ export async function initializeRateTracker(
 		// Trigger an initial sync
 		await rateTracker.syncWithApi();
 	} catch (error) {
-		console.error('[RateTracker] Failed to initialize rate tracker:', error);
+		const scrub = createOverrideScrubber(autotaskCredentialStore.getStore());
+		const sanitized = sanitizeErrorForLogging(error);
+		if (typeof sanitized.message === 'string') sanitized.message = scrub(sanitized.message);
+		console.error('[RateTracker] Failed to initialize rate tracker:', sanitized);
 	}
 }
 

--- a/nodes/Autotask/helpers/http/rateLimit.ts
+++ b/nodes/Autotask/helpers/http/rateLimit.ts
@@ -200,9 +200,12 @@ class RequestRateTracker {
             }
         } catch (error) {
             this.debugLog('Threshold sync error:', error);
-            // Import sanitization function to mask credentials in error logs
-            const { sanitizeErrorForLogging } = await import('../security/credential-masking');
-            console.error('Failed to sync with Autotask API threshold information:', sanitizeErrorForLogging(error));
+            const { sanitizeErrorForLogging, createOverrideScrubber } = await import('../security/credential-masking');
+            const { autotaskCredentialStore } = await import('../credential-store');
+            const scrub = createOverrideScrubber(autotaskCredentialStore.getStore());
+            const sanitized = sanitizeErrorForLogging(error);
+            if (typeof sanitized.message === 'string') sanitized.message = scrub(sanitized.message);
+            console.error('Failed to sync with Autotask API threshold information:', sanitized);
             // Fall back to local tracking on error
         }
     }

--- a/nodes/Autotask/helpers/http/rateLimit.ts
+++ b/nodes/Autotask/helpers/http/rateLimit.ts
@@ -283,6 +283,8 @@ export async function handleRateLimit(maxWaitMs = 600000): Promise<void> {
         let totalWaitTime = 0;
 
         while (rateTracker.shouldThrottle() && totalWaitTime < maxWaitMs) {
+            // ALS context (autotaskCredentialStore) propagates through setTimeout on Node >=12.17 — safe.
+            // This project requires node >=18.10 (package.json engines), so ALS propagation is guaranteed.
             await new Promise(resolve => setTimeout(resolve, waitInterval));
             totalWaitTime += waitInterval;
 
@@ -309,6 +311,8 @@ export async function handleRateLimit(maxWaitMs = 600000): Promise<void> {
     const throttleDelay = rateTracker.getThrottleDuration();
     if (throttleDelay > 0) {
         console.debug(`[RateLimit] Applying throttle delay of ${throttleDelay}ms (usage: ${usagePercent.toFixed(1)}%)`);
+        // ALS context (autotaskCredentialStore) propagates through setTimeout on Node >=12.17 — safe.
+        // This project requires node >=18.10 (package.json engines), so ALS propagation is guaranteed.
         await new Promise(resolve => setTimeout(resolve, throttleDelay));
     }
 }

--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -20,7 +20,7 @@ import { handleRateLimit } from './rateLimit';
 import { endpointThreadTracker } from './threadLimit';
 import { executeWithRetry } from './retryHandler';
 import { autotaskCredentialStore } from '../credential-store';
-import { createOverrideScrubber } from '../security/credential-masking';
+import { createOverrideScrubber, sanitizeErrorForLogging } from '../security/credential-masking';
 
 interface IAutotaskSuccessResponse {
 	id?: number;
@@ -328,8 +328,6 @@ export async function fetchThresholdInformation(
 
 		return null;
 	} catch (error) {
-		// Import sanitization function to mask credentials in error logs
-		const { sanitizeErrorForLogging } = await import('../security/credential-masking');
 		const overrideCreds = autotaskCredentialStore.getStore();
 		const scrub = createOverrideScrubber(overrideCreds);
 		const sanitized = sanitizeErrorForLogging(error);
@@ -571,8 +569,6 @@ export async function autotaskApiRequest<T = JsonObject>(
 			description?: string;
 		};
 
-		// Import sanitization function to mask credentials in error logs
-		const { sanitizeErrorForLogging } = await import('../security/credential-masking');
 		const overrideCreds = autotaskCredentialStore.getStore();
 		const scrub = createOverrideScrubber(overrideCreds);
 		const sanitized = sanitizeErrorForLogging(apiError);

--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -583,7 +583,7 @@ export async function autotaskApiRequest<T = JsonObject>(
 
 		const status = apiError.response?.status;
 		const url = options.url;
-		console.warn(`API ${method} ${url} failed (${status}): ${getErrorMessage(apiError as unknown as IAutotaskErrorResponse)}`);
+		console.warn(scrub(`API ${method} ${url} failed (${status}): ${getErrorMessage(apiError as unknown as IAutotaskErrorResponse)}`));
 
 		// Import the createStandardErrorObject function
 		const { createStandardErrorObject } = await import('../../helpers/errorHandler');

--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -653,6 +653,9 @@ export async function autotaskApiRequest<T = JsonObject>(
 				'Check Admin > Account Settings & Users > Resources > Security Levels for the impersonated resource\'s security level.';
 		}
 
+		// Scrub override credential values from the final message before it reaches the n8n UI.
+		detailedMessage = scrub(detailedMessage);
+
 		// Set consistent properties on the error object to ensure n8n displays the right message
 		apiError.message = detailedMessage;
 		(apiError as { description?: string }).description = detailedMessage;

--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -678,14 +678,14 @@ export async function autotaskApiRequest<T = JsonObject>(
 		// Log error details (useful for debugging)
 		const hasSpecificErrors = Array.isArray(errorsArray) && errorsArray.length > 0;
 
-		console.debug('Error details:', {
+		console.debug('Error details:', scrub(JSON.stringify({
 			status,
 			hasSpecificErrors,
 			errorCount: errorsArray.length || 0,
 			errorMessages: apiErrorMessages,
 			responseDataErrors: responseErrors,
 			errorObjectErrors: directErrors,
-		});
+		})));
 
 		// Throw standardized error with the detailed message.
 		// Pass message explicitly so NodeApiError.message is guaranteed to be the

--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -19,6 +19,8 @@ import type { OperationType } from '../../types/base/entity-types';
 import { handleRateLimit } from './rateLimit';
 import { endpointThreadTracker } from './threadLimit';
 import { executeWithRetry } from './retryHandler';
+import { autotaskCredentialStore } from '../credential-store';
+import { createOverrideScrubber } from '../security/credential-masking';
 
 interface IAutotaskSuccessResponse {
 	id?: number;
@@ -328,7 +330,13 @@ export async function fetchThresholdInformation(
 	} catch (error) {
 		// Import sanitization function to mask credentials in error logs
 		const { sanitizeErrorForLogging } = await import('../security/credential-masking');
-		console.error('Failed to fetch threshold information:', sanitizeErrorForLogging(error));
+		const overrideCreds = autotaskCredentialStore.getStore();
+		const scrub = createOverrideScrubber(overrideCreds);
+		const sanitized = sanitizeErrorForLogging(error);
+		if (typeof sanitized.message === 'string') {
+			sanitized.message = scrub(sanitized.message);
+		}
+		console.error('Failed to fetch threshold information:', sanitized);
 		return null;
 	}
 }
@@ -565,7 +573,13 @@ export async function autotaskApiRequest<T = JsonObject>(
 
 		// Import sanitization function to mask credentials in error logs
 		const { sanitizeErrorForLogging } = await import('../security/credential-masking');
-		console.error('API Error:', sanitizeErrorForLogging(apiError));
+		const overrideCreds = autotaskCredentialStore.getStore();
+		const scrub = createOverrideScrubber(overrideCreds);
+		const sanitized = sanitizeErrorForLogging(apiError);
+		if (typeof sanitized.message === 'string') {
+			sanitized.message = scrub(sanitized.message);
+		}
+		console.error('API Error:', sanitized);
 
 		const status = apiError.response?.status;
 		const url = options.url;

--- a/nodes/Autotask/helpers/security/credential-masking.ts
+++ b/nodes/Autotask/helpers/security/credential-masking.ts
@@ -152,3 +152,35 @@ export function sanitizeErrorForLogging(error: any): any {
   }
 }
 
+/**
+ * Returns a function that scrubs known override credential values from any string.
+ * Call once per tool invocation; pass the result into error/logging code paths.
+ *
+ * Scrubs Secret, APIIntegrationcode, AND Username — the spec (section 7) requires
+ * Username to be redacted from error messages where it appears verbatim. Note that
+ * field-name-based masking (`maskCredentialValue`) handles cases where the Username
+ * appears as a structured field in an API response; this runtime value scrubber is a
+ * defence-in-depth measure for cases where the value leaks into a free-form error
+ * message string.
+ *
+ * The ≥8 char guard prevents over-redacting short values (e.g. a 3-char Username
+ * could collide with arbitrary substrings in unrelated text). Values shorter than
+ * 8 chars are not added to the targets list — the field-name-based masking is the
+ * primary defence for those cases.
+ */
+export function createOverrideScrubber(
+    override: { Username: string; Secret: string; APIIntegrationcode: string } | undefined,
+): (text: string) => string {
+    if (!override) return (text) => text;
+    const targets = [override.Secret, override.APIIntegrationcode, override.Username]
+        .filter((v) => typeof v === 'string' && v.length >= 8);
+    if (targets.length === 0) return (text) => text;
+    return (text: string) => {
+        let result = text;
+        for (const target of targets) {
+            result = result.split(target).join('********');
+        }
+        return result;
+    };
+}
+

--- a/nodes/Autotask/helpers/security/credential-masking.ts
+++ b/nodes/Autotask/helpers/security/credential-masking.ts
@@ -163,17 +163,18 @@ export function sanitizeErrorForLogging(error: any): any {
  * defence-in-depth measure for cases where the value leaks into a free-form error
  * message string.
  *
- * The ≥8 char guard prevents over-redacting short values (e.g. a 3-char Username
+ * The ≥4 char guard prevents over-redacting very short values (e.g. a 1-3 char value
  * could collide with arbitrary substrings in unrelated text). Values shorter than
- * 8 chars are not added to the targets list — the field-name-based masking is the
- * primary defence for those cases.
+ * 4 chars are not added to the targets list — the field-name-based masking is the
+ * primary defence for those rare cases. Integration codes are typically ≥6 chars
+ * so the 4-char floor covers all realistic credential values.
  */
 export function createOverrideScrubber(
     override: { Username: string; Secret: string; APIIntegrationcode: string } | undefined,
 ): (text: string) => string {
     if (!override) return (text) => text;
     const targets = [override.Secret, override.APIIntegrationcode, override.Username]
-        .filter((v) => typeof v === 'string' && v.length >= 8);
+        .filter((v) => typeof v === 'string' && v.length >= 4);
     if (targets.length === 0) return (text) => text;
     return (text: string) => {
         let result = text;

--- a/nodes/Autotask/mcp-trigger/McpServer.ts
+++ b/nodes/Autotask/mcp-trigger/McpServer.ts
@@ -1,0 +1,384 @@
+/**
+ * AutotaskMcpServer — MCP server that delegates tool calls to connected
+ * n8n AI tools (e.g. AutotaskAiTools) and (optionally) injects per-user
+ * Autotask credentials via AsyncLocalStorage on a per-request basis.
+ *
+ * Responsibilities:
+ *   1. tools/list  → enumerate n8n AI tools (name, description, JSON-Schema input)
+ *   2. tools/call  → invoke the underlying tool's .invoke(args) inside an ALS
+ *                    context populated from the incoming HTTP request's headers
+ *                    (when injectAutotaskCredentials is enabled).
+ *   3. Transport binding for both SSE and Streamable HTTP servers.
+ *
+ * Concurrency / ALS contract:
+ *   The McpServer instance is shared across concurrent HTTP requests. We never
+ *   read headers from a shared property; instead each tools/call execution
+ *   runs inside `requestHeaderStore.run(headers, ...)` set by the webhook
+ *   handler, and the call handler reads via `requestHeaderStore.getStore()`.
+ *
+ * Runtime resolution:
+ *   The @modelcontextprotocol/sdk is NOT a production dependency of this
+ *   package. It is resolved lazily at first use via require.main (i.e. n8n's
+ *   own node_modules — n8n ships it with n8n-nodes-langchain). This mirrors
+ *   the @langchain/* / zod resolution strategy in ai-tools/runtime.ts.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { autotaskCredentialStore, requestHeaderStore, invalidateProbeCache, probeCredentialIdentity, probeCredentials, type OverrideAutotaskCredentials } from '../helpers/credential-store';
+import { parseAndValidateHeaders } from '../helpers/credential-proxy';
+import { wrapError, ERROR_TYPES } from '../ai-tools/error-formatter';
+
+// ---------------------------------------------------------------------------
+// Runtime-resolved SDK / zod-to-json-schema typings.
+// We treat them as `any` at the boundary — strong typing comes from the
+// helpers we own, not from a peer SDK whose exact version is not pinned.
+// ---------------------------------------------------------------------------
+
+interface McpToolDescriptor {
+    /** Tool name as exposed to MCP clients. */
+    name: string;
+    /** Human-readable description. */
+    description: string;
+    /** JSON Schema for the tool input. */
+    inputSchema: Record<string, unknown>;
+    /** Internal invoker — accepts MCP tool-call args, returns the result string. */
+    invoke: (args: Record<string, unknown>) => Promise<string>;
+}
+
+/**
+ * Shape of a tool object supplied by an n8n `supplyData()` node (e.g.
+ * `DynamicStructuredTool` from @langchain/core/tools). We only depend on the
+ * minimal surface area: name, description, schema (Zod), and invoke().
+ */
+export interface N8nLikeTool {
+    name: string;
+    description?: string;
+    schema: unknown; // Zod schema (or already JSON Schema in some adapters)
+    invoke: (args: Record<string, unknown>) => Promise<string | unknown>;
+}
+
+export interface AutotaskMcpServerOptions {
+    /** Service identity advertised to MCP clients. */
+    serverInfo: { name: string; version: string };
+    /** Tools to expose. Built fresh per request because invoke() closes over node context. */
+    tools: N8nLikeTool[];
+    /** When true, headers carrying X-Autotask-* are extracted and injected into tool calls. */
+    injectAutotaskCredentials: boolean;
+    /** HTTP request fn used for credential probing. Wrapper around n8n's helpers.httpRequest. */
+    httpRequest: (opts: { method: string; url: string; headers: Record<string, string> }) => Promise<unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Lazy SDK loader
+// ---------------------------------------------------------------------------
+
+interface LoadedMcpSdk {
+    Server: any;
+    SSEServerTransport: any;
+    StreamableHTTPServerTransport: any;
+    ListToolsRequestSchema: any;
+    CallToolRequestSchema: any;
+    zodToJsonSchema: (schema: unknown, opts?: unknown) => Record<string, unknown>;
+}
+
+let _sdk: LoadedMcpSdk | null = null;
+
+function loadMcpSdk(): LoadedMcpSdk {
+    if (_sdk) return _sdk;
+
+    const { createRequire } = require('module') as { createRequire: (f: string) => NodeRequire };
+    const errors: string[] = [];
+
+    // Two-strategy resolution (same pattern as ai-tools/runtime.ts):
+    //   1. require.main (n8n's process entry — its node_modules has the SDK
+    //      via n8n-nodes-langchain).
+    //   2. Standard resolution from this module (dev/test environments where
+    //      the SDK is in this package's node_modules as a devDependency).
+    const candidates: Array<{ source: string; req: NodeRequire }> = [];
+    const mainFile = require.main?.filename;
+    if (mainFile) candidates.push({ source: 'main', req: createRequire(mainFile) });
+    candidates.push({ source: 'local', req: createRequire(__filename) });
+
+    for (const { source, req } of candidates) {
+        try {
+            const serverIndex = req('@modelcontextprotocol/sdk/server/index.js');
+            const sse = req('@modelcontextprotocol/sdk/server/sse.js');
+            const streamable = req('@modelcontextprotocol/sdk/server/streamableHttp.js');
+            const types = req('@modelcontextprotocol/sdk/types.js');
+            const z2j = req('zod-to-json-schema');
+            _sdk = {
+                Server: serverIndex.Server,
+                SSEServerTransport: sse.SSEServerTransport,
+                StreamableHTTPServerTransport: streamable.StreamableHTTPServerTransport,
+                ListToolsRequestSchema: types.ListToolsRequestSchema,
+                CallToolRequestSchema: types.CallToolRequestSchema,
+                // zod-to-json-schema exposes `zodToJsonSchema` as named + default.
+                zodToJsonSchema: (z2j.zodToJsonSchema ?? z2j.default ?? z2j) as LoadedMcpSdk['zodToJsonSchema'],
+            };
+            return _sdk;
+        } catch (err) {
+            errors.push(`  ${source}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+
+    throw new Error(
+        `AutotaskMcpServer: failed to resolve @modelcontextprotocol/sdk from any source. ` +
+        `n8n must be running with @modelcontextprotocol/sdk available (typically via n8n-nodes-langchain).\n${errors.join('\n')}`,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_INPUT_SCHEMA: Record<string, unknown> = { type: 'object', properties: {} };
+
+function convertSchemaToJsonSchema(schema: unknown, sdk: LoadedMcpSdk): Record<string, unknown> {
+    if (!schema) return DEFAULT_INPUT_SCHEMA;
+    // Already a JSON Schema-like object.
+    if (typeof schema === 'object' && schema !== null && (schema as { type?: unknown }).type === 'object') {
+        return schema as Record<string, unknown>;
+    }
+    try {
+        const converted = sdk.zodToJsonSchema(schema as object, { name: undefined });
+        // zod-to-json-schema may wrap with $ref/definitions when `name` is set; we passed undefined to get a flat object.
+        if (converted && typeof converted === 'object') {
+            // Strip $schema, definitions if present at the top — MCP wants a clean object schema.
+            const { $schema: _s, definitions: _d, ...rest } = converted as Record<string, unknown>;
+            return rest as Record<string, unknown>;
+        }
+    } catch {
+        // Fall through to default
+    }
+    return DEFAULT_INPUT_SCHEMA;
+}
+
+function coerceInvokeResultToString(value: unknown): string {
+    if (typeof value === 'string') return value;
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+}
+
+function tryParseJson(text: string): unknown {
+    try { return JSON.parse(text); } catch { return undefined; }
+}
+
+// ---------------------------------------------------------------------------
+// AutotaskMcpServer
+// ---------------------------------------------------------------------------
+
+export class AutotaskMcpServer {
+    private readonly _serverInfo: AutotaskMcpServerOptions['serverInfo'];
+    private readonly _tools: Map<string, McpToolDescriptor>;
+    private readonly _injectAutotaskCredentials: boolean;
+    private readonly _httpRequest: AutotaskMcpServerOptions['httpRequest'];
+    private readonly _sdk: LoadedMcpSdk;
+
+    constructor(options: AutotaskMcpServerOptions) {
+        this._serverInfo = options.serverInfo;
+        this._injectAutotaskCredentials = options.injectAutotaskCredentials;
+        this._httpRequest = options.httpRequest;
+        this._sdk = loadMcpSdk();
+
+        this._tools = new Map();
+        for (const tool of options.tools) {
+            const inputSchema = convertSchemaToJsonSchema(tool.schema, this._sdk);
+            this._tools.set(tool.name, {
+                name: tool.name,
+                description: tool.description ?? '',
+                inputSchema,
+                invoke: async (args) => coerceInvokeResultToString(await tool.invoke(args)),
+            });
+        }
+    }
+
+    /**
+     * Returns the registered tool names. Used by the webhook handler for diagnostics.
+     */
+    listToolNames(): string[] {
+        return [...this._tools.keys()];
+    }
+
+    /**
+     * Create a fresh MCP `Server` instance, register handlers, and return it.
+     * We create a new Server per HTTP request so that transport lifecycle and
+     * any per-session state stays isolated (the MCP SDK's Server is designed
+     * around a single transport).
+     */
+    private createServer(): any {
+        const { Server, ListToolsRequestSchema, CallToolRequestSchema } = this._sdk;
+        const server = new Server(
+            { name: this._serverInfo.name, version: this._serverInfo.version },
+            { capabilities: { tools: {} } },
+        );
+        this.setupHandlers(server, ListToolsRequestSchema, CallToolRequestSchema);
+        return server;
+    }
+
+    /**
+     * Register `tools/list` and `tools/call` handlers on `server`.
+     *
+     * CRITICAL: capture instance state as locals BEFORE registering the
+     * handlers. The SDK's handler dispatch may cross async boundaries (await,
+     * setImmediate) and if we relied on `this` we would risk binding issues
+     * — especially under per-request McpServer wrappers in tests.
+     */
+    private setupHandlers(server: any, ListToolsRequestSchema: any, CallToolRequestSchema: any): void {
+        const tools = this._tools;
+        const injectAutotaskCredentials = this._injectAutotaskCredentials;
+        const httpRequest = this._httpRequest;
+
+        server.setRequestHandler(ListToolsRequestSchema, async () => {
+            const list = [...tools.values()].map((t) => ({
+                name: t.name,
+                description: t.description,
+                inputSchema: t.inputSchema,
+            }));
+            return { tools: list };
+        });
+
+        server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
+            const name: string | undefined = request?.params?.name;
+            const args: Record<string, unknown> = (request?.params?.arguments ?? {}) as Record<string, unknown>;
+            const tool = name ? tools.get(name) : undefined;
+
+            if (!tool) {
+                const err = wrapError(
+                    'autotaskMcpTrigger',
+                    name ?? 'unknown',
+                    ERROR_TYPES.INVALID_OPERATION,
+                    `Unknown tool '${name ?? '(missing)'}'. No tool with that name is registered.`,
+                    `Use 'tools/list' to enumerate available tools.`,
+                );
+                return { content: [{ type: 'text', text: JSON.stringify(err) }], isError: true };
+            }
+
+            const headers = requestHeaderStore.getStore() ?? {};
+            let overrideCreds: Readonly<OverrideAutotaskCredentials> | undefined;
+
+            if (injectAutotaskCredentials) {
+                const parsed = parseAndValidateHeaders(headers);
+                if (parsed.type === 'error') {
+                    const err = wrapError(
+                        'autotaskMcpTrigger',
+                        name as string,
+                        ERROR_TYPES.PERMISSION_DENIED,
+                        `Per-user credential injection is enabled but the X-Autotask-* headers are invalid: ${parsed.message}`,
+                        `Provide a complete and valid set of X-Autotask-* request headers (Username, Secret, IntegrationCode, Zone).`,
+                    );
+                    return { content: [{ type: 'text', text: JSON.stringify(err) }], isError: true };
+                }
+                if (parsed.type === 'ok') {
+                    overrideCreds = parsed.creds;
+                    // Probe before injecting to fail fast on invalid creds.
+                    // probeCredentials returns true on network errors (not cached),
+                    // so transient outages do not lock users out.
+                    let probeOk = true;
+                    try {
+                        probeOk = await probeCredentials(overrideCreds, httpRequest);
+                    } catch {
+                        // Defensive: treat unexpected throw as "allow through" — same as network errors.
+                        probeOk = true;
+                    }
+                    if (!probeOk) {
+                        const err = wrapError(
+                            'autotaskMcpTrigger',
+                            name as string,
+                            ERROR_TYPES.PERMISSION_DENIED,
+                            `Autotask rejected the injected credentials (401/403).`,
+                            `Verify the X-Autotask-Username, X-Autotask-Secret, and X-Autotask-IntegrationCode header values are correct for the X-Autotask-Zone you provided.`,
+                        );
+                        return { content: [{ type: 'text', text: JSON.stringify(err) }], isError: true };
+                    }
+                }
+            }
+
+            // Execute the tool, optionally inside the credential ALS context.
+            let resultStr: string;
+            try {
+                if (overrideCreds) {
+                    resultStr = await autotaskCredentialStore.run(
+                        overrideCreds,
+                        async () => tool.invoke(args),
+                    );
+                } else {
+                    resultStr = await tool.invoke(args);
+                }
+            } catch (toolErr) {
+                const err = wrapError(
+                    'autotaskMcpTrigger',
+                    name as string,
+                    ERROR_TYPES.API_ERROR,
+                    `Tool '${name}' threw during invocation: ${toolErr instanceof Error ? toolErr.message : String(toolErr)}`,
+                    `Inspect the n8n execution logs for the underlying error.`,
+                );
+                return { content: [{ type: 'text', text: JSON.stringify(err) }], isError: true };
+            }
+
+            // If the tool returned a PERMISSION_DENIED envelope (Autotask 401/403 during
+            // a real call), evict the probe cache so the next request re-probes instead
+            // of using a stale positive entry.
+            if (overrideCreds) {
+                const parsed = tryParseJson(resultStr) as { errorType?: string } | undefined;
+                if (parsed && parsed.errorType === ERROR_TYPES.PERMISSION_DENIED) {
+                    try {
+                        invalidateProbeCache(probeCredentialIdentity(overrideCreds));
+                    } catch {
+                        // Defensive — invalidation is best-effort; never fail the tool call on it.
+                    }
+                }
+            }
+
+            return { content: [{ type: 'text', text: resultStr }] };
+        });
+    }
+
+    /**
+     * Connect a Streamable HTTP transport and dispatch the current request.
+     * Webhook handler should call this for POST/DELETE on the main MCP path.
+     */
+    async handleStreamableHttpRequest(
+        req: IncomingMessage,
+        res: ServerResponse,
+        parsedBody?: unknown,
+    ): Promise<void> {
+        const { StreamableHTTPServerTransport } = this._sdk;
+        const transport = new StreamableHTTPServerTransport({
+            // Stateless mode — n8n is fronted by an HTTP layer that has no
+            // persistent connection to the MCP client between requests.
+            sessionIdGenerator: undefined,
+        });
+        const server = this.createServer();
+        await server.connect(transport);
+        await transport.handleRequest(req, res, parsedBody);
+        // Clean up — close the transport so any allocated resources are released.
+        try { await transport.close?.(); } catch { /* ignore */ }
+        try { await server.close?.(); } catch { /* ignore */ }
+    }
+
+    /**
+     * Open a long-lived SSE connection for the legacy SSE transport.
+     * `messageEndpoint` is the URL clients should POST messages to (relative
+     * or absolute as the deployment requires).
+     *
+     * Returns the underlying transport so the caller can plug in POST message
+     * routing via `transport.handlePostMessage(req, res, body)`.
+     */
+    async openSseConnection(messageEndpoint: string, res: ServerResponse): Promise<any> {
+        const { SSEServerTransport } = this._sdk;
+        const transport = new SSEServerTransport(messageEndpoint, res);
+        const server = this.createServer();
+        await server.connect(transport);
+        return transport;
+    }
+
+    /**
+     * Convenience: route an incoming POST to an already-open SSE transport.
+     */
+    async handleSsePostMessage(transport: any, req: IncomingMessage, res: ServerResponse, body?: unknown): Promise<void> {
+        await transport.handlePostMessage(req, res, body);
+    }
+}

--- a/nodes/Autotask/mcp-trigger/McpServer.ts
+++ b/nodes/Autotask/mcp-trigger/McpServer.ts
@@ -364,15 +364,16 @@ export class AutotaskMcpServer {
      * `messageEndpoint` is the URL clients should POST messages to (relative
      * or absolute as the deployment requires).
      *
-     * Returns the underlying transport so the caller can plug in POST message
-     * routing via `transport.handlePostMessage(req, res, body)`.
+     * Returns both the transport and the server so the caller can call
+     * `server.close()` when the session ends — necessary to release SDK-internal
+     * listeners that `server.connect(transport)` registers on the transport.
      */
-    async openSseConnection(messageEndpoint: string, res: ServerResponse): Promise<any> {
+    async openSseConnection(messageEndpoint: string, res: ServerResponse): Promise<{ transport: any; server: any }> {
         const { SSEServerTransport } = this._sdk;
         const transport = new SSEServerTransport(messageEndpoint, res);
         const server = this.createServer();
         await server.connect(transport);
-        return transport;
+        return { transport, server };
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@langchain/classic": "^1.0.29",
     "@langchain/core": "^1.1.39",
+    "@modelcontextprotocol/sdk": "~1.26.0",
     "@n8n/node-cli": ">=0.29.0",
     "@types/node": "^22.15.0",
     "@types/pluralize": "^0.0.33",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "nodes": [
       "dist/nodes/Autotask/Autotask.node.js",
       "dist/nodes/Autotask/AutotaskTrigger.node.js",
-      "dist/nodes/Autotask/AutotaskAiTools.node.js"
+      "dist/nodes/Autotask/AutotaskAiTools.node.js",
+      "dist/nodes/Autotask/AutotaskMcpTrigger.node.js"
     ]
   },
   "devDependencies": {

--- a/tests/.env.test.example
+++ b/tests/.env.test.example
@@ -1,0 +1,75 @@
+# Required — n8n MCP Trigger URL for the AutotaskAiTools workflow (baseline endpoint)
+MCP_ENDPOINT_BASELINE=
+
+# Optional — endpoint configured with allowWriteOperations=false (validates write blocking)
+MCP_ENDPOINT_READONLY=
+
+# Optional — 'sse' (default) or 'streamable-http'; selects MCP client transport
+# Note: Streamable HTTP requires n8n server-side support — verify your n8n version before using
+MCP_TRANSPORT=
+
+# Optional — set to 'true' to skip all write operations in tests (create/update/delete/createIfNotExists)
+# Useful when running against a production-like endpoint where writes are undesirable
+# Default: false (write tests run when endpoint supports them)
+TEST_READ_ONLY_MODE=
+
+# Required — known-good numeric ticket ID in the Autotask sandbox
+# Must have: ticketNumber field populated, SLA configured (for slaHealthCheck assertions)
+TEST_TICKET_ID=
+
+# Unused — ticket number is derived automatically from the TEST_TICKET_ID API response.
+# Kept as a reminder: slaHealthCheck and summary test cases use the ticketNumber
+# from the get(TEST_TICKET_ID) call in beforeAll, not this env var.
+TEST_TICKET_NUMBER=
+
+# Required — exact company name string for label-resolution filter test and evals
+# Must be an exact case-insensitive match to a company with tickets in the sandbox
+TEST_COMPANY_NAME=
+
+# Optional — known-good company ID (numeric). If unset, derived from the pivot ticket's companyID.
+TEST_COMPANY_ID=
+
+# Optional — second company name for evals that compare two clients or test a different account
+# (e.g. sales-support scenarios, senior-engineer cross-client scenarios)
+# Must be a different company from TEST_COMPANY_NAME with some ticket history
+TEST_COMPANY_NAME_2=
+
+# Optional — third company name for additional eval variety
+TEST_COMPANY_NAME_3=
+
+# Optional — second ticket ID for evals needing a distinct second ticket
+TEST_TICKET_ID_2=
+
+# Optional — known-good contact ID (numeric) at the above company. If unset, derived from ticket's contactID.
+TEST_CONTACT_ID=
+
+# Optional — known-good resource ID (numeric). If unset, derived from autotask_resource.whoAmI response.
+TEST_RESOURCE_ID=
+
+# Optional — known-good ticket note ID (numeric) on the pivot ticket. If unset, the first result from
+# getMany(filter ticketID=TEST_TICKET_ID) is used at runtime.
+TEST_TICKET_NOTE_ID=
+
+# Optional — known-good time entry ID (numeric) on the pivot ticket. If unset, the first result from
+# getUnposted(filter ticketID=TEST_TICKET_ID) is used at runtime.
+TEST_TIME_ENTRY_ID=
+
+# ---- LLM Behavioral Evals (pnpm test:evals) -----------------------------------
+
+# LM Studio host running the eval model (no API key required)
+LM_STUDIO_HOST=192.168.253.143
+
+# LM Studio port (default: 1234)
+LM_STUDIO_PORT=1234
+
+# Model identifier exactly as shown in LM Studio
+EVAL_MODEL=qwen3.6-35b-a3b
+
+# Optional: credential injection endpoint tests
+# Configure an n8n workflow with AutotaskMcpTrigger (injectAutotaskCredentials=true)
+# + AutotaskAiTools (acceptInjectedCredentials=true) and set these vars to run injection tests.
+TEST_INJECTION_ENDPOINT_URL=
+TEST_AT_OVERRIDE_USERNAME=
+TEST_AT_OVERRIDE_SECRET=
+TEST_AT_OVERRIDE_CODE=
+TEST_AT_OVERRIDE_ZONE=

--- a/tests/ai-tools/mcp-client.ts
+++ b/tests/ai-tools/mcp-client.ts
@@ -1,0 +1,118 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp';
+
+export type TransportType = 'sse' | 'streamable-http';
+
+export interface McpToolSpec {
+  name: string;
+  description?: string;
+  inputSchema: unknown;
+}
+
+export class McpTestClient {
+  private client: Client;
+  private transportType: TransportType;
+  public availableTools: McpToolSpec[] = [];
+
+  constructor(
+    transportType: TransportType = (process.env.MCP_TRANSPORT as TransportType) ?? 'sse'
+  ) {
+    this.transportType = transportType;
+    this.client = new Client(
+      { name: 'autotask-test-client', version: '1.0.0' },
+      { capabilities: {} }
+    );
+  }
+
+  /**
+   * Establishes the MCP connection and runs a tools/list health-check.
+   * Throws if the server returns no tools — fails fast before test execution begins.
+   */
+  async connect(url: string, customHeaders?: Record<string, string>): Promise<void> {
+    const parsedUrl = new URL(url);
+    // StreamableHTTPClientTransport / SSEClientTransport accept a second options argument.
+    // Recent SDK versions use `requestInit: { headers }`; older versions use `{ headers }`
+    // directly. Provide both — the unused key is silently ignored.
+    const transportOptions = customHeaders
+      ? { requestInit: { headers: customHeaders }, headers: customHeaders }
+      : undefined;
+    const transport =
+      this.transportType === 'streamable-http'
+        ? new StreamableHTTPClientTransport(parsedUrl, transportOptions)
+        : new SSEClientTransport(parsedUrl, transportOptions);
+
+    await this.client.connect(transport);
+
+    const tools = await this.client.listTools();
+    if (!tools.tools || tools.tools.length === 0) {
+      throw new Error(
+        `MCP health check failed: no tools found at ${url}. ` +
+        `Verify the n8n workflow is active and the MCP Trigger is enabled.`
+      );
+    }
+    this.availableTools = tools.tools as McpToolSpec[];
+  }
+
+  /**
+   * Sends a tools/call request and returns the parsed tool response.
+   *
+   * Prefers result.structuredContent when present (newer MCP versions).
+   * Falls back to parsing content[0].text.
+   *
+   * Note: result.isError signals an MCP transport-level error, not a tool error.
+   * Our tools always return structured JSON — even application errors come back
+   * as { error: true, errorType, ... } inside content[0].text.
+   * We parse unconditionally and let the caller's assertions surface the error shape.
+   */
+  async callTool(
+    name: string,
+    args: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    const result = await this.client.callTool({ name, arguments: args });
+
+    // result.isError signals an MCP transport-level error (e.g. server crash, protocol failure).
+    // Application-level errors from our tools come back as { error: true, errorType, ... } in
+    // structuredContent or content[0].text — those are expected and handled by assertions.
+    if (result.isError === true) {
+      throw new Error(
+        `MCP transport error calling "${name}": ${JSON.stringify(result)}`
+      );
+    }
+
+    if (
+      result.structuredContent !== undefined &&
+      result.structuredContent !== null &&
+      typeof result.structuredContent === 'object'
+    ) {
+      return result.structuredContent as Record<string, unknown>;
+    }
+
+    const contentArray = result.content as Array<{ type: string; text?: string }> | undefined;
+    const firstContent = contentArray?.[0];
+    if (!firstContent) {
+      throw new Error(
+        `Tool call "${name}" returned no content. ` +
+        `Raw result: ${JSON.stringify(result)}`
+      );
+    }
+    if (firstContent.type !== 'text' || typeof firstContent.text !== 'string') {
+      throw new Error(
+        `Expected text content from "${name}", got type: "${firstContent.type}". ` +
+        `Raw content: ${JSON.stringify(firstContent)}`
+      );
+    }
+    const text = firstContent.text;
+    try {
+      return JSON.parse(text) as Record<string, unknown>;
+    } catch (e) {
+      throw new Error(
+        `Failed to parse tool response JSON from "${name}": ${e}\nRaw text: ${text}`
+      );
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    await this.client.close();
+  }
+}

--- a/tests/ai-tools/mcp-client.ts
+++ b/tests/ai-tools/mcp-client.ts
@@ -60,25 +60,17 @@ export class McpTestClient {
    * Prefers result.structuredContent when present (newer MCP versions).
    * Falls back to parsing content[0].text.
    *
-   * Note: result.isError signals an MCP transport-level error, not a tool error.
-   * Our tools always return structured JSON — even application errors come back
-   * as { error: true, errorType, ... } inside content[0].text.
-   * We parse unconditionally and let the caller's assertions surface the error shape.
+   * result.isError is the MCP protocol flag for tool-level errors — the server sets it
+   * when the tool itself signals failure (e.g. PERMISSION_DENIED, INVALID_OPERATION).
+   * The content array still carries the structured error payload in content[0].text,
+   * so we parse unconditionally and let the caller's assertions surface the error shape.
+   * We never throw on isError — that would hide the structured body from tests.
    */
   async callTool(
     name: string,
     args: Record<string, unknown>
   ): Promise<Record<string, unknown>> {
     const result = await this.client.callTool({ name, arguments: args });
-
-    // result.isError signals an MCP transport-level error (e.g. server crash, protocol failure).
-    // Application-level errors from our tools come back as { error: true, errorType, ... } in
-    // structuredContent or content[0].text — those are expected and handled by assertions.
-    if (result.isError === true) {
-      throw new Error(
-        `MCP transport error calling "${name}": ${JSON.stringify(result)}`
-      );
-    }
 
     if (
       result.structuredContent !== undefined &&

--- a/tests/ai-tools/suites/credential-injection.test.ts
+++ b/tests/ai-tools/suites/credential-injection.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { McpTestClient } from '../mcp-client';
+
+// These tests only run when a credential-injection endpoint is configured.
+const INJECTION_URL = process.env.TEST_INJECTION_ENDPOINT_URL;
+const AT_USERNAME = process.env.TEST_AT_OVERRIDE_USERNAME;
+const AT_SECRET = process.env.TEST_AT_OVERRIDE_SECRET;
+const AT_CODE = process.env.TEST_AT_OVERRIDE_CODE;
+const AT_ZONE = process.env.TEST_AT_OVERRIDE_ZONE;
+
+const CONFIGURED = !!(INJECTION_URL && AT_USERNAME && AT_SECRET && AT_CODE && AT_ZONE);
+
+describe.skipIf(!CONFIGURED)('credential injection — autotask mcp trigger', () => {
+    const client = new McpTestClient('streamable-http');
+    const headers = {
+        'X-Autotask-Username': AT_USERNAME!,
+        'X-Autotask-Secret': AT_SECRET!,
+        'X-Autotask-IntegrationCode': AT_CODE!,
+        'X-Autotask-Zone': AT_ZONE!,
+    };
+
+    beforeAll(async () => {
+        await client.connect(INJECTION_URL!, headers);
+    });
+
+    afterAll(async () => {
+        await client.disconnect();
+    });
+
+    it('describeFields returns fields under override credential', async () => {
+        const result = await client.callTool('autotask_ticket', { operation: 'describeFields' });
+        const parsed = JSON.parse(typeof result === 'string' ? result : JSON.stringify(result));
+        expect(parsed.fields).toBeDefined();
+        expect(Array.isArray(parsed.fields)).toBe(true);
+        expect(parsed.fields.length).toBeGreaterThan(0);
+    });
+
+    it('response does not contain credential values', async () => {
+        const result = await client.callTool('autotask_ticket', { operation: 'describeFields' });
+        const text = typeof result === 'string' ? result : JSON.stringify(result);
+        // Secret and integration code must not appear verbatim in any response
+        expect(text).not.toContain(AT_SECRET!);
+        expect(text).not.toContain(AT_CODE!);
+    });
+});
+
+describe.skipIf(!INJECTION_URL)('credential injection — rejection cases', () => {
+    it('returns PERMISSION_DENIED for invalid credentials', async () => {
+        const client = new McpTestClient('streamable-http');
+        const badHeaders = {
+            'X-Autotask-Username': 'invalid@example.com',
+            'X-Autotask-Secret': 'wrongpassword123',
+            'X-Autotask-IntegrationCode': 'wrongcode456',
+            'X-Autotask-Zone': 'https://webservices6.autotask.net/atservicesrest',
+        };
+        await client.connect(INJECTION_URL!, badHeaders);
+        const result = await client.callTool('autotask_ticket', { operation: 'describeFields' });
+        const parsed = JSON.parse(typeof result === 'string' ? result : JSON.stringify(result));
+        expect(parsed.error).toBe(true);
+        expect(parsed.errorType).toBe('PERMISSION_DENIED');
+        await client.disconnect();
+    });
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "autotask-ai-tools-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:evals": "vitest run --config vitest.evals.config.ts",
+    "test:unit": "vitest run --config vitest.unit.config.ts"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/sdk": "~1.26.0",
+    "@types/node": "^22.15.0",
+    "dotenv": "^16.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0"
+  },
+  "dependencies": {
+    "yaml": "^2.8.3"
+  }
+}

--- a/tests/unit/credential-proxy.test.ts
+++ b/tests/unit/credential-proxy.test.ts
@@ -1,0 +1,169 @@
+// tests/unit/credential-proxy.test.ts
+import { describe, it, expect } from 'vitest';
+
+describe('parseAndValidateHeaders', () => {
+  it('returns OverrideAutotaskCredentials on valid complete headers', async () => {
+    const { parseAndValidateHeaders } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const headers = {
+      'x-autotask-username': 'user@example.com',
+      'x-autotask-secret': 'secretpass',
+      'x-autotask-integrationcode': 'abc123',
+      'x-autotask-zone': 'https://webservices6.autotask.net/atservicesrest/',
+    };
+    const result = parseAndValidateHeaders(headers);
+    expect(result.type).toBe('ok');
+    if (result.type === 'ok') {
+      expect(result.creds.Username).toBe('user@example.com');
+      expect(result.creds.zone).toBe('https://webservices6.autotask.net/atservicesrest'); // normalised
+    }
+  });
+
+  it('returns none when all four headers absent', async () => {
+    const { parseAndValidateHeaders } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const result = parseAndValidateHeaders({});
+    expect(result.type).toBe('none');
+  });
+
+  it('returns error on partial headers (3 of 4)', async () => {
+    const { parseAndValidateHeaders } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const result = parseAndValidateHeaders({
+      'x-autotask-username': 'u',
+      'x-autotask-secret': 's',
+      'x-autotask-integrationcode': 'c',
+    });
+    expect(result.type).toBe('error');
+    if (result.type === 'error') {
+      expect(result.message).toMatch(/missing/i);
+    }
+  });
+
+  it('rejects zone URL not matching allowlist', async () => {
+    const { parseAndValidateHeaders } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const result = parseAndValidateHeaders({
+      'x-autotask-username': 'u',
+      'x-autotask-secret': 's',
+      'x-autotask-integrationcode': 'c',
+      'x-autotask-zone': 'http://169.254.169.254/latest/meta-data/',
+    });
+    expect(result.type).toBe('error');
+    if (result.type === 'error') {
+      expect(result.message).toMatch(/zone/i);
+    }
+  });
+
+  it('rejects zone with non-HTTPS scheme', async () => {
+    const { parseAndValidateHeaders } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const result = parseAndValidateHeaders({
+      'x-autotask-username': 'u',
+      'x-autotask-secret': 's',
+      'x-autotask-integrationcode': 'c',
+      'x-autotask-zone': 'ftp://webservices6.autotask.net/atservicesrest',
+    });
+    expect(result.type).toBe('error');
+  });
+
+  it('rejects header value with control character', async () => {
+    const { parseAndValidateHeaders } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const result = parseAndValidateHeaders({
+      'x-autotask-username': 'user\r\nevil',
+      'x-autotask-secret': 's',
+      'x-autotask-integrationcode': 'c',
+      'x-autotask-zone': 'https://webservices6.autotask.net/atservicesrest',
+    });
+    expect(result.type).toBe('error');
+    if (result.type === 'error') {
+      expect(result.message).toMatch(/invalid characters/i);
+    }
+  });
+
+  it('rejects header value exceeding 1024 chars', async () => {
+    const { parseAndValidateHeaders } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const result = parseAndValidateHeaders({
+      'x-autotask-username': 'u'.repeat(1025),
+      'x-autotask-secret': 's',
+      'x-autotask-integrationcode': 'c',
+      'x-autotask-zone': 'https://webservices6.autotask.net/atservicesrest',
+    });
+    expect(result.type).toBe('error');
+  });
+
+  it('accepts unicode characters in header values', async () => {
+    const { parseAndValidateHeaders } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const result = parseAndValidateHeaders({
+      'x-autotask-username': 'josé@example.com',
+      'x-autotask-secret': 'naïve123',
+      'x-autotask-integrationcode': 'abc123',
+      'x-autotask-zone': 'https://webservices6.autotask.net/atservicesrest',
+    });
+    expect(result.type).toBe('ok');
+    if (result.type === 'ok') {
+      expect(result.creds.Username).toBe('josé@example.com');
+    }
+  });
+});
+
+describe('normaliseIncomingHeaders', () => {
+  it('lowercases header names', async () => {
+    const { normaliseIncomingHeaders } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const result = normaliseIncomingHeaders({ 'X-Autotask-Username': 'u', 'X-AUTOTASK-SECRET': 's' });
+    expect(result['x-autotask-username']).toBe('u');
+    expect(result['x-autotask-secret']).toBe('s');
+  });
+
+  it('takes first value when header is array', async () => {
+    const { normaliseIncomingHeaders } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const result = normaliseIncomingHeaders({ 'x-autotask-username': ['first', 'second'] });
+    expect(result['x-autotask-username']).toBe('first');
+  });
+
+  it('skips undefined values', async () => {
+    const { normaliseIncomingHeaders } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const result = normaliseIncomingHeaders({ 'x-autotask-username': undefined });
+    expect('x-autotask-username' in result).toBe(false);
+  });
+});
+
+describe('buildCredentialProxy', () => {
+  it('getCredentials returns override for autotaskApi', async () => {
+    const { buildCredentialProxy } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const override = Object.freeze({ Username: 'u', Secret: 's', APIIntegrationcode: 'c', zone: 'https://ws.test' });
+
+    const mockContext = {
+      getCredentials: async (_name: string) => ({ Username: 'configured', Secret: 'conf-secret', zone: 'configured-zone' }),
+    };
+
+    const proxied = buildCredentialProxy(mockContext as any, override);
+    const result = await proxied.getCredentials('autotaskApi');
+    expect((result as any).Username).toBe('u');
+    expect((result as any).Secret).toBe('s');
+  });
+
+  it('getCredentials delegates to original for other credential names', async () => {
+    const { buildCredentialProxy } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const override = Object.freeze({ Username: 'u', Secret: 's', APIIntegrationcode: 'c', zone: 'https://ws.test' });
+    const original = { Username: 'other-configured' };
+
+    const mockContext = {
+      getCredentials: async (name: string) => (name === 'someOtherCred' ? original : null),
+    };
+
+    const proxied = buildCredentialProxy(mockContext as any, override);
+    const result = await proxied.getCredentials('someOtherCred');
+    expect(result).toBe(original);
+  });
+
+  it('proxy forwards all getCredentials args', async () => {
+    const { buildCredentialProxy } = await import('../../nodes/Autotask/helpers/credential-proxy');
+    const override = Object.freeze({ Username: 'u', Secret: 's', APIIntegrationcode: 'c', zone: 'https://ws.test' });
+    let capturedArgs: unknown[] = [];
+
+    const mockContext = {
+      getCredentials: async (...args: unknown[]) => { capturedArgs = args; return null; },
+    };
+
+    const proxied = buildCredentialProxy(mockContext as any, override);
+    await proxied.getCredentials('otherCred' as any, 5 as any); // itemIndex = 5
+    expect(capturedArgs[0]).toBe('otherCred');
+    expect(capturedArgs[1]).toBe(5);
+  });
+});

--- a/tests/unit/credential-store.test.ts
+++ b/tests/unit/credential-store.test.ts
@@ -129,8 +129,8 @@ describe('probe cache', () => {
     const creds = { Username: 'net-u', Secret: 's', APIIntegrationcode: 'c', zone: 'https://ws.test' };
     let calls = 0;
     const http = async () => { calls += 1; const e: any = new Error('ECONNREFUSED'); throw e; };
-    await probeCredentials(creds, http);
-    await probeCredentials(creds, http);
+    expect(await probeCredentials(creds, http)).toBe(true);
+    expect(await probeCredentials(creds, http)).toBe(true);
     expect(calls).toBe(2);
   });
 });

--- a/tests/unit/credential-store.test.ts
+++ b/tests/unit/credential-store.test.ts
@@ -1,0 +1,136 @@
+// tests/unit/credential-store.test.ts
+import { describe, it, expect } from 'vitest';
+import { AsyncLocalStorage } from 'async_hooks';
+
+describe('autotaskCredentialStore singleton', () => {
+  it('returns same instance on repeated import', async () => {
+    const mod1 = await import('../../nodes/Autotask/helpers/credential-store');
+    const mod2 = await import('../../nodes/Autotask/helpers/credential-store');
+    expect(mod1.autotaskCredentialStore).toBe(mod2.autotaskCredentialStore);
+  });
+
+  it('is an AsyncLocalStorage', async () => {
+    const { autotaskCredentialStore } = await import('../../nodes/Autotask/helpers/credential-store');
+    expect(autotaskCredentialStore).toBeInstanceOf(AsyncLocalStorage);
+  });
+
+  it('getStore returns undefined outside run()', async () => {
+    const { autotaskCredentialStore } = await import('../../nodes/Autotask/helpers/credential-store');
+    expect(autotaskCredentialStore.getStore()).toBeUndefined();
+  });
+
+  it('getStore returns value inside run()', async () => {
+    const { autotaskCredentialStore } = await import('../../nodes/Autotask/helpers/credential-store');
+    const creds = { Username: 'u', Secret: 's', APIIntegrationcode: 'c', zone: 'https://ws.test' };
+    let stored: unknown;
+    await new Promise<void>(resolve => {
+      autotaskCredentialStore.run(Object.freeze(creds), () => {
+        stored = autotaskCredentialStore.getStore();
+        resolve();
+      });
+    });
+    expect(stored).toEqual(creds);
+  });
+});
+
+describe('requestHeaderStore singleton', () => {
+  it('returns same instance on repeated import', async () => {
+    const mod1 = await import('../../nodes/Autotask/helpers/credential-store');
+    const mod2 = await import('../../nodes/Autotask/helpers/credential-store');
+    expect(mod1.requestHeaderStore).toBe(mod2.requestHeaderStore);
+  });
+
+  it('is an AsyncLocalStorage', async () => {
+    const { requestHeaderStore } = await import('../../nodes/Autotask/helpers/credential-store');
+    expect(requestHeaderStore).toBeInstanceOf(AsyncLocalStorage);
+  });
+
+  it('getStore returns headers inside run()', async () => {
+    const { requestHeaderStore } = await import('../../nodes/Autotask/helpers/credential-store');
+    const headers = { 'x-autotask-username': 'u' };
+    let stored: unknown;
+    await new Promise<void>(resolve => {
+      requestHeaderStore.run(headers, () => {
+        stored = requestHeaderStore.getStore();
+        resolve();
+      });
+    });
+    expect(stored).toEqual(headers);
+  });
+});
+
+describe('normaliseZone', () => {
+  it('strips trailing slash', async () => {
+    const { normaliseZone } = await import('../../nodes/Autotask/helpers/credential-store');
+    expect(normaliseZone('https://webservices6.autotask.net/atservicesrest/')).toBe(
+      'https://webservices6.autotask.net/atservicesrest'
+    );
+  });
+
+  it('strips multiple trailing slashes', async () => {
+    const { normaliseZone } = await import('../../nodes/Autotask/helpers/credential-store');
+    expect(normaliseZone('https://webservices6.autotask.net/atservicesrest///')).toBe(
+      'https://webservices6.autotask.net/atservicesrest'
+    );
+  });
+
+  it('leaves URL without trailing slash unchanged', async () => {
+    const { normaliseZone } = await import('../../nodes/Autotask/helpers/credential-store');
+    expect(normaliseZone('https://webservices6.autotask.net/atservicesrest')).toBe(
+      'https://webservices6.autotask.net/atservicesrest'
+    );
+  });
+});
+
+describe('probe cache', () => {
+  it('probeCredentialIdentity returns 16-char hex string', async () => {
+    const { probeCredentialIdentity } = await import('../../nodes/Autotask/helpers/credential-store');
+    const creds = { Username: 'u', Secret: 's', APIIntegrationcode: 'c', zone: 'https://ws.test' };
+    const id = probeCredentialIdentity(creds);
+    expect(id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('two different secrets produce different identity', async () => {
+    const { probeCredentialIdentity } = await import('../../nodes/Autotask/helpers/credential-store');
+    const a = probeCredentialIdentity({ Username: 'u', Secret: 's1', APIIntegrationcode: 'c', zone: 'https://ws.test' });
+    const b = probeCredentialIdentity({ Username: 'u', Secret: 's2', APIIntegrationcode: 'c', zone: 'https://ws.test' });
+    expect(a).not.toBe(b);
+  });
+
+  it('trailing-slash zone and non-trailing-slash produce same identity', async () => {
+    const { probeCredentialIdentity } = await import('../../nodes/Autotask/helpers/credential-store');
+    const a = probeCredentialIdentity({ Username: 'u', Secret: 's', APIIntegrationcode: 'c', zone: 'https://ws.test/path/' });
+    const b = probeCredentialIdentity({ Username: 'u', Secret: 's', APIIntegrationcode: 'c', zone: 'https://ws.test/path' });
+    expect(a).toBe(b);
+  });
+
+  it('probeCredentials caches positive result and avoids second http call', async () => {
+    const { probeCredentials } = await import('../../nodes/Autotask/helpers/credential-store');
+    const creds = { Username: 'cache-test-u', Secret: 's', APIIntegrationcode: 'c', zone: 'https://ws.test' };
+    let calls = 0;
+    const http = async () => { calls += 1; return {}; };
+    expect(await probeCredentials(creds, http)).toBe(true);
+    expect(await probeCredentials(creds, http)).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  it('probeCredentials returns false and caches negative on 401', async () => {
+    const { probeCredentials } = await import('../../nodes/Autotask/helpers/credential-store');
+    const creds = { Username: 'neg-u', Secret: 's', APIIntegrationcode: 'c', zone: 'https://ws.test' };
+    let calls = 0;
+    const http = async () => { calls += 1; const e: any = new Error('unauth'); e.statusCode = 401; throw e; };
+    expect(await probeCredentials(creds, http)).toBe(false);
+    expect(await probeCredentials(creds, http)).toBe(false);
+    expect(calls).toBe(1);
+  });
+
+  it('probeCredentials does not cache network errors (allows retry)', async () => {
+    const { probeCredentials } = await import('../../nodes/Autotask/helpers/credential-store');
+    const creds = { Username: 'net-u', Secret: 's', APIIntegrationcode: 'c', zone: 'https://ws.test' };
+    let calls = 0;
+    const http = async () => { calls += 1; const e: any = new Error('ECONNREFUSED'); throw e; };
+    await probeCredentials(creds, http);
+    await probeCredentials(creds, http);
+    expect(calls).toBe(2);
+  });
+});

--- a/tests/vitest.unit.config.ts
+++ b/tests/vitest.unit.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['unit/**/*.test.ts'],
+    testTimeout: 10_000,
+    hookTimeout: 5_000,
+  },
+});


### PR DESCRIPTION
## Summary

- Adds opt-in per-user credential injection to the Autotask MCP Trigger node: MCP clients supply `X-Autotask-Username`, `X-Autotask-Secret`, `X-Autotask-IntegrationCode`, and `X-Autotask-Zone` HTTP headers; the trigger validates and injects them server-side via AsyncLocalStorage so the LLM/MCP client never sees the credentials
- Adds `acceptInjectedCredentials` toggle to `AutotaskAiTools` — injection is opt-in per tool node, allowing mixed workflows (some tools use injected creds, others use workflow-owner creds)
- Credentials are scrubbed from all error paths: `NodeApiError` message, `console.warn`/`console.debug` in `request.ts`, and JSONL debug traces in `debug-trace.ts`

## Architecture

**AsyncLocalStorage singletons** (`credential-store.ts`):
- `autotaskCredentialStore` — carries resolved `OverrideAutotaskCredentials` into `getCredentials('autotaskApi')` calls
- `requestHeaderStore` — carries per-request raw headers into the MCP `tools/call` handler without shared state across concurrent connections
- Both use `Symbol.for()` on `globalThis` to survive `require.cache` invalidation and `npm link` symlinks

**Probe cache** (`credential-store.ts`):
- 256-entry FIFO, 60 s positive TTL, 5 s negative TTL (401/403 only)
- Network errors are **not** cached — transient outages fail-open rather than locking users out
- In-flight coalescing prevents thundering herd on first use of a credential
- Post-invoke: `PERMISSION_DENIED` error type in the tool result invalidates the probe cache entry

**Header validation** (`credential-proxy.ts`):
- SSRF allowlist: `^https://webservicesN.autotask.(net|com|com.au|co.uk)/atservicesrest$`
- Header value guard: rejects control characters (CR/LF/NUL), max 1024 chars, Unicode allowed
- `buildCredentialProxy`: `Proxy` over `ISupplyDataFunctions` that merges override auth fields into the original credentials — non-auth settings (`cacheEnabled`, `cacheTTL`, etc.) are preserved from the workflow-owner credential so caching continues to work

**`AutotaskMcpServer`** (`mcp-trigger/McpServer.ts`):
- Custom class; `@modelcontextprotocol/sdk` resolved lazily via `require.main` (same two-strategy pattern as `ai-tools/runtime.ts`)
- `setupHandlers` captures instance state as locals before `setRequestHandler` closures to avoid async `this`-binding issues
- SSE session map capped at 256 entries with FIFO eviction and `server.close()` on cleanup

## Test Plan

- [x] `pnpm build` exits 0
- [x] `tests/unit/credential-store.test.ts` — 16 tests (ALS singletons, probe cache, normaliseZone, FIFO, TTL, network-error no-cache)
- [x] `tests/unit/credential-proxy.test.ts` — 14 tests (header validation, SSRF allowlist, unicode, proxy credential delegation)
- [x] `tests/ai-tools/suites/credential-injection.test.ts` — integration suite (skips when env vars absent; exercises describeFields under injected creds and rejects invalid creds with PERMISSION_DENIED)
- [ ] Live integration test: configure `TEST_INJECTION_ENDPOINT_URL` + `TEST_AT_OVERRIDE_*` vars in `tests/.env.test` and run `pnpm test:ai` — see `tests/.env.test.example` for var names

## Security notes

- Injected credentials never appear in MCP protocol messages or tool result envelopes
- `createOverrideScrubber` redacts Secret, IntegrationCode, and Username (≥4 char guard) from free-form error strings before they reach n8n UI or logs
- `execute()` path on `AutotaskAiTools` does **not** use injected credentials (Agent V3 path) — warns and ignores if ALS is unexpectedly populated
- Queue-mode guard: warns at runtime when `EXECUTIONS_MODE=queue` + injection enabled (ALS cannot cross process boundaries)