### PR TITLE
fix: force langsmith>=0.6.0 and tmp>=0.2.6 — resolve 4 Dependabot CVEs (v2.20.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,12 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
-## [2.20.3] - 2026-05-28
-
-### Fixed
-- **Security: force `langsmith >= 0.6.0`**: Added npm `overrides` and `pnpm.overrides` to resolve three Dependabot advisories (CVE-2026-45134 high — untrusted manifest deserialization; CVE-2026-41182 medium — streaming token bypass of output redaction; CVE-2026-40190 medium — prototype pollution via incomplete `__proto__` guard). Transitive chain: `@n8n/node-cli` → `@n8n/ai-utilities` → `@langchain/classic` → `langsmith@0.3.87`. Forced to 0.7.3 via override.
-- **Security: force `tmp >= 0.2.6`**: Added npm `overrides` and `pnpm.overrides` to resolve CVE-2026-44705 (high — path traversal via unsanitised prefix/postfix). Transitive chain: `@n8n/node-cli` → `@n8n/ai-utilities` → `tmp-promise` → `tmp@0.2.5`. Forced to 0.2.7 via override.
-
 ## [2.20.2] - 2026-05-28
 
 ### Fixed
 - **Security (GHSA-hh59-fgrr-93hf): HMAC bypass via unsigned Deactivated event**: `AutotaskTrigger.webhook()` processed `Action=Deactivated` payloads before HMAC verification and cleared `webhookData.secretKey`. An unauthenticated attacker could send a fake Deactivated event to permanently disable signature verification, then inject arbitrary forged webhook events. Fix: (1) the pre-HMAC deactivated handler no longer clears `secretKey` — only `webhookId` is cleared; (2) the no-secretKey fallback is now fail-closed, throwing a `NodeOperationError` instead of accepting unsigned requests; (3) `checkExists()` auto-migrates legacy webhooks — if `webhookId` is stored but `secretKey` is absent, a new HMAC secret is generated and PATCHed onto the Autotask webhook record automatically on next workflow load, with no user action required. If the PATCH fails, a warning is logged and the user must re-activate manually. CWE-287 / CVSS 8.2 (AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:L).
+- **Security: force `langsmith >= 0.6.0`**: Added npm `overrides` and `pnpm.overrides` to resolve three Dependabot advisories (CVE-2026-45134 high — untrusted manifest deserialization; CVE-2026-41182 medium — streaming token bypass of output redaction; CVE-2026-40190 medium — prototype pollution via incomplete `__proto__` guard). Transitive chain: `@n8n/node-cli` → `@n8n/ai-utilities` → `@langchain/classic` → `langsmith@0.3.87`. Forced to 0.7.3 via override.
+- **Security: force `tmp >= 0.2.6`**: Added npm `overrides` and `pnpm.overrides` to resolve CVE-2026-44705 (high — path traversal via unsanitised prefix/postfix). Transitive chain: `@n8n/node-cli` → `@n8n/ai-utilities` → `tmp-promise` → `tmp@0.2.5`. Forced to 0.2.7 via override.
 
 ## [2.20.1] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.20.3] - 2026-05-28
+
+### Fixed
+- **Security: force `langsmith >= 0.6.0`**: Added npm `overrides` and `pnpm.overrides` to resolve three Dependabot advisories (CVE-2026-45134 high — untrusted manifest deserialization; CVE-2026-41182 medium — streaming token bypass of output redaction; CVE-2026-40190 medium — prototype pollution via incomplete `__proto__` guard). Transitive chain: `@n8n/node-cli` → `@n8n/ai-utilities` → `@langchain/classic` → `langsmith@0.3.87`. Forced to 0.7.3 via override.
+- **Security: force `tmp >= 0.2.6`**: Added npm `overrides` and `pnpm.overrides` to resolve CVE-2026-44705 (high — path traversal via unsanitised prefix/postfix). Transitive chain: `@n8n/node-cli` → `@n8n/ai-utilities` → `tmp-promise` → `tmp@0.2.5`. Forced to 0.2.7 via override.
+
 ## [2.20.2] - 2026-05-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-autotask",
-      "version": "2.20.1",
+      "version": "2.20.2",
       "license": "MIT",
       "dependencies": {
         "change-case": "^4.1.2",
@@ -998,42 +998,6 @@
           "optional": true
         },
         "typeorm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/@langchain/classic/node_modules/langsmith": {
-      "version": "0.3.87",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
-      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "*",
-        "@opentelemetry/exporter-trace-otlp-proto": "*",
-        "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-proto": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        },
-        "openai": {
           "optional": true
         }
       }
@@ -2199,14 +2163,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.1",
@@ -3441,17 +3397,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/console-table-printer": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
-      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "simple-wcswidth": "^1.1.2"
-      }
     },
     "node_modules/constant-case": {
       "version": "3.0.4",
@@ -6329,9 +6274,9 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.3.tgz",
-      "integrity": "sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.3.tgz",
+      "integrity": "sha512-Gg+IeRGoF1/aStu80aEnIXJCu+N6+4NoV4tAVFS51ZPRBsRa2KG0LkS7K7/ryZ/yES7O9xdqah5QuuWMIeMjQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7927,14 +7872,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-wcswidth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
-      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -8134,9 +8071,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.20.3",
+  "version": "2.20.2",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",
@@ -82,13 +82,16 @@
     "n8n-workflow": "*"
   },
   "overrides": {
-    "uuid": ">=11.1.1"
+    "uuid": ">=11.1.1",
+    "langsmith": ">=0.6.0",
+    "tmp": ">=0.2.6"
   },
   "pnpm": {
     "overrides": {
       "uuid": ">=11.1.1",
       "uuid@>=13.0.0 <13.0.1": ">=13.0.1",
-      "langsmith@<0.6.0": "^0.6.3"
+      "langsmith@<0.6.0": "^0.6.3",
+      "tmp@<0.2.6": ">=0.2.6"
     }
   }
 }


### PR DESCRIPTION
## Summary

Resolves all 4 open Dependabot security alerts via npm `overrides`.

| Alert | Package | Severity | CVE | Fixed |
|---|---|---|---|---|
| #42 | `tmp` | **High** | CVE-2026-44705 | 0.2.5 → 0.2.7 |
| #38 | `langsmith` | **High** | CVE-2026-45134 | 0.3.87 → 0.7.3 |
| #21 | `langsmith` | Medium | CVE-2026-41182 | 0.3.87 → 0.7.3 |
| #17 | `langsmith` | Medium | CVE-2026-40190 | 0.3.87 → 0.7.3 |

## Dependency chains (devDependencies only — no consumer impact)

```
langsmith: @n8n/node-cli → @n8n/ai-node-sdk → @n8n/ai-utilities → @langchain/classic → langsmith@0.3.87
tmp:       @n8n/node-cli → @n8n/ai-node-sdk → @n8n/ai-utilities → tmp-promise → tmp@0.2.5
```

Both are deep transitive **devDependencies**. They are not shipped in the published package and do not affect consumers.

## Fix

Added `langsmith: ">=0.6.0"` and `tmp: ">=0.2.6"` to npm `overrides` (and `pnpm.overrides` for older pnpm). Running `npm install` resolved the lock file: nested vulnerable copies eliminated, both forced to patched versions.