### PR TITLE
fix: force axios>=1.16.1 to resolve four Dependabot CVEs (v2.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.21.1] - 2026-06-01
+
+### Fixed
+
+- **Supply chain: axios dev-dependency CVEs** — Four Dependabot security advisories detected in `axios` (transitive dev-only dependency via `@n8n/node-cli` → `@n8n/ai-utilities` → `@langchain/community` → `ibm-cloud-sdk-core`; axios is not present in the published package). Forced `axios>=1.16.1` via npm `overrides` and `pnpm.overrides` to address: MitM via Prototype Pollution in `config.proxy` (High), IPv4-mapped IPv6 `NO_PROXY` bypass (High, CVE-2025-62718 incomplete fix), DoS/Header Injection via merge-function Prototype Pollution (Moderate), and Proxy-Authorization Header Injection (Low). No end-user runtime impact; this is a development environment hygiene fix.
+
 ## [2.21.0] - 2026-06-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.20.2",
+  "version": "2.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-autotask",
-      "version": "2.20.2",
+      "version": "2.21.1",
       "license": "MIT",
       "dependencies": {
         "change-case": "^4.1.2",
@@ -2991,16 +2991,46 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axios/node_modules/proxy-from-env": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",
@@ -82,12 +82,14 @@
     "n8n-workflow": "*"
   },
   "overrides": {
+    "axios": ">=1.16.1",
     "uuid": ">=11.1.1",
     "langsmith": ">=0.6.0",
     "tmp": ">=0.2.6"
   },
   "pnpm": {
     "overrides": {
+      "axios@<1.16.0": ">=1.16.1",
       "uuid": ">=11.1.1",
       "uuid@>=13.0.0 <13.0.1": ">=13.0.1",
       "langsmith@<0.6.0": "^0.6.3",


### PR DESCRIPTION
## Summary

- Adds `"axios": ">=1.16.1"` to npm `overrides` and `pnpm.overrides` in `package.json`
- Regenerates `package-lock.json` with axios 1.16.1 throughout the entire dependency tree
- Bumps version to **2.21.1** (patch release)

## Vulnerabilities Addressed

All four are from the **May 2026 Prototype Pollution batch** in axios `>=1.0.0 <1.16.0`:

| Alert | Severity | Advisory | Description |
|---|---|---|---|
| #46 | High | GHSA-35jp-ww65-95wh | MitM via Prototype Pollution Gadget in `config.proxy` |
| #45 | High | GHSA-pjwm-pj3p-43mv | `shouldBypassProxy` IPv4-mapped IPv6 NO_PROXY bypass (CVE-2025-62718 incomplete fix) |
| #44 | Moderate | CVE-2026-44490/44491 | DoS & Header Injection via Prototype Pollution in merge functions |
| #43 | Low | GHSA-654m-c8p4-x5fp | Proxy-Authorization Header Injection via incomplete null-prototype fix |

## Scope Assessment

axios is a **transitive dev-only dependency** — not present in the published npm package:

```
@n8n/node-cli → @n8n/ai-node-sdk → @n8n/ai-utilities → @langchain/community → ibm-cloud-sdk-core → axios
```

The published package ships only: `change-case`, `keyv`, `keyv-file`, `moment`, `moment-timezone`, `pluralize`. There is **no end-user runtime exposure**. This is a development environment and supply-chain hygiene fix.

## Verification

```
npm ls axios
└─┬ @n8n/node-cli@0.29.1
  └─┬ @n8n/ai-node-sdk@0.10.1
    └─┬ @n8n/ai-utilities@0.13.1
      └─┬ @langchain/community@1.1.14
        └─┬ ibm-cloud-sdk-core@5.4.14
          ├── axios@1.16.1  ✓
          └─┬ retry-axios@2.6.0
            └── axios@1.16.1 deduped  ✓

npm audit: 0 axios vulnerabilities
npx n8n-node build: ✓ successful
```

## Test Plan

- [x] `npm ls axios` shows 1.16.1 at all nodes
- [x] `npm audit` reports zero axios vulnerabilities
- [x] `npx n8n-node build` exits 0
- [ ] Dependabot alerts #43–#46 auto-close after merge (or dismiss manually as "resolved via override")