### PR TITLE
fix: guard ThresholdInformation poll with Redis concurrency slot (v2.23.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.23.2] - 2026-06-24
+
+### Fixed
+- ThresholdInformation polling now acquires a Redis concurrency slot, closing the unguarded-poller hole that tripped the 3-thread limit on getThresholdAndUsageInfo in queue mode. The guard sits at the fetchThresholdInformation chokepoint, covering both in-request polling and the apiThreshold resource fallback. The rate tracker now prefers the shared Redis usage snapshot before polling, reducing redundant poll volume.
+
 ## [2.23.1] - 2026-06-17
 
 ### Changed

--- a/nodes/Autotask/helpers/http/initRateTracker.ts
+++ b/nodes/Autotask/helpers/http/initRateTracker.ts
@@ -1,6 +1,7 @@
 import type { IExecuteFunctions, IHookFunctions, ILoadOptionsFunctions, ISupplyDataFunctions } from 'n8n-workflow';
 import { getTrackerForCredential, rateTracker } from './rateLimit';
 import { fetchThresholdInformation } from './request';
+import { readSharedUsageSnapshot } from './redis/usageStore';
 import { autotaskCredentialStore } from '../credential-store';
 import { sanitizeErrorForLogging, createOverrideScrubber } from '../security/credential-masking';
 
@@ -34,6 +35,17 @@ export async function initializeRateTracker(
 
 		tracker.setThresholdInfoFetcher(async () => {
 			try {
+				// Snapshot-first: prefer the shared Redis usage snapshot a peer worker
+				// already polled, avoiding a redundant ThresholdInformation request (which
+				// itself consumes a thread slot). Only poll the API directly on a miss.
+				const shared = await readSharedUsageSnapshot(context);
+				if (shared) {
+					return {
+						externalRequestThreshold: shared.externalRequestThreshold,
+						requestThresholdTimeframe: shared.requestThresholdTimeframe,
+						currentTimeframeRequestCount: shared.currentTimeframeRequestCount,
+					};
+				}
 				const result = await fetchThresholdInformation.call(context as IExecuteFunctions);
 				return result;
 			} catch (error) {

--- a/nodes/Autotask/helpers/http/redis/usageStore.ts
+++ b/nodes/Autotask/helpers/http/redis/usageStore.ts
@@ -1,5 +1,7 @@
+import type { IExecuteFunctions, IHookFunctions, ILoadOptionsFunctions, ISupplyDataFunctions } from 'n8n-workflow';
 import type { RedisLike } from './client';
-import { REDIS_KEY_PREFIX } from './client';
+import { REDIS_KEY_PREFIX, getRedisConfigFromCredentials, getRedisClient, redisUsageKeyHash } from './client';
+import type { IAutotaskCredentials } from '../../../types/base/auth';
 
 export interface SharedUsage {
 	externalRequestThreshold: number;
@@ -44,6 +46,40 @@ export async function readUsage(client: RedisLike, hash: string): Promise<Shared
 	if (!raw) return null;
 	try {
 		return JSON.parse(raw) as SharedUsage;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Best-effort read of the cluster-wide ThresholdInformation snapshot for the given
+ * execution context's credentials. Resolves Redis fail-open (returns null when Redis
+ * is disabled, unconfigured, unhealthy, or the snapshot is absent), and computes the
+ * SAME poll/usage identity the poller writes under in request.ts — normalised baseUrl +
+ * integration code + Username (see redisUsageKeyHash). Any throw degrades to null so
+ * callers can fall through to a direct API fetch.
+ *
+ * Single source of truth shared by the rate tracker's threshold fetcher and the
+ * apiThreshold resource — both must read the same key the poller wrote.
+ */
+export async function readSharedUsageSnapshot(
+	context: IExecuteFunctions | IHookFunctions | ILoadOptionsFunctions | ISupplyDataFunctions,
+): Promise<SharedUsage | null> {
+	try {
+		const credentials = (await context.getCredentials('autotaskApi')) as IAutotaskCredentials;
+		const redisConfig = getRedisConfigFromCredentials(credentials as unknown as Record<string, unknown>);
+		if (!redisConfig) return null;
+		const redis = await getRedisClient(redisConfig);
+		if (!redis) return null;
+		const baseUrl = credentials.zone === 'other' ? credentials.customZoneUrl || '' : credentials.zone;
+		// Writer normalises baseUrl (strips trailing slash[es]) before hashing — reader MUST too.
+		const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
+		const hash = redisUsageKeyHash(
+			normalizedBaseUrl,
+			String(credentials.APIIntegrationcode ?? ''),
+			String(credentials.Username ?? ''),
+		);
+		return await readUsage(redis, hash);
 	} catch {
 		return null;
 	}

--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -415,12 +415,13 @@ export async function fetchThresholdInformation(
 		const redis = redisConfig ? await getRedisClient(redisConfig) : null;
 		const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
 		const threadHash = redisKeyHash(normalizedBaseUrl, String(credentials.APIIntegrationcode ?? ''));
-		const threadKey = `n8n-autotask:thr:${threadHash}:${getEndpointFromUrl(options.url as string)}`;
+		const endpoint = getEndpointFromUrl(options.url as string);
+		const threadKey = `n8n-autotask:thr:${threadHash}:${endpoint}`;
 
 		// Bypass the RATE limiter (circular dependency, see function docs above) but NOT
 		// the concurrency semaphore. A semaphore-full throw propagates to the outer
 		// try/catch and surfaces as null ("no data") — consistent with existing behaviour.
-		const release = await acquireConcurrencySlot(redis, threadKey, getEndpointFromUrl(options.url as string));
+		const release = await acquireConcurrencySlot(redis, threadKey, endpoint);
 		let response: unknown;
 		try {
 			response = await this.helpers.request(options);

--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -403,14 +403,37 @@ export async function fetchThresholdInformation(
 			json: true,
 		};
 
-		// Bypass rate limiter to avoid circular dependency (see function documentation above)
-		const response = await this.helpers.request(options);
+		// This poll IS a real Autotask request and counts against the 3-concurrent
+		// thread limit (Itgenatr005) like any entity call. It MUST therefore acquire a
+		// concurrency slot just like autotaskApiRequest() does — bypassing the semaphore
+		// here re-opens the unguarded-poller hole that trips the thread limit in queue
+		// mode with multiple workers. Resolve Redis fail-open (null when disabled/
+		// unhealthy → in-memory fallback inside acquireConcurrencySlot), then build the
+		// per-endpoint thread key with the SAME identity the entity path uses
+		// (redisKeyHash over normalised baseUrl + integration code; NO Username).
+		const redisConfig = getRedisConfigFromCredentials(credentials as unknown as Record<string, unknown>);
+		const redis = redisConfig ? await getRedisClient(redisConfig) : null;
+		const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
+		const threadHash = redisKeyHash(normalizedBaseUrl, String(credentials.APIIntegrationcode ?? ''));
+		const threadKey = `n8n-autotask:thr:${threadHash}:${getEndpointFromUrl(options.url as string)}`;
+
+		// Bypass the RATE limiter (circular dependency, see function docs above) but NOT
+		// the concurrency semaphore. A semaphore-full throw propagates to the outer
+		// try/catch and surfaces as null ("no data") — consistent with existing behaviour.
+		const release = await acquireConcurrencySlot(redis, threadKey, getEndpointFromUrl(options.url as string));
+		let response: unknown;
+		try {
+			response = await this.helpers.request(options);
+		} finally {
+			await release();
+		}
 
 		if (response && typeof response === 'object') {
+			const r = response as Record<string, number | undefined>;
 			return {
-				externalRequestThreshold: response.externalRequestThreshold || 10000,
-				requestThresholdTimeframe: response.requestThresholdTimeframe || 60,
-				currentTimeframeRequestCount: response.currentTimeframeRequestCount || 0,
+				externalRequestThreshold: r.externalRequestThreshold || 10000,
+				requestThresholdTimeframe: r.requestThresholdTimeframe || 60,
+				currentTimeframeRequestCount: r.currentTimeframeRequestCount || 0,
 			};
 		}
 

--- a/nodes/Autotask/resources/apiThreshold/execute.ts
+++ b/nodes/Autotask/resources/apiThreshold/execute.ts
@@ -1,8 +1,6 @@
 ﻿import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { fetchThresholdInformation } from '../../helpers/http/request';
-import type { IAutotaskCredentials } from '../../types/base/auth';
-import { getRedisConfigFromCredentials, getRedisClient, redisUsageKeyHash } from '../../helpers/http/redis/client';
-import { readUsage } from '../../helpers/http/redis/usageStore';
+import { readSharedUsageSnapshot } from '../../helpers/http/redis/usageStore';
 
 /**
  * Executes the API threshold information operation
@@ -13,35 +11,17 @@ export async function executeApiThresholdOperation(this: IExecuteFunctions): Pro
 
 	// For now we only have one operation: get
 	if (operation === 'get') {
-		const credentials = (await this.getCredentials('autotaskApi')) as IAutotaskCredentials;
-		const baseUrl = credentials.zone === 'other' ? credentials.customZoneUrl || '' : credentials.zone;
-
 		let source: 'redis' | 'api' = 'api';
 		let thresholdInfo: Awaited<ReturnType<typeof fetchThresholdInformation>> | null = null;
 
 		// Prefer the cluster-wide shared snapshot when Redis coordination is on and healthy.
-		const redisConfig = getRedisConfigFromCredentials(credentials as unknown as Record<string, unknown>);
-		if (redisConfig) {
-			try {
-				const redis = await getRedisClient(redisConfig);
-				if (redis) {
-					// MUST match the poller's identity in request.ts (baseUrl + integrationCode + Username),
-					// or this read never finds the snapshot the poller wrote. The writer normalises
-					// baseUrl (strips trailing slash[es]) before hashing, so the reader MUST too —
-					// otherwise a trailing-slash credential reads a different key than it wrote.
-					const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
-					const hash = redisUsageKeyHash(
-						normalizedBaseUrl,
-						String(credentials.APIIntegrationcode ?? ''),
-						String(credentials.Username ?? ''),
-					);
-					const shared = await readUsage(redis, hash);
-					if (shared) {
-						thresholdInfo = shared;
-						source = 'redis';
-					}
-				}
-			} catch { /* fall back to direct fetch */ }
+		// readSharedUsageSnapshot resolves the same poll/usage identity the poller writes
+		// under (normalised baseUrl + integration code + Username) and is best-effort (null
+		// on any miss/error), so a miss falls through to the direct API fetch below.
+		const shared = await readSharedUsageSnapshot(this);
+		if (shared) {
+			thresholdInfo = shared;
+			source = 'redis';
 		}
 
 		if (!thresholdInfo) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Problem

In n8n queue mode, the rate tracker polls Autotask's `ThresholdInformation` endpoint via `fetchThresholdInformation` (`nodes/Autotask/helpers/http/request.ts`), which called `this.helpers.request(options)` **directly** — bypassing the Redis concurrency semaphore (`acquireConcurrencySlot`) that every entity request goes through. With ≥3 concurrent workers polling `getThresholdAndUsageInfo`, this unguarded path tripped Autotask's 3-thread-per-integration limit (`Itgenatr005`).

## Changes

**Change 1 — guard the poller (load-bearing).** `fetchThresholdInformation` now acquires a concurrency slot via `acquireConcurrencySlot`, using the same thread-key identity as the entity path (`redisKeyHash` over normalised `baseUrl` + integration code, per-endpoint). Redis resolves fail-open (null → in-memory fallback). A semaphore-full throw propagates to the existing outer `try/catch` and surfaces as `null` ("no data") — consistent with prior behaviour. The guard sits at the single `fetchThresholdInformation` chokepoint, covering both in-request polling and the `apiThreshold` resource fallback.

**Change 2 — snapshot-first + dedup (defence-in-depth).** New `readSharedUsageSnapshot(context)` helper in `redis/usageStore.ts` dedups the redis-resolve + hash + `readUsage` logic (previously copied in `apiThreshold/execute.ts`). The rate tracker's `setThresholdInfoFetcher` closure now prefers the shared Redis usage snapshot before polling the API, reducing redundant poll volume. `apiThreshold/execute.ts` reuses the same helper; `source:'redis'`/`'api'` behaviour preserved exactly.

## Verification

- `pnpm build` exits 0.
- `vitest run unit/http` — 11 files, 57 tests passed (incl. new `threshold-poll-thread-limit.test.ts` and `redis/shared-usage-snapshot.test.ts`): semaphore-full → `fetchThresholdInformation` returns null and `helpers.request` is never called; free slot → request runs once and result parsed; snapshot short-circuits the fetcher when present and falls through when absent; `apiThreshold` still reports `source:'redis'` on hit.

Ships as patch **v2.23.2**.
