### PR TITLE
fix: cap ThresholdInformation poll at 1 concurrent thread (v2.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.24.0] - 2026-07-04
+
+### Fixed
+- The ThresholdInformation poll could exceed Autotask's 3-thread limit on the (tracking-id + ThresholdInformation) endpoint. Autotask scopes its concurrent-thread limit to 3 per (tracking identifier + object endpoint), so the poll shared the cap of 3 with Autotask's own concurrent count on that endpoint with zero headroom — multiple uncoordinated poll sources plus release/decrement skew could admit a 4th request, surfacing as "Thread Threshold Exceeded" on method getThresholdAndUsageInfo. The poll now uses a dedicated concurrency limit of 1, leaving 2 slots of headroom. This also closes a lease-eviction race where a request running the full 5-minute Autotask exec timeout could have its semaphore lease evicted mid-flight: the lease has been raised above that ceiling so a slot is only reclaimed after Autotask has already timed out and decremented its own thread count.
+
+### Changed
+- The in-memory concurrency fallback now honours per-call limits, so the poll's cap-1 holds even during a Redis degradation. The per-endpoint thread key is retained (Autotask's limit is per tracking-id + endpoint, so cross-object parallelism stays permitted) and entity requests keep the full 3-slot budget per endpoint.
+
 ## [2.23.2] - 2026-06-24
 
 ### Fixed

--- a/nodes/Autotask/helpers/http/request.ts
+++ b/nodes/Autotask/helpers/http/request.ts
@@ -26,8 +26,9 @@ import { acquireThreadSlot, releaseThreadSlot } from './redis/threadStore';
 import { tryAcquirePollLock, writeUsage } from './redis/usageStore';
 
 const THREAD_LIMIT = 3;
-const THREAD_LEASE_MS = 300_000;        // Autotask 5-min REST exec timeout
-const THREAD_KEY_TTL_MS = 330_000;      // lease + skew buffer
+const POLL_THREAD_LIMIT = 1;
+const THREAD_LEASE_MS = 330_000;        // sits ABOVE Autotask's 5-min (300s) REST exec timeout: our semaphore slot is only reclaimed after Autotask has already timed out and decremented its own thread count, so a lease eviction can never free a slot while Autotask still counts the request as live
+const THREAD_KEY_TTL_MS = 360_000;      // whole-key TTL must stay > lease; only cost of the longer lease is a crashed worker's slot lingering ~30s longer
 const THREAD_ACQUIRE_MAX_WAIT_MS = 45_000;
 const THREAD_POLL_BASE_MS = 300;
 const POLL_DEDUP_WINDOW_MS = 90_000;
@@ -63,13 +64,14 @@ export async function acquireConcurrencySlot(
 	redis: RedisLike | null,
 	threadKey: string,
 	inMemoryEndpoint: string,
+	limit: number = THREAD_LIMIT,
 ): Promise<() => Promise<void>> {
 	if (redis) {
 		const deadline = Date.now() + THREAD_ACQUIRE_MAX_WAIT_MS;
 		while (true) {
 			try {
 				const { acquired, member } = await acquireThreadSlot(
-					redis, threadKey, THREAD_LIMIT, THREAD_LEASE_MS, THREAD_KEY_TTL_MS,
+					redis, threadKey, limit, THREAD_LEASE_MS, THREAD_KEY_TTL_MS,
 				);
 				if (acquired) {
 					return async () => { try { await releaseThreadSlot(redis, threadKey, member); } catch { /* ignore */ } };
@@ -88,7 +90,7 @@ export async function acquireConcurrencySlot(
 		}
 	}
 	// Fail-open: in-memory per-worker semaphore (endpointThreadTracker already statically imported)
-	await endpointThreadTracker.acquireThread(inMemoryEndpoint);
+	await endpointThreadTracker.acquireThread(inMemoryEndpoint, limit);
 	return async () => { endpointThreadTracker.releaseThread(inMemoryEndpoint); };
 }
 
@@ -421,7 +423,12 @@ export async function fetchThresholdInformation(
 		// Bypass the RATE limiter (circular dependency, see function docs above) but NOT
 		// the concurrency semaphore. A semaphore-full throw propagates to the outer
 		// try/catch and surfaces as null ("no data") — consistent with existing behaviour.
-		const release = await acquireConcurrencySlot(redis, threadKey, endpoint);
+		//
+		// A threshold poll is a singleton measurement — one snapshot suffices, it never needs 3
+		// concurrent threads. Capping it at 1 leaves 2 of Autotask's 3 (tracking-id +
+		// ThresholdInformation) slots as headroom, absorbing release/decrement skew, co-tenant
+		// noise, and lease eviction so an uncoordinated 4th poll can never trip the limit.
+		const release = await acquireConcurrencySlot(redis, threadKey, endpoint, POLL_THREAD_LIMIT);
 		let response: unknown;
 		try {
 			response = await this.helpers.request(options);

--- a/nodes/Autotask/helpers/http/threadLimit.ts
+++ b/nodes/Autotask/helpers/http/threadLimit.ts
@@ -50,7 +50,7 @@ class EndpointThreadTracker {
      * Acquires a thread for the specified endpoint or URL
      * Waits until a thread is available if all are in use
      */
-    public async acquireThread(endpointOrUrl: string): Promise<void> {
+    public async acquireThread(endpointOrUrl: string, limit: number = this.threadLimit): Promise<void> {
         let endpoint: string;
 
         // Check if this is an endpoint name or a URL
@@ -67,15 +67,16 @@ class EndpointThreadTracker {
             this.activeThreadsPerEndpoint[endpoint] = 0;
         }
 
-        // Wait until a thread is available
-        while (this.activeThreadsPerEndpoint[endpoint] >= this.threadLimit) {
+        // Wait until a thread is available (honours the caller-supplied limit so the
+        // poll's cap-1 holds even when Redis has degraded to this in-memory fallback)
+        while (this.activeThreadsPerEndpoint[endpoint] >= limit) {
             this.debugLog(`Waiting for thread availability for endpoint: ${endpoint}`);
             await new Promise(resolve => setTimeout(resolve, 500));
         }
 
         // Acquire thread
         this.activeThreadsPerEndpoint[endpoint]++;
-        this.debugLog(`Thread acquired for ${endpoint}: ${this.activeThreadsPerEndpoint[endpoint]}/${this.threadLimit}`);
+        this.debugLog(`Thread acquired for ${endpoint}: ${this.activeThreadsPerEndpoint[endpoint]}/${limit}`);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.23.2",
+  "version": "2.24.0",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Problem

Production error on `n8n.expertcare.com.au`:

```
Thread Threshold Exceeded — The Autotask API thread threshold of 3 threads has been exceeded.
Method: getThresholdAndUsageInfo
```

Recurred after v2.23.0→v2.23.2, all of which guarded the poll but never closed the actual gap.

## Root cause

Autotask scopes its concurrent-thread limit to **3 per (tracking identifier + object endpoint)** — not integration-wide ([spec](https://www.autotask.net/help/developerhelp/Content/APIs/General/ThreadLimiting.htm)). `ThresholdInformation` is **not** exempt (only `ZoneInformation` is), so it counts as its own object endpoint with a cap of 3.

v2.23.2 correctly routed the poll through the Redis semaphore, but at the shared `THREAD_LIMIT=3` on the ThresholdInformation endpoint key — **the same cap Autotask enforces, with zero headroom**. Our slot releases the instant `helpers.request` resolves; Autotask decrements slightly later. With multiple uncoordinated poll sources (entity path, trigger, apiThreshold op, rate-tracker sync — 3 of 4 not poll-locked) and sub-second skew, a 4th poll reached Autotask → Itgenatr005.

## Fix

- **`POLL_THREAD_LIMIT=1`** for the ThresholdInformation poll — a threshold poll is a singleton measurement, never needs 3. Leaves 2 of Autotask's 3 slots on that endpoint as headroom, absorbing release/decrement skew and lease eviction. Plumbed a `limit` param through `acquireConcurrencySlot` → `acquireThreadSlot` (Redis) and `acquireThread` (in-memory fallback).
- **Per-endpoint thread key retained** — entity requests keep the full 3-slot-per-endpoint budget; cross-object parallelism stays permitted per spec.
- **Lease-eviction race closed** — `THREAD_LEASE_MS` raised 300s→330s (above Autotask's 5-min exec timeout), key TTL 330s→360s. A slot is only reclaimed after Autotask has already timed out and decremented its own count.
- **In-memory fallback honours per-call limits** so cap-1 holds during a Redis degradation.

## Scope confirmation

- Same `APIIntegrationcode` is reused only within the same n8n system → all workflows share the same Redis → fully coordinated through the one thread key. No invisible external co-tenant.
- All queue-mode workers run ≥ this build.

## Verification

`pnpm build` exits 0.

Files: `request.ts`, `threadLimit.ts`, `CHANGELOG.md`, `package.json`.