### PR TITLE
fix: entityInformation thread-key scoping + block model-defined AI operations field (v2.25.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.25.1] - 2026-07-08
+
+### Fixed
+- `autotaskAiTools`: the "Operations Names or IDs" field can no longer be switched to expression / "Let the model define this parameter" mode, which previously produced a persistent error (issue #105). That field configures *which* operations the tool exposes — it is not a runtime value. Its option list is populated by a `loadOptionsMethod` that depends on the selected `resource`, so in expression/model-defined mode the list can never resolve and n8n raised an error. The field now sets `noDataExpression: true` (mirroring the `resource` field), so the expression toggle is not offered. This does not reduce capability: the AI agent still selects the operation on every call via the tool schema's required `operation` argument — the configured set here is just the menu the agent chooses from. The field description was updated to explain this.
+- "Thread Threshold Exceeded" (Itgenatr005) surfacing on `getFieldInfo`/`entityInformation` field-metadata fetches, especially right after an upgrade (the version bump invalidates the field-info cache, forcing a cold-cache burst of metadata calls). The per-endpoint thread semaphore keys each request by the entity extracted from its URL via `getEndpointFromUrl`, but that extractor's version-matching patterns used `\d+` for the API version segment — which cannot match Autotask's dotted `v1.0` (the character after the `1` is a `.`, not the required `/`). All four version patterns silently failed for every real Autotask URL, so extraction fell through to the last-path-segment pattern. For entityInformation URLs (`/v1.0/Tickets/entityInformation/fields`) that returned `fields` / `userdefinedfields` instead of the entity name, so field-info fetches were **not** scoped to their entity's thread bucket: the concurrent read+write × standard+UDF metadata fetches `describeResource` issues for a single entity split across two shared keys, each stayed under the limit, and all fired at Autotask's single per-object thread bucket → thread-limit rejection. The version patterns now accept dotted versions (`v[\d.]+`), so every URL — queries, single-record GETs, ThresholdInformation, and entityInformation field/UDF metadata — keys to the correct entity endpoint and field-info fetches share their entity's 3-slot budget. Regression test added covering all URL shapes.
+
 ## [2.25.0] - 2026-07-08
 
 ### Fixed

--- a/nodes/Autotask/AutotaskAiTools.node.ts
+++ b/nodes/Autotask/AutotaskAiTools.node.ts
@@ -345,13 +345,21 @@ export class AutotaskAiTools implements INodeType {
 				name: 'operations',
 				type: 'multiOptions',
 				required: true,
+				// noDataExpression: this field configures WHICH operations the tool exposes; it is not a
+				// runtime value. It must not be switchable to expression / "Let the model define this
+				// parameter" mode — the multiOptions list is populated by a loadOptionsMethod that depends
+				// on `resource`, so in expression/model-defined mode the option list can never resolve and
+				// n8n surfaces an error (issue #105). The AI agent already selects the operation per call
+				// via the tool schema's required `operation` argument; the model does not define this
+				// configured set. Mirrors the `resource` field above.
+				noDataExpression: true,
 				typeOptions: {
 					loadOptionsMethod: 'getToolResourceOperations',
 					loadOptionsDependsOn: ['resource', 'allowWriteOperations'],
 				},
 				default: [],
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Select which Autotask operations this tool exposes to the AI agent. The agent picks one of these per call via the tool\'s required "operation" argument — this configured set cannot be model-defined. The helper operations describeFields, listPicklistValues and describeOperation are always available regardless of selection.',
 			},
 			{
 				displayName: 'Allow Write Operations',

--- a/nodes/Autotask/helpers/http/threadLimit.ts
+++ b/nodes/Autotask/helpers/http/threadLimit.ts
@@ -106,11 +106,20 @@ class EndpointThreadTracker {
  * Exported for reuse by the Redis thread-limit keying (helpers/http/redis/threadStore.ts).
  */
 export function getEndpointFromUrl(url: string): string {
+	// NOTE: the version segment is DOTTED ("v1.0"), so the version-matching patterns
+	// MUST use [\d.]+ not \d+. With \d+ the trailing "\/" never matches (the char after
+	// the "1" is "."), so patterns 1-4 silently failed for EVERY real Autotask URL and
+	// extraction fell through to the last-segment pattern. For entityInformation URLs
+	// (/v1.0/Tickets/entityInformation/fields) that returned "fields"/"userdefinedfields"
+	// instead of the entity name, so field-info fetches were NOT scoped to their entity's
+	// thread bucket — concurrent read+write × standard+udf metadata fetches for one entity
+	// split across two shared keys, each under the limit, and all fired at Autotask's single
+	// per-object thread bucket → Itgenatr005 thread-limit errors on getFieldInfo.
 	const patterns = [
-		/\/V\d+\/(\w+)/i,           // /V1.0/Tickets
-		/\/v\d+\/(\w+)/i,           // /v1.0/Tickets
-		/\/api\/v\d+\/(\w+)/i,      // /api/v1.0/Tickets
-		/\/\w+\/v\d+\/(\w+)/i,      // /ATServicesRest/v1.0/Tickets
+		/\/V[\d.]+\/(\w+)/i,        // /V1.0/Tickets
+		/\/v[\d.]+\/(\w+)/i,        // /v1.0/Tickets
+		/\/api\/v[\d.]+\/(\w+)/i,   // /api/v1.0/Tickets
+		/\/\w+\/v[\d.]+\/(\w+)/i,   // /ATServicesRest/v1.0/Tickets
 		/\/([^/]+)\/query/i,        // /Tickets/query
 		/\/([^/]+)\/\d+/i,          // /Tickets/123
 		/\/([^/]+)\/?$/i,           // /Tickets or /Tickets/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.23.0",
+  "version": "2.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-autotask",
-      "version": "2.23.0",
+      "version": "2.25.1",
       "license": "MIT",
       "dependencies": {
         "change-case": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Release **v2.25.1**. Two fixes.

## 1. Thread limit tripping on `getFieldInfo` / `entityInformation` (Itgenatr005)

The per-endpoint Redis thread semaphore keys each request by the entity extracted from its URL via `getEndpointFromUrl`. Its version-matching regexes used `\d+`, which cannot match Autotask's **dotted** version segment `v1.0` — the character after `1` is `.`, not the required `/`. So all four version patterns silently failed for every real Autotask URL and extraction fell through to the last-path-segment pattern:

| URL | extracted key (before) | entity |
|---|---|---|
| `/v1.0/Tickets/query` | `tickets` ✅ | Tickets |
| `/v1.0/Tickets/entityInformation/fields` | **`fields`** ❌ | Tickets |
| `/v1.0/Companies/entityInformation/userDefinedFields` | **`userdefinedfields`** ❌ | Companies |

Because field-info URLs keyed to `fields`/`userdefinedfields` instead of the entity, field-metadata fetches were **not** scoped to their entity's thread bucket. `describeResource` issues concurrent read+write × standard+UDF metadata fetches for a single entity; the standard pair keyed to `fields`, the UDF pair to `userdefinedfields`, each staying under the limit — so all fired simultaneously at Autotask's single per-object thread bucket, tripping the 3-thread limit. It surfaces on `getFieldInfo` **especially right after an upgrade**, because the version bump invalidates the field-info cache and forces a cold-cache burst of metadata calls.

**Fix:** version patterns now accept dotted versions (`v[\d.]+`), so every URL — queries, single-record GETs, ThresholdInformation, and entityInformation field/UDF metadata — keys to the correct entity endpoint and field-info fetches share their entity's 3-slot budget. Regression test added (private test repo) covering all URL shapes.

## 2. AI tools: "Operations Names or IDs" cannot be model-defined (#105)

The multiOptions field could be switched to expression / "Let the model define this parameter" mode, producing a persistent error (reported across Tickets, Ticket Notes, Resources, Contacts, Companies). Its option list is populated by a `loadOptionsMethod` that depends on the selected `resource`, so in expression/model-defined mode the list can never resolve and n8n raises an error.

**Fix:** the field now sets `noDataExpression: true` (mirroring the `resource` field), so the toggle is not offered. Capability is unchanged — the AI agent already selects the operation on every call via the tool schema's required `operation` argument; this configured field is just the menu it chooses from. Field description updated to explain this.

Closes #105

## Verification
- `pnpm build` exits 0
- Unit test suite: 124 passed, 0 assertion failures (live MCP integration suites require `.env.test` and are environment-gated)