### PR TITLE
fix: unfiltered getMany sends limit as filter field (v2.22.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.22.2] - 2026-06-03
+
+### Fixed
+
+- **AI tools: unfiltered `getMany` on Agent V3 path sent `limit` as a filter field name** — When a read operation (`getMany`, `count`, `getPosted`, `getUnposted`) was invoked with no filter parameters via the Agent V3 `execute()` path, `requestData` contained only `{limit: N}`. The `fieldsToMap` override fell through to `value: requestData`, leaking `limit` into the filter body constructed by `convertFieldsToFilters`. The Autotask API received `{filter: [{field:"limit", op:"eq", value:5}]}`, found no field named `limit` on the entity, and returned `"Unable to find limit in the <Entity>"`. Fixed by returning `{value:{}}` for read ops when `requestData.filter` is absent, allowing the `{op:exist, field:id}` fallback in `finalizeResourceMapperFilters` to fire. Affects all entities; was most visible on `company` because `ticket`/`contact` callers almost always include at least one filter.
+
 ## [2.22.1] - 2026-06-03
 
 ### Fixed

--- a/nodes/Autotask/resources/tool/execute.ts
+++ b/nodes/Autotask/resources/tool/execute.ts
@@ -470,14 +470,17 @@ export async function executeToolOperation(
 			// Resource mapper format for create/update and getMany filter fields
 			case 'fieldsToMap':
 				if (Object.keys(requestData).length > 0) {
-					if (['getMany', 'count'].includes(resourceOperation) && Array.isArray(requestData.filter)) {
-						const value: Record<string, string | number> = {};
-						for (const f of requestData.filter) {
-							if (typeof f === 'object' && f !== null && 'field' in f && 'value' in f) {
-								value[(f as { field: string }).field] = (f as { value: string | number }).value;
+					if (['getMany', 'count', 'getPosted', 'getUnposted'].includes(resourceOperation)) {
+						if (Array.isArray(requestData.filter)) {
+							const value: Record<string, string | number> = {};
+							for (const f of requestData.filter) {
+								if (typeof f === 'object' && f !== null && 'field' in f && 'value' in f) {
+									value[(f as { field: string }).field] = (f as { value: string | number }).value;
+								}
 							}
+							return { value };
 						}
-						return { value };
+						return { value: {} };
 					}
 					return { mappingMode: 'defineBelow', value: requestData };
 				}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

- Fixes a bug where `getMany`/`count`/`getPosted`/`getUnposted` with **no filter parameters** sent `{field:"limit", op:"eq", value:N}` to the Autotask API on the Agent V3 `execute()` path
- API returned `"Unable to find limit in the <Entity>"` for any unfiltered list query
- Bumps to v2.22.2

## Root cause

In `resources/tool/execute.ts`, the `fieldsToMap` `getNodeParameter` override fell through to `value: requestData` when no filters were present. With `requestData = {limit: 5}`, `convertFieldsToFilters` built a filter `[{field:"limit", op:"eq", value:5}]`. The Autotask API treated `limit` as an entity field name and rejected the query.

**Fix:** For read ops (`getMany`, `count`, `getPosted`, `getUnposted`), when `requestData.filter` is absent, return `{value:{}}` so `finalizeResourceMapperFilters` fires the `id exist` fallback and a valid unfiltered query is sent.

The bug existed on **all entities** — `company` surfaced it first during CRM test suite because ticket/contact callers almost always include at least one filter.

## Test plan

- [x] `autotask_company` `getMany` with no filters — returns results (was: API error)
- [x] `autotask_company` `getMany` with `fields` but no filters — returns sparse results (was: API error)
- [x] `autotask_company` `getMany` with filter — still works
- [x] 54/54 unit tests pass
- [x] CRM test suite: 16 PASS / 4 EXPECTED / 0 FAIL (A6 fixed; 1.20 calls/test)