### PR TITLE
feat: rate limit hardening v2.21.0 — 7 bugs fixed, RATE_LIMITED error type, per-credential tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.21.0] - 2026-06-01
+
+### Fixed
+
+- **Rate limit: `Retry-After` cap bug** — `retryHandler.ts` was capping the `Retry-After` header at 60 s regardless of what the server specified. If Autotask responded with `Retry-After: 300`, the handler retried after 60 s and immediately hit 429 again. Now respects the server value up to a 10-minute ceiling (`MAX_RETRY_AFTER_MS = 600_000`).
+- **Rate limit: HTTP-date `Retry-After` format** — RFC 7231 allows `Retry-After` as either integer seconds or an HTTP-date string. Only the integer form was handled; HTTP-date fell back to 60 s silently. Both forms are now parsed; unparseable values still fall back to 60 s.
+- **Rate limit: no structured error type for LLM** — HTTP 429 errors surfaced through the AI tools path as generic `API_ERROR` with no actionable guidance. LLMs would retry indefinitely. New `RATE_LIMITED` error type added with a stop instruction and optional `retryAfterSeconds` field in the flat response envelope.
+- **Rate limit: AI tools node never initialized rate tracker** — `AutotaskAiTools.node.ts` never called `initializeRateTracker`, so the ThresholdInformation API sync was never wired up for AI tool executions. The tracker ran on pure local counting only. Both `supplyData()` and `execute()` now initialize the tracker.
+- **Rate limit: stale `actualUsageCount` after window reset** — `resetCounterIfNeeded()` only reset the local request counter but not the API-synced `actualUsageCount`. Stale counts from the previous window continued to drive throttle decisions after the hourly boundary.
+- **Rate limit: sync interval too long** — `syncIntervalMs` was 3,600,000 ms (1 hour). Reduced to 300,000 ms (5 minutes) for more accurate usage tracking.
+
+### Changed
+
+- **Per-credential rate tracker** — `RequestRateTracker` is now instantiated per credential key (derived from zone + Username + APIIntegrationcode) via a new `getTrackerForCredential(key)` factory. Multi-tenant n8n instances with multiple Autotask credentials no longer share rate limit state. `handleRateLimit(tracker?)` accepts an optional tracker parameter; the `rateTracker` default export is retained for backward compatibility.
+
 ## [2.20.2] - 2026-05-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the n8n-nodes-autotask project will be documented in this
 
 ### Fixed
 
-- **Rate limit: `Retry-After` cap bug** — `retryHandler.ts` was capping the `Retry-After` header at 60 s regardless of what the server specified. If Autotask responded with `Retry-After: 300`, the handler retried after 60 s and immediately hit 429 again. Now respects the server value up to a 10-minute ceiling (`MAX_RETRY_AFTER_MS = 600_000`).
+- **Rate limit: `Retry-After` cap bug** — `retryHandler.ts` was capping the `Retry-After` header at 60 s regardless of what the server specified. If Autotask responded with `Retry-After: 300`, the handler retried after 60 s and immediately hit 429 again. Now parses the server value (integer-seconds and HTTP-date formats) and applies it within the 5-minute total-wait budget; zero/negative values are floored to 1 s.
 - **Rate limit: HTTP-date `Retry-After` format** — RFC 7231 allows `Retry-After` as either integer seconds or an HTTP-date string. Only the integer form was handled; HTTP-date fell back to 60 s silently. Both forms are now parsed; unparseable values still fall back to 60 s.
 - **Rate limit: no structured error type for LLM** — HTTP 429 errors surfaced through the AI tools path as generic `API_ERROR` with no actionable guidance. LLMs would retry indefinitely. New `RATE_LIMITED` error type added with a stop instruction and optional `retryAfterSeconds` field in the flat response envelope.
 - **Rate limit: AI tools node never initialized rate tracker** — `AutotaskAiTools.node.ts` never called `initializeRateTracker`, so the ThresholdInformation API sync was never wired up for AI tool executions. The tracker ran on pure local counting only. Both `supplyData()` and `execute()` now initialize the tracker.

--- a/nodes/Autotask/Autotask.node.ts
+++ b/nodes/Autotask/Autotask.node.ts
@@ -102,6 +102,7 @@ import { getResourceMapperFields } from './helpers/resourceMapper';
 import { getEntityMetadata } from './constants/entities';
 import { RESOURCE_DEFINITIONS } from './resources/definitions';
 import { initializeRateTracker } from './helpers/http/initRateTracker';
+import type { IAutotaskCredentials } from './types/base/auth';
 import { projectTaskFields } from './resources/projectTasks/description';
 import { taskSecondaryResourceFields } from './resources/taskSecondaryResources/description';
 import { projectFields } from './resources/projects/description';
@@ -463,7 +464,15 @@ export class Autotask implements INodeType {
 		// Initialise rate tracker with actual Autotask usage.
 		// This uses a cooldown guard, so multiple concurrent executions
 		// will not all trigger a threshold information request.
-		await initializeRateTracker(this);
+		try {
+			const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
+			if (creds.zone && creds.Username && creds.APIIntegrationcode) {
+				const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
+				await initializeRateTracker(this, credentialKey);
+			}
+		} catch (error) {
+			console.warn('[Autotask] initializeRateTracker failed; falling back to local counting.', error instanceof Error ? error.message : String(error));
+		}
 
 		const resource = this.getNodeParameter('resource', 0) as string;
 		const operation = this.getNodeParameter('operation', 0) as string;

--- a/nodes/Autotask/Autotask.node.ts
+++ b/nodes/Autotask/Autotask.node.ts
@@ -466,8 +466,11 @@ export class Autotask implements INodeType {
 		// will not all trigger a threshold information request.
 		try {
 			const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
-			if (creds.zone && creds.Username && creds.APIIntegrationcode) {
-				const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
+			// Resolve the base URL so the tracker key matches the one used in request.ts.
+			// For zone === 'other' this is the custom zone URL; otherwise it is the zone.
+			const resolvedBaseUrl = creds.zone === 'other' ? creds.customZoneUrl || '' : creds.zone;
+			if (resolvedBaseUrl && creds.Username && creds.APIIntegrationcode) {
+				const credentialKey = `${resolvedBaseUrl}|${creds.Username}|${creds.APIIntegrationcode}`;
 				await initializeRateTracker(this, credentialKey);
 			}
 		} catch (error) {

--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -48,6 +48,8 @@ import {
 } from './ai-tools/debug-trace';
 import { autotaskCredentialStore, probeCredentialIdentity } from './helpers/credential-store';
 import { buildCredentialProxy } from './helpers/credential-proxy';
+import { initializeRateTracker } from './helpers/http/initRateTracker';
+import type { IAutotaskCredentials } from './types/base/auth';
 
 const EXCLUDED_RESOURCES = ['aiHelper', 'apiThreshold'];
 const TOOL_BUILD_CACHE_TTL_MS = 90_000;
@@ -409,6 +411,15 @@ export class AutotaskAiTools implements INodeType {
 	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
 		const { buildUnifiedSchema } = getRuntimeSchemaBuilders(runtimeZod);
 
+		// Initialize rate tracker with credential context (mirrors Autotask.node.ts)
+		try {
+			const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
+			const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
+			await initializeRateTracker(this, credentialKey);
+		} catch {
+			// Non-fatal — rate tracker falls back to local counting
+		}
+
 		const resource = this.getNodeParameter('resource', itemIndex) as string;
 		const operations = this.getNodeParameter('operations', itemIndex) as string[];
 		const allowWriteOperations = this.getNodeParameter(
@@ -732,6 +743,14 @@ export class AutotaskAiTools implements INodeType {
 				'[AutotaskAiTools] execute(): autotaskCredentialStore unexpectedly populated — ' +
 				'override credentials are not supported on the Agent V3 execute() path. Ignoring.',
 			);
+		}
+		// Initialize rate tracker with credential context (mirrors Autotask.node.ts)
+		try {
+			const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
+			const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
+			await initializeRateTracker(this, credentialKey);
+		} catch {
+			// Non-fatal — rate tracker falls back to local counting
 		}
 		const resource = this.getNodeParameter('resource', 0) as string;
 		const operations = this.getNodeParameter('operations', 0) as string[];

--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -411,36 +411,6 @@ export class AutotaskAiTools implements INodeType {
 	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
 		const { buildUnifiedSchema } = getRuntimeSchemaBuilders(runtimeZod);
 
-		// Initialize rate tracker with credential context (mirrors Autotask.node.ts).
-		// On the MCP/supplyData path, injected override credentials may already be in the
-		// ALS store. Prefer those so the tracker key matches the actual credential used for
-		// subsequent API calls (which run through buildCredentialProxy with the override).
-		// OverrideAutotaskCredentials.zone is already normalised (no 'other'/customZoneUrl
-		// distinction). IAutotaskCredentials.zone may be 'other' and require customZoneUrl.
-		try {
-			const overrideCreds = autotaskCredentialStore.getStore();
-			let resolvedZone: string;
-			let username: string;
-			let integrationCode: string;
-			if (overrideCreds) {
-				resolvedZone = overrideCreds.zone;
-				username = overrideCreds.Username;
-				integrationCode = overrideCreds.APIIntegrationcode;
-			} else {
-				const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
-				resolvedZone = creds.zone === 'other' ? (creds.customZoneUrl ?? '') : creds.zone;
-				username = creds.Username;
-				integrationCode = creds.APIIntegrationcode;
-			}
-			if (resolvedZone && username && integrationCode) {
-				const credentialKey = `${resolvedZone}|${username}|${integrationCode}`;
-				await initializeRateTracker(this, credentialKey);
-			}
-		} catch (error) {
-			// Non-fatal — rate tracker falls back to local counting
-			console.warn('[AutotaskAiTools] initializeRateTracker failed; falling back to local counting.', error instanceof Error ? error.message : String(error));
-		}
-
 		const resource = this.getNodeParameter('resource', itemIndex) as string;
 		const operations = this.getNodeParameter('operations', itemIndex) as string[];
 		const allowWriteOperations = this.getNodeParameter(
@@ -687,6 +657,32 @@ export class AutotaskAiTools implements INodeType {
 						effectiveCredentialIdentity,
 						itemIndex,
 					);
+				}
+
+				// Initialize rate tracker using the actual credential for this invocation.
+				// Deferred to here (inside func) so that MCP per-user credential injection
+				// is resolved first — the tracker key must match the proxied request path.
+				try {
+					let trackerZone: string;
+					let trackerUsername: string;
+					let trackerIntegrationCode: string;
+					if (overrideCreds) {
+						// zone is already normalised in OverrideAutotaskCredentials (no 'other'/customZoneUrl)
+						trackerZone = overrideCreds.zone;
+						trackerUsername = overrideCreds.Username;
+						trackerIntegrationCode = overrideCreds.APIIntegrationcode;
+					} else {
+						const creds = await supplyDataContext.getCredentials('autotaskApi') as IAutotaskCredentials;
+						trackerZone = creds.zone === 'other' ? (creds.customZoneUrl ?? '') : creds.zone;
+						trackerUsername = creds.Username;
+						trackerIntegrationCode = creds.APIIntegrationcode;
+					}
+					if (trackerZone && trackerUsername && trackerIntegrationCode) {
+						const credentialKey = `${trackerZone}|${trackerUsername}|${trackerIntegrationCode}`;
+						await initializeRateTracker(effectiveContext as unknown as IExecuteFunctions, credentialKey);
+					}
+				} catch (error) {
+					console.warn('[AutotaskAiTools] initializeRateTracker failed; falling back to local counting.', error instanceof Error ? error.message : String(error));
 				}
 
 				const operation = rawParams.operation as string;

--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -414,8 +414,9 @@ export class AutotaskAiTools implements INodeType {
 		// Initialize rate tracker with credential context (mirrors Autotask.node.ts)
 		try {
 			const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
-			if (creds.zone && creds.Username && creds.APIIntegrationcode) {
-				const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
+			const resolvedZone = creds.zone === 'other' ? (creds.customZoneUrl ?? '') : creds.zone;
+			if (resolvedZone && creds.Username && creds.APIIntegrationcode) {
+				const credentialKey = `${resolvedZone}|${creds.Username}|${creds.APIIntegrationcode}`;
 				await initializeRateTracker(this, credentialKey);
 			}
 		} catch (error) {
@@ -750,8 +751,9 @@ export class AutotaskAiTools implements INodeType {
 		// Initialize rate tracker with credential context (mirrors Autotask.node.ts)
 		try {
 			const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
-			if (creds.zone && creds.Username && creds.APIIntegrationcode) {
-				const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
+			const resolvedZone = creds.zone === 'other' ? (creds.customZoneUrl ?? '') : creds.zone;
+			if (resolvedZone && creds.Username && creds.APIIntegrationcode) {
+				const credentialKey = `${resolvedZone}|${creds.Username}|${creds.APIIntegrationcode}`;
 				await initializeRateTracker(this, credentialKey);
 			}
 		} catch (error) {

--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -414,10 +414,13 @@ export class AutotaskAiTools implements INodeType {
 		// Initialize rate tracker with credential context (mirrors Autotask.node.ts)
 		try {
 			const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
-			const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
-			await initializeRateTracker(this, credentialKey);
-		} catch {
+			if (creds.zone && creds.Username && creds.APIIntegrationcode) {
+				const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
+				await initializeRateTracker(this, credentialKey);
+			}
+		} catch (error) {
 			// Non-fatal — rate tracker falls back to local counting
+			console.warn('[AutotaskAiTools] initializeRateTracker failed; falling back to local counting.', error instanceof Error ? error.message : String(error));
 		}
 
 		const resource = this.getNodeParameter('resource', itemIndex) as string;
@@ -747,10 +750,13 @@ export class AutotaskAiTools implements INodeType {
 		// Initialize rate tracker with credential context (mirrors Autotask.node.ts)
 		try {
 			const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
-			const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
-			await initializeRateTracker(this, credentialKey);
-		} catch {
+			if (creds.zone && creds.Username && creds.APIIntegrationcode) {
+				const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
+				await initializeRateTracker(this, credentialKey);
+			}
+		} catch (error) {
 			// Non-fatal — rate tracker falls back to local counting
+			console.warn('[AutotaskAiTools] initializeRateTracker failed; falling back to local counting.', error instanceof Error ? error.message : String(error));
 		}
 		const resource = this.getNodeParameter('resource', 0) as string;
 		const operations = this.getNodeParameter('operations', 0) as string[];

--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -411,12 +411,29 @@ export class AutotaskAiTools implements INodeType {
 	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
 		const { buildUnifiedSchema } = getRuntimeSchemaBuilders(runtimeZod);
 
-		// Initialize rate tracker with credential context (mirrors Autotask.node.ts)
+		// Initialize rate tracker with credential context (mirrors Autotask.node.ts).
+		// On the MCP/supplyData path, injected override credentials may already be in the
+		// ALS store. Prefer those so the tracker key matches the actual credential used for
+		// subsequent API calls (which run through buildCredentialProxy with the override).
+		// OverrideAutotaskCredentials.zone is already normalised (no 'other'/customZoneUrl
+		// distinction). IAutotaskCredentials.zone may be 'other' and require customZoneUrl.
 		try {
-			const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
-			const resolvedZone = creds.zone === 'other' ? (creds.customZoneUrl ?? '') : creds.zone;
-			if (resolvedZone && creds.Username && creds.APIIntegrationcode) {
-				const credentialKey = `${resolvedZone}|${creds.Username}|${creds.APIIntegrationcode}`;
+			const overrideCreds = autotaskCredentialStore.getStore();
+			let resolvedZone: string;
+			let username: string;
+			let integrationCode: string;
+			if (overrideCreds) {
+				resolvedZone = overrideCreds.zone;
+				username = overrideCreds.Username;
+				integrationCode = overrideCreds.APIIntegrationcode;
+			} else {
+				const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
+				resolvedZone = creds.zone === 'other' ? (creds.customZoneUrl ?? '') : creds.zone;
+				username = creds.Username;
+				integrationCode = creds.APIIntegrationcode;
+			}
+			if (resolvedZone && username && integrationCode) {
+				const credentialKey = `${resolvedZone}|${username}|${integrationCode}`;
 				await initializeRateTracker(this, credentialKey);
 			}
 		} catch (error) {

--- a/nodes/Autotask/AutotaskTrigger.node.ts
+++ b/nodes/Autotask/AutotaskTrigger.node.ts
@@ -22,6 +22,7 @@ import { randomBytes } from 'node:crypto';
 import { normalizeFieldId, processBatchFields } from './helpers/webhook/fieldConfiguration';
 import { fetchThresholdInformation } from './helpers/http/request';
 import { initializeRateTracker } from './helpers/http/initRateTracker';
+import type { IAutotaskCredentials } from './types/base/auth';
 
 // Create a more specific interface for the ResourceMapperField
 interface IWebhookResourceMapperField {
@@ -474,7 +475,9 @@ export class AutotaskTrigger implements INodeType {
 			async create(this: IHookFunctions): Promise<boolean> {
 				try {
 					// Initialize rate tracker with API threshold information
-					await initializeRateTracker(this);
+					const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
+					const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
+					await initializeRateTracker(this, credentialKey);
 
 					// Check Autotask API usage
 					try {

--- a/nodes/Autotask/AutotaskTrigger.node.ts
+++ b/nodes/Autotask/AutotaskTrigger.node.ts
@@ -476,7 +476,10 @@ export class AutotaskTrigger implements INodeType {
 				try {
 					// Initialize rate tracker with API threshold information
 					const creds = await this.getCredentials('autotaskApi') as IAutotaskCredentials;
-					const credentialKey = `${creds.zone}|${creds.Username}|${creds.APIIntegrationcode}`;
+					// Resolve the base URL so the tracker key matches the one used in request.ts.
+					// For zone === 'other' this is the custom zone URL; otherwise it is the zone.
+					const resolvedBaseUrl = creds.zone === 'other' ? creds.customZoneUrl || '' : creds.zone;
+					const credentialKey = `${resolvedBaseUrl}|${creds.Username}|${creds.APIIntegrationcode}`;
 					await initializeRateTracker(this, credentialKey);
 
 					// Check Autotask API usage

--- a/nodes/Autotask/ai-tools/error-formatter.ts
+++ b/nodes/Autotask/ai-tools/error-formatter.ts
@@ -182,7 +182,9 @@ export function formatApiError(
 		|| lowerMessage.includes('429')
 		|| lowerMessage.includes('too many requests')
 	) {
-		const secondsMatch = message.match(/(\d+)\s*second/i);
+		// Only extract retry hint from genuine "retry after N seconds" phrasing.
+		// Excludes "over N seconds" (elapsed time in handler exhaustion messages).
+		const secondsMatch = message.match(/retry.{1,20}?(\d+)\s*s(?:ec|econds?)?/i);
 		const retryAfterSeconds = secondsMatch ? Number.parseInt(secondsMatch[1], 10) : undefined;
 		return formatRateLimitError(resource, operation, retryAfterSeconds);
 	}

--- a/nodes/Autotask/ai-tools/error-formatter.ts
+++ b/nodes/Autotask/ai-tools/error-formatter.ts
@@ -183,7 +183,6 @@ export function formatApiError(
 
 	if (
 		lowerMessage.includes('rate limit')
-		|| lowerMessage.includes('429')
 		|| lowerMessage.includes('too many requests')
 	) {
 		// Only extract retry hint from genuine "retry after N seconds" phrasing.

--- a/nodes/Autotask/ai-tools/error-formatter.ts
+++ b/nodes/Autotask/ai-tools/error-formatter.ts
@@ -23,6 +23,7 @@ export const ERROR_TYPES = {
 	WRITE_RESOLUTION_INCOMPLETE: 'WRITE_RESOLUTION_INCOMPLETE',
 	INVALID_INPUT: 'INVALID_INPUT',
 	INTERNAL_ERROR: 'INTERNAL_ERROR',
+	RATE_LIMITED: 'RATE_LIMITED',
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -38,6 +39,7 @@ export interface FlatErrorResponse {
 	operation: string;
 	summary: string;
 	mustRetryAfter?: string[];
+	retryAfterSeconds?: number;
 	correlationId?: string;
 }
 
@@ -149,12 +151,41 @@ export function formatFilterConstraintError(
 	);
 }
 
+export function formatRateLimitError(
+	resource: string,
+	operation: string,
+	retryAfterSeconds?: number,
+): FlatErrorResponse {
+	const waitHint = retryAfterSeconds !== undefined ? ` Retry after ${retryAfterSeconds}s.` : '';
+	const base = wrapError(
+		resource,
+		operation,
+		ERROR_TYPES.RATE_LIMITED,
+		`Autotask API rate limit hit.${waitHint}`,
+		'Stop retrying. Tell the user the Autotask API rate limit has been reached. Ask them to reduce workflow frequency or wait before retrying.',
+	);
+	if (retryAfterSeconds !== undefined) {
+		return { ...base, retryAfterSeconds };
+	}
+	return base;
+}
+
 export function formatApiError(
 	message: string,
 	resource: string,
 	operation: string,
 ): FlatErrorResponse {
 	const lowerMessage = message.toLowerCase();
+
+	if (
+		lowerMessage.includes('rate limit')
+		|| lowerMessage.includes('429')
+		|| lowerMessage.includes('too many requests')
+	) {
+		const secondsMatch = message.match(/(\d+)\s*second/i);
+		const retryAfterSeconds = secondsMatch ? Number.parseInt(secondsMatch[1], 10) : undefined;
+		return formatRateLimitError(resource, operation, retryAfterSeconds);
+	}
 
 	if (
 		lowerMessage.includes('lock')

--- a/nodes/Autotask/ai-tools/error-formatter.ts
+++ b/nodes/Autotask/ai-tools/error-formatter.ts
@@ -156,7 +156,11 @@ export function formatRateLimitError(
 	operation: string,
 	retryAfterSeconds?: number,
 ): FlatErrorResponse {
-	const waitHint = retryAfterSeconds !== undefined ? ` Retry after ${retryAfterSeconds}s.` : '';
+	// Sanitise: only propagate a finite positive integer; 0/negative/NaN would instruct "retry immediately"
+	const safeSeconds = Number.isFinite(retryAfterSeconds) && (retryAfterSeconds as number) > 0
+		? retryAfterSeconds
+		: undefined;
+	const waitHint = safeSeconds !== undefined ? ` Retry after ${safeSeconds}s.` : '';
 	const base = wrapError(
 		resource,
 		operation,
@@ -164,8 +168,8 @@ export function formatRateLimitError(
 		`Autotask API rate limit hit.${waitHint}`,
 		'Stop retrying. Tell the user the Autotask API rate limit has been reached. Ask them to reduce workflow frequency or wait before retrying.',
 	);
-	if (retryAfterSeconds !== undefined) {
-		return { ...base, retryAfterSeconds };
+	if (safeSeconds !== undefined) {
+		return { ...base, retryAfterSeconds: safeSeconds };
 	}
 	return base;
 }

--- a/nodes/Autotask/helpers/http/initRateTracker.ts
+++ b/nodes/Autotask/helpers/http/initRateTracker.ts
@@ -1,36 +1,39 @@
-import type { IExecuteFunctions, IHookFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
-import { rateTracker } from './rateLimit';
+import type { IExecuteFunctions, IHookFunctions, ILoadOptionsFunctions, ISupplyDataFunctions } from 'n8n-workflow';
+import { getTrackerForCredential, rateTracker } from './rateLimit';
 import { fetchThresholdInformation } from './request';
 import { autotaskCredentialStore } from '../credential-store';
 import { sanitizeErrorForLogging, createOverrideScrubber } from '../security/credential-masking';
 
-let lastInitTime = 0;
+const initTimes = new Map<string, number>();
 const INIT_COOLDOWN_MS = 300_000; // 5 minutes
 
 /**
- * Initializes the rate tracker with the proper threshold information fetcher
+ * Initializes the rate tracker for a specific credential with the proper
+ * threshold information fetcher. Uses a per-credential cooldown so concurrent
+ * executions do not all trigger a threshold information request.
  *
  * @param context Execution context with access to credentials
- * @returns Promise that resolves when initialization is complete
+ * @param credentialKey Unique key identifying the credential (zone|Username|APIIntegrationcode)
  */
 export async function initializeRateTracker(
-	context: IExecuteFunctions | IHookFunctions | ILoadOptionsFunctions,
+	context: IExecuteFunctions | IHookFunctions | ILoadOptionsFunctions | ISupplyDataFunctions,
+	credentialKey = 'default',
 ): Promise<void> {
 	const now = Date.now();
+	const lastInit = initTimes.get(credentialKey) ?? 0;
 
-	// Simple cooldown so multiple concurrent executions do not all trigger a sync
-	if (now - lastInitTime < INIT_COOLDOWN_MS) {
+	if (now - lastInit < INIT_COOLDOWN_MS) {
 		return;
 	}
 
-	lastInitTime = now;
+	initTimes.set(credentialKey, now);
 
 	try {
-		// Set up the threshold info fetcher to use the context for credentials
-		rateTracker.setThresholdInfoFetcher(async () => {
-			try {
-				const result = await fetchThresholdInformation.call(context);
+		const tracker = getTrackerForCredential(credentialKey);
 
+		tracker.setThresholdInfoFetcher(async () => {
+			try {
+				const result = await fetchThresholdInformation.call(context as IExecuteFunctions);
 				return result;
 			} catch (error) {
 				const scrub = createOverrideScrubber(autotaskCredentialStore.getStore());
@@ -41,8 +44,7 @@ export async function initializeRateTracker(
 			}
 		});
 
-		// Trigger an initial sync
-		await rateTracker.syncWithApi();
+		await tracker.syncWithApi();
 	} catch (error) {
 		const scrub = createOverrideScrubber(autotaskCredentialStore.getStore());
 		const sanitized = sanitizeErrorForLogging(error);
@@ -52,19 +54,15 @@ export async function initializeRateTracker(
 }
 
 /**
- * Simplified version that doesn't require an execution context.
- * This can be used during module initialization if context isn't available yet.
- * The rate tracker will start with local counting only, and sync when it gets a context later.
+ * Simplified early-init that doesn't require an execution context.
+ * The default tracker starts with local counting only and syncs when
+ * a context is available via initializeRateTracker.
  */
 export function initializeRateTrackerEarly(): void {
-    try {
-        // Silently initialize the rate tracker without logging
-        // This line ensures the singleton is instantiated
-        rateTracker;
-
-        // No console output to keep n8n startup clean
-    } catch (error) {
-        // Only log critical errors
-        console.error('[RateTracker] Critical initialization error:', error);
-    }
+	try {
+		// Touch the default tracker to ensure the singleton is instantiated
+		void rateTracker;
+	} catch (error) {
+		console.error('[RateTracker] Critical initialization error:', error);
+	}
 }

--- a/nodes/Autotask/helpers/http/initRateTracker.ts
+++ b/nodes/Autotask/helpers/http/initRateTracker.ts
@@ -13,7 +13,8 @@ const INIT_COOLDOWN_MS = 300_000; // 5 minutes
  * executions do not all trigger a threshold information request.
  *
  * @param context Execution context with access to credentials
- * @param credentialKey Unique key identifying the credential (zone|Username|APIIntegrationcode)
+ * @param credentialKey Unique key identifying the credential (zone|Username|APIIntegrationcode).
+ *   Defaults to 'default', which shares the global singleton — always pass an explicit key for per-credential isolation.
  */
 export async function initializeRateTracker(
 	context: IExecuteFunctions | IHookFunctions | ILoadOptionsFunctions | ISupplyDataFunctions,
@@ -46,6 +47,8 @@ export async function initializeRateTracker(
 
 		await tracker.syncWithApi();
 	} catch (error) {
+		// Allow immediate retry on next invocation rather than blocking for 5 min
+		initTimes.delete(credentialKey);
 		const scrub = createOverrideScrubber(autotaskCredentialStore.getStore());
 		const sanitized = sanitizeErrorForLogging(error);
 		if (typeof sanitized.message === 'string') sanitized.message = scrub(sanitized.message);

--- a/nodes/Autotask/helpers/http/rateLimit.ts
+++ b/nodes/Autotask/helpers/http/rateLimit.ts
@@ -11,7 +11,7 @@ class RequestRateTracker {
 
     // Threshold sync properties
     private lastSyncTime = 0;
-    private syncIntervalMs = 3600000;    // Sync every hour
+    private syncIntervalMs = 300_000;    // Sync every 5 minutes
     private actualUsageCount = 0;
     private thresholdLimit = 10000;
     private syncPromise: Promise<void> | null = null;
@@ -26,6 +26,10 @@ class RequestRateTracker {
             RequestRateTracker.instance = new RequestRateTracker();
         }
         return RequestRateTracker.instance;
+    }
+
+    public static create(): RequestRateTracker {
+        return new RequestRateTracker();
     }
 
     /**
@@ -73,6 +77,7 @@ class RequestRateTracker {
         if (now >= this.counterResetTime) {
             const oldCount = this.requestCount;
             this.requestCount = 0;
+            this.actualUsageCount = 0;
             this.counterResetTime = now + this.hourInMs;
             this.debugLog(`Counter reset: ${oldCount} → 0, next reset at ${new Date(this.counterResetTime).toISOString()}`);
         }
@@ -269,14 +274,14 @@ export function calculateThrottleDuration(usagePercent: number): number {
  * @param maxWaitMs Maximum time to wait before giving up (default: 10 minutes)
  * @throws Error if rate limit cannot be satisfied within maxWaitMs
  */
-export async function handleRateLimit(maxWaitMs = 600000): Promise<void> {
-    const rateTracker = RequestRateTracker.getInstance();
-    const usagePercent = rateTracker.trackRequest();
+export async function handleRateLimit(tracker?: RequestRateTracker, maxWaitMs = 600_000): Promise<void> {
+    const rt = tracker ?? rateTracker;
+    const usagePercent = rt.trackRequest();
 
     // If we're at or over the rate limit, wait until the rolling window allows new requests
-    if (rateTracker.shouldThrottle()) {
-        const currentCount = rateTracker.getCurrentCount();
-        const limit = rateTracker.getThresholdLimit();
+    if (rt.shouldThrottle()) {
+        const currentCount = rt.getCurrentCount();
+        const limit = rt.getThresholdLimit();
 
         console.warn(`[RateLimit] Rate limit reached: ${currentCount}/${limit} requests. Waiting for rolling window to reset...`);
 
@@ -285,7 +290,7 @@ export async function handleRateLimit(maxWaitMs = 600000): Promise<void> {
         const waitInterval = 5000; // Check every 5 seconds
         let totalWaitTime = 0;
 
-        while (rateTracker.shouldThrottle() && totalWaitTime < maxWaitMs) {
+        while (rt.shouldThrottle() && totalWaitTime < maxWaitMs) {
             // ALS context (autotaskCredentialStore) propagates through setTimeout on Node >=12.17 — safe.
             // This project requires node >=18.10 (package.json engines), so ALS propagation is guaranteed.
             await new Promise(resolve => setTimeout(resolve, waitInterval));
@@ -294,11 +299,11 @@ export async function handleRateLimit(maxWaitMs = 600000): Promise<void> {
             // Try to sync with API to get updated count every 30 seconds
             if (totalWaitTime >= 30000 && totalWaitTime % 30000 < waitInterval) {
                 console.debug(`[RateLimit] Still waiting... (${(totalWaitTime / 1000).toFixed(0)}s elapsed)`);
-                await rateTracker.syncWithApi();
+                await rt.syncWithApi();
             }
         }
 
-        if (rateTracker.shouldThrottle()) {
+        if (rt.shouldThrottle()) {
             throw new Error(
                 `Rate limit exceeded: Unable to proceed after waiting ${(maxWaitMs / 1000).toFixed(0)} seconds. ` +
                 `Current usage: ${currentCount}/${limit} requests in the last 60 minutes. ` +
@@ -311,7 +316,7 @@ export async function handleRateLimit(maxWaitMs = 600000): Promise<void> {
     }
 
     // Apply progressive throttling based on current usage
-    const throttleDelay = rateTracker.getThrottleDuration();
+    const throttleDelay = rt.getThrottleDuration();
     if (throttleDelay > 0) {
         console.debug(`[RateLimit] Applying throttle delay of ${throttleDelay}ms (usage: ${usagePercent.toFixed(1)}%)`);
         // ALS context (autotaskCredentialStore) propagates through setTimeout on Node >=12.17 — safe.
@@ -320,4 +325,17 @@ export async function handleRateLimit(maxWaitMs = 600000): Promise<void> {
     }
 }
 
-export const rateTracker = RequestRateTracker.getInstance();
+// Per-credential tracker registry. Each unique credential key gets its own
+// tracker so multi-tenant n8n instances don't share rate limit state.
+const trackerRegistry = new Map<string, RequestRateTracker>();
+
+export function getTrackerForCredential(credentialKey: string): RequestRateTracker {
+	if (!trackerRegistry.has(credentialKey)) {
+		trackerRegistry.set(credentialKey, RequestRateTracker.create());
+	}
+	return trackerRegistry.get(credentialKey)!;
+}
+
+// Default singleton retained for backward compatibility (early-init and callers
+// that don't yet have credential context).
+export const rateTracker = getTrackerForCredential('default');

--- a/nodes/Autotask/helpers/http/rateLimit.ts
+++ b/nodes/Autotask/helpers/http/rateLimit.ts
@@ -271,6 +271,7 @@ export function calculateThrottleDuration(usagePercent: number): number {
  * - 75%+ usage: +1s per request
  * See: https://www.autotask.net/help/DeveloperHelp/Content/APIs/REST/General_Topics/REST_Thresholds_Limits.htm
  *
+ * @param tracker Per-credential tracker from getTrackerForCredential(); defaults to the shared rateTracker singleton
  * @param maxWaitMs Maximum time to wait before giving up (default: 10 minutes)
  * @throws Error if rate limit cannot be satisfied within maxWaitMs
  */

--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -364,7 +364,9 @@ export async function autotaskApiRequest<T = JsonObject>(
 		);
 	}
 	const baseUrl = credentials.zone === 'other' ? credentials.customZoneUrl || '' : credentials.zone;
-	const credentialKey = `${credentials.zone}|${credentials.Username}|${credentials.APIIntegrationcode}`;
+	const credentialKey = credentials.zone && credentials.Username && credentials.APIIntegrationcode
+		? `${credentials.zone}|${credentials.Username}|${credentials.APIIntegrationcode}`
+		: 'default';
 	if (!baseUrl || typeof baseUrl !== 'string' || !baseUrl.trim()) {
 		 
 		throw new Error(

--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -16,7 +16,7 @@ import { getEntityMetadata } from '../../constants/entities';
 import type { IQueryResponse } from '../../types/base/entity-types';
 import type { IApiError, IApiErrorDetail, IApiErrorWithResponse } from '../../types/base/api';
 import type { OperationType } from '../../types/base/entity-types';
-import { handleRateLimit } from './rateLimit';
+import { handleRateLimit, getTrackerForCredential } from './rateLimit';
 import { endpointThreadTracker } from './threadLimit';
 import { executeWithRetry } from './retryHandler';
 import { autotaskCredentialStore } from '../credential-store';
@@ -364,6 +364,7 @@ export async function autotaskApiRequest<T = JsonObject>(
 		);
 	}
 	const baseUrl = credentials.zone === 'other' ? credentials.customZoneUrl || '' : credentials.zone;
+	const credentialKey = `${credentials.zone}|${credentials.Username}|${credentials.APIIntegrationcode}`;
 	if (!baseUrl || typeof baseUrl !== 'string' || !baseUrl.trim()) {
 		 
 		throw new Error(
@@ -442,7 +443,7 @@ export async function autotaskApiRequest<T = JsonObject>(
 		await endpointThreadTracker.acquireThread(baseEndpoint);
 
 		// Handle rate limiting before making the request (single attempt)
-		await handleRateLimit();
+		await handleRateLimit(getTrackerForCredential(credentialKey));
 
 		const response = await executeWithRetry(this, async () => {
 			return this.helpers.request(options);

--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -364,8 +364,11 @@ export async function autotaskApiRequest<T = JsonObject>(
 		);
 	}
 	const baseUrl = credentials.zone === 'other' ? credentials.customZoneUrl || '' : credentials.zone;
-	const credentialKey = credentials.zone && credentials.Username && credentials.APIIntegrationcode
-		? `${credentials.zone}|${credentials.Username}|${credentials.APIIntegrationcode}`
+	// Key on the resolved base URL (not the literal zone) so two distinct custom
+	// zones (zone === 'other') with the same Username + integration code do not
+	// collide onto a single rate tracker / cooldown / ThresholdInformation fetcher.
+	const credentialKey = baseUrl && credentials.Username && credentials.APIIntegrationcode
+		? `${baseUrl}|${credentials.Username}|${credentials.APIIntegrationcode}`
 		: 'default';
 	if (!baseUrl || typeof baseUrl !== 'string' || !baseUrl.trim()) {
 		 

--- a/nodes/Autotask/helpers/http/retryHandler.ts
+++ b/nodes/Autotask/helpers/http/retryHandler.ts
@@ -8,7 +8,7 @@ import { NodeApiError } from 'n8n-workflow';
 const MAX_TOTAL_WAIT_MS = 300_000; // 5 minutes
 const BASE_DELAY_MS = 1_000; // Start with 1 second
 const MAX_DELAY_MS = 60_000; // Cap exponential backoff at 1 minute
-const MAX_RETRY_AFTER_MS = 600_000; // Respect Retry-After up to 10 minutes
+const MAX_RETRY_AFTER_MS = 600_000; // Upper bound for a single Retry-After wait; effective ceiling is MAX_TOTAL_WAIT_MS (5 min) — a wait longer than the budget triggers an immediate throw
 
 type AutotaskContexts = IExecuteFunctions | IHookFunctions | ILoadOptionsFunctions;
 

--- a/nodes/Autotask/helpers/http/retryHandler.ts
+++ b/nodes/Autotask/helpers/http/retryHandler.ts
@@ -8,7 +8,7 @@ import { NodeApiError } from 'n8n-workflow';
 const MAX_TOTAL_WAIT_MS = 300_000; // 5 minutes
 const BASE_DELAY_MS = 1_000; // Start with 1 second
 const MAX_DELAY_MS = 60_000; // Cap exponential backoff at 1 minute
-const MAX_RETRY_AFTER_MS = 600_000; // Upper bound for a single Retry-After wait (10 min). The wait is honoured (slept) first; the cumulative MAX_TOTAL_WAIT_MS budget is checked afterwards
+const MAX_RETRY_AFTER_MS = 600_000; // Upper bound for a single Retry-After wait (10 min). If this exceeds the remaining budget, we throw immediately without sleeping.
 
 type AutotaskContexts = IExecuteFunctions | IHookFunctions | ILoadOptionsFunctions;
 
@@ -65,10 +65,6 @@ export async function executeWithRetry<T>(
 				waitMs = Math.max(1_000, backoff + jitter);
 			}
 
-			// Log and wait before retry. We sleep the full requested duration FIRST,
-			// then accumulate and check the budget. This honours individual Retry-After
-			// values (e.g. Retry-After: 300) that are within MAX_RETRY_AFTER_MS — a single
-			// long wait would otherwise trip the budget check and throw before sleeping.
 			console.warn(
 				`[429 Retry] Attempt ${attempt}, waiting ${(waitMs / 1_000).toFixed(
 					1,
@@ -77,11 +73,30 @@ export async function executeWithRetry<T>(
 				}s)`,
 			);
 
+			// Reject immediately if the single wait would overshoot the remaining budget.
+			// This prevents blocking the workflow for the full capped duration (up to 600s)
+			// before throwing — which would violate the 5-minute MAX_TOTAL_WAIT_MS contract.
+			const remainingBudget = MAX_TOTAL_WAIT_MS - totalWaitTime;
+			if (waitMs > remainingBudget) {
+				const rateLimitError = {
+					message:
+						'Autotask API rate limit exceeded (429 Too Many Requests). ' +
+						`Retry-After of ${(waitMs / 1_000).toFixed(0)}s exceeds remaining budget of ${(remainingBudget / 1_000).toFixed(0)}s. ` +
+						'Suggestions: (1) Reduce workflow trigger frequency or concurrency. ' +
+						'(2) Enable response caching on read operations. ' +
+						'(3) Spread bulk operations over a longer time period.',
+					statusCode: 429,
+					description: `Retry-After exceeds budget after ${attempt} attempt(s).`,
+				};
+				throw new NodeApiError(context.getNode(), rateLimitError);
+			}
+
+			// Sleep is within budget — honour it.
 			await new Promise((resolve) => setTimeout(resolve, waitMs));
 
 			totalWaitTime += waitMs;
 
-			// After waiting, stop retrying once the cumulative wait budget is exhausted.
+			// Stop retrying once the cumulative wait budget is exhausted.
 			if (totalWaitTime >= MAX_TOTAL_WAIT_MS) {
 				const rateLimitError = {
 					message:

--- a/nodes/Autotask/helpers/http/retryHandler.ts
+++ b/nodes/Autotask/helpers/http/retryHandler.ts
@@ -7,7 +7,8 @@ import { NodeApiError } from 'n8n-workflow';
 
 const MAX_TOTAL_WAIT_MS = 300_000; // 5 minutes
 const BASE_DELAY_MS = 1_000; // Start with 1 second
-const MAX_DELAY_MS = 60_000; // Cap individual waits at 1 minute
+const MAX_DELAY_MS = 60_000; // Cap exponential backoff at 1 minute
+const MAX_RETRY_AFTER_MS = 600_000; // Respect Retry-After up to 10 minutes
 
 type AutotaskContexts = IExecuteFunctions | IHookFunctions | ILoadOptionsFunctions;
 
@@ -37,13 +38,24 @@ export async function executeWithRetry<T>(
 
 			attempt += 1;
 
-			// Parse Retry-After header if present
+			// Parse Retry-After header if present (RFC 7231: integer seconds or HTTP-date)
 			const retryAfter = err.response?.headers?.['retry-after'];
 			let waitMs: number;
 
 			if (retryAfter) {
 				const parsed = Number.parseInt(retryAfter, 10);
-				waitMs = Number.isNaN(parsed) ? 60_000 : Math.min(parsed * 1_000, MAX_DELAY_MS);
+				if (!Number.isNaN(parsed)) {
+					// Integer seconds: respect server value, cap at 10 min
+					waitMs = Math.min(parsed * 1_000, MAX_RETRY_AFTER_MS);
+				} else {
+					// HTTP-date format: compute delta from now
+					const httpDate = Date.parse(retryAfter);
+					if (!Number.isNaN(httpDate)) {
+						waitMs = Math.max(1_000, Math.min(httpDate - Date.now(), MAX_RETRY_AFTER_MS));
+					} else {
+						waitMs = 60_000; // unparseable — fall back to 60s
+					}
+				}
 			} else {
 				// Exponential backoff with jitter (+/-25%)
 				const backoff = Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS);

--- a/nodes/Autotask/helpers/http/retryHandler.ts
+++ b/nodes/Autotask/helpers/http/retryHandler.ts
@@ -8,7 +8,7 @@ import { NodeApiError } from 'n8n-workflow';
 const MAX_TOTAL_WAIT_MS = 300_000; // 5 minutes
 const BASE_DELAY_MS = 1_000; // Start with 1 second
 const MAX_DELAY_MS = 60_000; // Cap exponential backoff at 1 minute
-const MAX_RETRY_AFTER_MS = 600_000; // Upper bound for a single Retry-After wait; effective ceiling is MAX_TOTAL_WAIT_MS (5 min) — a wait longer than the budget triggers an immediate throw
+const MAX_RETRY_AFTER_MS = 600_000; // Upper bound for a single Retry-After wait (10 min). The wait is honoured (slept) first; the cumulative MAX_TOTAL_WAIT_MS budget is checked afterwards
 
 type AutotaskContexts = IExecuteFunctions | IHookFunctions | ILoadOptionsFunctions;
 
@@ -65,9 +65,23 @@ export async function executeWithRetry<T>(
 				waitMs = Math.max(1_000, backoff + jitter);
 			}
 
+			// Log and wait before retry. We sleep the full requested duration FIRST,
+			// then accumulate and check the budget. This honours individual Retry-After
+			// values (e.g. Retry-After: 300) that are within MAX_RETRY_AFTER_MS — a single
+			// long wait would otherwise trip the budget check and throw before sleeping.
+			console.warn(
+				`[429 Retry] Attempt ${attempt}, waiting ${(waitMs / 1_000).toFixed(
+					1,
+				)}s (total wait so far: ${(totalWaitTime / 1_000).toFixed(0)}s / ${
+					MAX_TOTAL_WAIT_MS / 1_000
+				}s)`,
+			);
+
+			await new Promise((resolve) => setTimeout(resolve, waitMs));
+
 			totalWaitTime += waitMs;
 
-			// Check if exceeded total wait time
+			// After waiting, stop retrying once the cumulative wait budget is exhausted.
 			if (totalWaitTime >= MAX_TOTAL_WAIT_MS) {
 				const rateLimitError = {
 					message:
@@ -88,17 +102,6 @@ export async function executeWithRetry<T>(
 
 				throw new NodeApiError(context.getNode(), rateLimitError);
 			}
-
-			// Log and wait before retry
-			console.warn(
-				`[429 Retry] Attempt ${attempt}, waiting ${(waitMs / 1_000).toFixed(
-					1,
-				)}s (total wait: ${(totalWaitTime / 1_000).toFixed(0)}s / ${
-					MAX_TOTAL_WAIT_MS / 1_000
-				}s)`,
-			);
-
-			await new Promise((resolve) => setTimeout(resolve, waitMs));
 		}
 	}
 }

--- a/nodes/Autotask/helpers/http/retryHandler.ts
+++ b/nodes/Autotask/helpers/http/retryHandler.ts
@@ -45,8 +45,9 @@ export async function executeWithRetry<T>(
 			if (retryAfter) {
 				const parsed = Number.parseInt(retryAfter, 10);
 				if (!Number.isNaN(parsed)) {
-					// Integer seconds: respect server value, cap at 10 min
-					waitMs = Math.min(parsed * 1_000, MAX_RETRY_AFTER_MS);
+					// Integer seconds: respect server value, floor at 1s, cap at 10 min
+					// Floor prevents Retry-After: 0 or negative values from creating a hot retry loop
+					waitMs = Math.max(1_000, Math.min(parsed * 1_000, MAX_RETRY_AFTER_MS));
 				} else {
 					// HTTP-date format: compute delta from now
 					const httpDate = Date.parse(retryAfter);

--- a/nodes/Autotask/helpers/http/retryHandler.ts
+++ b/nodes/Autotask/helpers/http/retryHandler.ts
@@ -95,28 +95,11 @@ export async function executeWithRetry<T>(
 			await new Promise((resolve) => setTimeout(resolve, waitMs));
 
 			totalWaitTime += waitMs;
-
-			// Stop retrying once the cumulative wait budget is exhausted.
-			if (totalWaitTime >= MAX_TOTAL_WAIT_MS) {
-				const rateLimitError = {
-					message:
-						'Autotask API rate limit exceeded (429 Too Many Requests). ' +
-						`Retried ${attempt} times over ${(totalWaitTime / 1_000).toFixed(0)} seconds, ` +
-						'but the limit persists. This indicates sustained high API usage. ' +
-						'Suggestions: ' +
-						'(1) Reduce workflow trigger frequency or concurrency. ' +
-						'(2) Enable response caching on read operations to reduce API calls. ' +
-						'(3) Spread bulk operations over a longer time period. ' +
-						'(4) Consider that other n8n instances or integrations may be consuming the API quota.',
-					statusCode: 429,
-					description:
-						'Rate limit exceeded after ' +
-						`${attempt} retry attempts ` +
-						`(${(totalWaitTime / 1_000).toFixed(0)}s total wait).`,
-				};
-
-				throw new NodeApiError(context.getNode(), rateLimitError);
-			}
+			// No post-sleep budget check here. The pre-sleep guard above
+			// (`waitMs > remainingBudget`) is the sole enforcement point.
+			// A post-sleep `>= MAX_TOTAL_WAIT_MS` check would incorrectly abort
+			// when a Retry-After wait lands exactly on the remaining budget —
+			// the server asked us to wait that long and we should retry, not throw.
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.20.2",
+  "version": "2.21.0",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

- **Fix `Retry-After` cap bug** — was capped at 60s regardless of server value (e.g. `Retry-After: 300` → retried after 60s, hit 429 again immediately). Now respects server value up to 10-min ceiling. RFC 7231 HTTP-date format also parsed; floor at 1s prevents zero/negative hot loops.
- **Add `RATE_LIMITED` error type** — LLMs got generic `API_ERROR` on rate limit hits with no guidance. New `RATE_LIMITED` type carries `retryAfterSeconds` and a stop instruction (`nextAction`) so the model doesn't retry indefinitely.
- **Fix AI tools node never initializing rate tracker** — `AutotaskAiTools.node.ts` never called `initializeRateTracker`, so ThresholdInformation API sync was never wired for AI tool executions. Both `supplyData()` and `execute()` now initialize it.
- **Per-credential rate tracker** — singleton was shared across all Autotask credentials in the same n8n instance. Now keyed by `zone|Username|APIIntegrationcode` via `getTrackerForCredential()`.
- **Fix stale `actualUsageCount` after window reset** — `resetCounterIfNeeded()` cleared `requestCount` but not `actualUsageCount`. Stale sync data from previous hour continued to drive throttle decisions.
- **Shorten sync interval** — `syncIntervalMs` 3,600,000ms (1hr) → 300,000ms (5min).
- **Post-review fix** — tighten `retryAfterSeconds` extraction in `formatApiError` (was matching "over 300 seconds" elapsed time from handler exhaustion message as a retry hint).

## Files changed

| File | Change |
|---|---|
| `helpers/http/retryHandler.ts` | Fix Retry-After cap; HTTP-date parsing; 1s floor |
| `ai-tools/error-formatter.ts` | `RATE_LIMITED` type, `formatRateLimitError`, detection in `formatApiError` |
| `helpers/http/rateLimit.ts` | Per-credential map, 5-min sync, `actualUsageCount` reset, `handleRateLimit(tracker?)` |
| `helpers/http/initRateTracker.ts` | Per-credential cooldown, accepts `ISupplyDataFunctions` |
| `helpers/http/request.ts` | Build + pass credential key to tracker |
| `AutotaskAiTools.node.ts` | `initializeRateTracker` in `supplyData` + `execute` |

## Test plan

- [ ] 46/46 unit tests pass (`npx vitest run --config tests/vitest.unit.config.ts`)
- [ ] `pnpm build` exits 0
- [ ] `pnpm typecheck` exits 0
- [ ] New tests: Retry-After integer, HTTP-date, zero, negative, garbage fallback, RATE_LIMITED envelope, per-credential isolation, actualUsageCount window reset