### PR TITLE
fix: runtime-accurate + concise AI-tools schema descriptions (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.26.3] - 2026-07-22
+
+### Fixed
+- AI Tools: schema descriptions now state cross-field filter constraints, resolving the incomplete-second-filter friction in #116 (the model would emit a partial second filter clause with an empty value, which the node correctly rejected as `INVALID_FILTER_CONSTRAINT`). Each filter field now states its pairing rule explicitly: provide `filter_field`/`filter_field_2` together with its value (operator optional, defaults to `eq`; value not needed for `exist`/`notExist`), or omit the clause. Also corrected the `since` description, which claimed it "overrides recency" while the runtime rejects the combination — now stated as mutually exclusive; and added the missing `filter_logic` rule (valid only when both filter pairs are present, rejected with one).
+- AI Tools: stated previously-undocumented constraints on `globalNotesSearch` (at least one of `keyword`/`since`/`until` required), `transferOwnership` allowlists (`companyIdAllowlist` applies only when `includeCompanies=true`; `statusAllowlistByValue` takes precedence over `statusAllowlistByLabel`), and `rejectReason` (required when `rejectReasonPolicy='mandatory'`).
+
+### Changed
+- AI Tools: concision pass over all tool and field description text — tight-imperative phrasing, filler removed, every semantic token (field names, enum values, defaults, examples, bounds) preserved. Extracted the shared read-param descriptions into a single source imported by both the Zod schema and the `describeOperation` docs, so cross-field constraints are stated once and cannot drift between the two.
+
 ## [2.26.2] - 2026-07-17
 
 ### Fixed

--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -136,11 +136,10 @@ function describeFieldsHint(resourceName: string, mode: 'read' | 'write' | '' = 
 
 export function buildGetDescription(resourceLabel: string, resourceName: string): string {
 	return (
-		`Retrieve a single ${resourceLabel} record by numeric ID. ` +
-		`ONLY call this when you already have a numeric ID — never pass a name or text. ` +
+		`Retrieve a single ${resourceLabel} record by numeric ID — never pass a name or text. ` +
 		`If you only have a name or description, call autotask_${resourceName} with operation 'getMany' with a filter first, extract the 'id' from results, then call this. ` +
-		`Optionally use 'fields' to return only selected columns. ` +
-		`If a record should exist but response is empty, verify API user permissions (including line-of-business access). ` +
+		`Use 'fields' to return only selected columns. ` +
+		`If a record should exist but the response is empty, verify API user permissions (including line-of-business access). ` +
 		`Do not guess field names. ${describeFieldsHint(resourceName, 'read')}`
 	);
 }
@@ -232,7 +231,7 @@ export function buildCreateDescription(
 		`Create a new ${resourceLabel} record. ` +
 		`${requiredSummary}${parentHint} ` +
 		`Picklist and reference fields accept human-readable names — auto-resolved to IDs. ` +
-		`Date-time values must be ISO-8601 and UTC-safe (for example 2026-02-14T03:15:00Z). ` +
+		`Date-time values must be ISO-8601 and UTC-safe (e.g. 2026-02-14T03:15:00Z). ` +
 		`Confirm field values with user before executing when acting autonomously. ` +
 		`If picklist values fail validation, call autotask_${resourceName} with operation 'listPicklistValues'.` +
 		(extraHint ? ` ${extraHint}` : '')
@@ -255,12 +254,11 @@ export function buildUpdateDescription(
 	return (
 		ref +
 		`Update an existing ${resourceLabel} record by numeric ID. ` +
-		`PREREQUISITE: you need the numeric ID. If you only have a name or text, call autotask_${resourceName} with operation 'getMany' with a filter to find the record and get its 'id' first. ` +
-		`Only provide fields to change (PATCH-style behaviour). ` +
-		`Do not assume PUT-style replacement where omitted fields become null. ` +
+		`If you only have a name or text, call autotask_${resourceName} with operation 'getMany' with a filter to find the record's 'id' first. ` +
+		`Provide only fields to change (PATCH semantics — omitted fields keep existing values, not PUT-style nulling). ` +
 		createFieldsNote +
 		`Picklist and reference fields accept human-readable names — auto-resolved to IDs. ` +
-		`Date-time values must be ISO-8601 and UTC-safe (for example 2026-02-14T03:15:00Z). ` +
+		`Date-time values must be ISO-8601 and UTC-safe (e.g. 2026-02-14T03:15:00Z). ` +
 		`Confirm field values with user before executing when acting autonomously. ` +
 		`${describeFieldsHint(resourceName, 'write')} ` +
 		`Use autotask_${resourceName} with operation 'listPicklistValues' for picklist fields.` +
@@ -270,10 +268,9 @@ export function buildUpdateDescription(
 
 export function buildDeleteDescription(resourceLabel: string, resourceName: string): string {
 	return (
-		`Delete a ${resourceLabel} record by numeric ID. ` +
-		`ONLY on explicit user intent. Do not infer delete intent from context. Confirm ID is correct before proceeding. ` +
-		`Operational delete responses may be minimal, so treat non-200 outcomes as failures. ` +
-		`Use autotask_${resourceName} with operation 'getMany' or autotask_${resourceName} with operation 'get' first to confirm the correct ID before deletion.`
+		`Delete a ${resourceLabel} record by numeric ID — ONLY on explicit user intent, never inferred from context. ` +
+		`Confirm the correct ID first via autotask_${resourceName} with operation 'getMany' or operation 'get'. ` +
+		`Delete responses may be minimal; treat non-200 outcomes as failures.`
 	);
 }
 
@@ -281,7 +278,7 @@ export function buildWhoAmIDescription(resourceLabel: string): string {
 	return (
 		`Resolve the current authenticated ${resourceLabel} record from API credentials. ` +
 		`Use this to discover the active Autotask user context before running user-scoped actions. ` +
-		`Optionally use 'fields' to limit returned columns.`
+		`Use 'fields' to limit returned columns.`
 	);
 }
 
@@ -316,23 +313,22 @@ export function buildUnpostedTimeEntriesDescription(
 export function buildCompanySearchByDomainDescription(resourceName: string): string {
 	return (
 		'Search companies by domain using website-style fields. ' +
-		'Identifier priority for company resolution: first extract/use domain from any provided email or website, then use company-name contains matching only as fallback. ' +
-		'Input can be a bare domain or full URL; the tool normalises it to a domain fragment (for example autotask.net). ' +
-		'IMPORTANT: Autotask typically stores company websites as full URLs (for example https://www.autotask.net/), so exact operator matches can fail on bare domain input. ' +
-		'To avoid false negatives, eq/like semantics are handled safely for website matching. ' +
-		'Always searches both company website fields and contact-email domains (no toggle): when no company website field matches, the tool searches Contact.emailAddress by domain and resolves the canonical company from companyID references. Public email-provider domains (gmail.com, outlook.com, etc.) skip the contact-email fallback to avoid over-matching consumer addresses. ' +
-		"Use the 'fields' parameter to limit which company fields are returned per result (comma-separated); omit to receive the full company entity. matchedField and matchedValue are always included to indicate which website field matched and its value. " +
+		'Resolution priority: extract/use domain from any provided email or website first; use company-name contains matching only as fallback. ' +
+		'Accepts a bare domain or full URL — normalised to a domain fragment (e.g. autotask.net). ' +
+		'Autotask stores company websites as full URLs (e.g. https://www.autotask.net/), so exact operator matches can fail on bare domain input; eq/like semantics are handled safely for website matching to avoid false negatives. ' +
+		'Always searches both company website fields and contact-email domains (no toggle): when no company website field matches, searches Contact.emailAddress by domain and resolves the canonical company from companyID references. Public email-provider domains (gmail.com, outlook.com, etc.) skip the contact-email fallback to avoid over-matching consumer addresses. ' +
+		"Use 'fields' (comma-separated) to limit returned company fields per result; omit for the full company entity. matchedField and matchedValue are always included to indicate which website field matched and its value. " +
 		describeFieldsHint(resourceName)
 	);
 }
 
 export function buildCompanySearchByIdentityDescription(resourceName: string): string {
 	return (
-		'Preferred AI company resolution operation. Accepts companyName, email, and website/domain, then ranks candidates by confidence. ' +
-		'Domain is normalised from website first, then email; domain matching is attempted first (company website fields, then contact-email fallback). ' +
-		'If domain signals are weak or absent, companyName contains matching is executed and merged into a confidence-ranked candidate list. ' +
-		'Use this operation as first choice for company lookup when identity hints may be incomplete or noisy. ' +
-		"Use the 'fields' parameter to limit returned company fields; omit for full records. " +
+		'Preferred AI company resolution operation — first choice when identity hints may be incomplete or noisy. ' +
+		'Accepts companyName, email, and website/domain; ranks candidates by confidence. ' +
+		'Domain is normalised from website first, then email; domain matching runs first (company website fields, then contact-email fallback). ' +
+		'If domain signals are weak or absent, companyName contains matching is executed and merged into the confidence-ranked candidate list. ' +
+		"Use 'fields' to limit returned company fields; omit for full records. " +
 		describeFieldsHint(resourceName)
 	);
 }
@@ -386,7 +382,7 @@ export function buildTicketSlaHealthCheckDescription(resourceName: string): stri
 		'Returns first-response, resolution-plan, and resolution milestone timing and status in consistent hours (2 decimal places). ' +
 		"Use 'ticketFields' to limit which ticket fields are returned in the ticket section. " +
 		'Includes wallClockRemainingHours, where negative values indicate overdue milestones. ' +
-		'This operation combines data from Ticket and ServiceLevelAgreementResults entities. ' +
+		'Combines data from Ticket and ServiceLevelAgreementResults entities. ' +
 		"For population-level SLA queries (e.g. 'how many breached this week?'), do NOT call slaHealthCheck without an id. Use operation 'count' or 'getMany' with filter_field='serviceLevelAgreementHasBeenMet', filter_op='eq', filter_value=false instead. " +
 		describeFieldsHint(resourceName)
 	);
@@ -399,7 +395,7 @@ export function buildTicketTimelineDescription(resourceName: string): string {
 		'Chronological merged event stream (notes, time entries, and optionally field-change history) for a single ticket — use for escalation briefs, effort audits, and manager summaries. ' +
 		identifierRule +
 		"Events sorted oldest-first. Each event has a 'type' field: 'note' (communications), 'timeEntry' (work logged), or 'history' (field changes). " +
-		"Parameters: 'since'/'until' (ISO date — strongly recommended for active tickets to scope results); " +
+		"Parameters: 'since'/'until' (ISO date — use on active tickets to scope results); " +
 		"'resourceId' (name or numeric ID — filters note authors, time entry resources, and history actors); " +
 		"'includeHistories' (default false — enable for full field-change audit; can be very large on busy tickets — combine with since/until); " +
 		"'textLimit' (default 500 chars for note/entry text, 0=no limit); " +
@@ -520,12 +516,12 @@ export function buildConfigurationItemMoveConfigurationItemDescription(
 	resourceName: string,
 ): string {
 	return (
-		'Clone a configuration item to a different company because companyID cannot be updated in place. ' +
-		'Copies CI core fields and optional UDFs, optional CI attachments, optional notes, and optional note attachments. ' +
-		'Always writes audit notes and can deactivate the source CI after safety checks. ' +
-		'Optionally provide impersonationResourceId so created records (CI, notes, attachments) are attributed to that resource. ' +
-		'Optionally set proceedWithoutImpersonationIfDenied (default on); this only applies when impersonationResourceId is set and retries without impersonation if write permissions are denied for the impersonated resource. ' +
-		'This operation does not migrate tickets, tasks, projects, contracts, related items, DNS records, or billing-product associations. ' +
+		'Clone a configuration item to a different company (companyID cannot be updated in place). ' +
+		'Copies CI core fields plus optional UDFs, CI attachments, notes, and note attachments. ' +
+		'Always writes audit notes; can deactivate the source CI after safety checks. ' +
+		'impersonationResourceId attributes created records (CI, notes, attachments) to that resource. ' +
+		'proceedWithoutImpersonationIfDenied (default on) applies only when impersonationResourceId is set — retries without impersonation if write permissions are denied for the impersonated resource. ' +
+		'Does not migrate tickets, tasks, projects, contracts, related items, DNS records, or billing-product associations. ' +
 		`If field names or expected behaviour are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
 	);
 }
@@ -533,19 +529,19 @@ export function buildConfigurationItemMoveConfigurationItemDescription(
 export function buildContactMoveToCompanyDescription(resourceName: string): string {
 	return (
 		'Move a contact to another company by cloning the contact record and optional related data. ' +
-		'Supports duplicate email safeguards, optional company note and attachment copy, contact group copy, and configurable source/destination audit notes. ' +
-		'Supports optional impersonation for write attribution with optional fallback when impersonation is denied. ' +
+		'Includes duplicate-email safeguards, optional company note and attachment copy, contact group copy, and configurable source/destination audit notes. ' +
+		'Supports impersonation for write attribution, with fallback when impersonation is denied. ' +
 		`If field names or expected behaviour are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
 	);
 }
 
 export function buildResourceTransferOwnershipDescription(resourceName: string): string {
 	return (
-		'Transfer ownership and assignments from a source resource to a receiving resource. ' +
-		'Supports companies, opportunities, tickets, tasks, projects, task secondary resources, service call assignments, and appointments. ' +
+		'Transfer ownership and assignments from a source resource to a receiving resource: ' +
+		'companies, opportunities, tickets, tasks, projects, task secondary resources, service call assignments, and appointments. ' +
 		'Supports due-window filtering, status filtering, and optional audit notes. ' +
-		"Use dueWindowPreset for convenient date ranges, or dueWindowPreset='custom' with dueBeforeCustom for exact cut-offs. " +
-		'By default, only open/active-style work is targeted by excluding terminal statuses. ' +
+		"Use dueWindowPreset for date ranges, or dueWindowPreset='custom' with dueBeforeCustom for exact cut-offs. " +
+		'By default targets only open/active work by excluding terminal statuses. ' +
 		`If field names or expected behaviour are uncertain, call autotask_${resourceName} with operation 'describeFields' first.`
 	);
 }
@@ -733,12 +729,24 @@ const DEDUP_NOTES = [
 	'updateFields: field names to compare against the duplicate — values that differ cause an update. Requires errorOnDuplicate=false.',
 	'Returns outcome: created, skipped, updated, or a resource-specific not_found variant.',
 ];
-const LIST_ADVANCED_NOTES = [
-	'filtersJson: JSON array of Autotask IFilterCondition objects for 3+ conditions or nested OR. Mutually exclusive with flat filter_field triplets. No label resolution — pass numeric IDs.',
-	`returnAll=true: fetches ALL matching records via API-native pagination. Without fields param: capped at ${MAX_RESPONSE_RECORDS} records. With fields param (sparse): no cap — all records returned. Use a narrow fields list for bulk ID/lookup patterns.`,
-	ASCENDING_ID_WARNING,
-	RECENCY_VS_SINCE_UNTIL_RULE.trim(),
-];
+let _listAdvancedNotesCache: string[] | undefined;
+
+/**
+ * Built lazily (first call, memoized) rather than as a module-load-time const:
+ * MAX_RESPONSE_RECORDS comes from operation-dispatch.ts, which sits in the same
+ * circular-import cycle as this module — reading it at module-eval time can yield
+ * undefined ("capped at undefined") depending on which module is required first.
+ */
+function getListAdvancedNotes(): string[] {
+	if (_listAdvancedNotesCache) return _listAdvancedNotesCache;
+	_listAdvancedNotesCache = [
+		'filtersJson: JSON array of Autotask IFilterCondition objects for 3+ conditions or nested OR. Mutually exclusive with flat filter_field triplets. No label resolution — pass numeric IDs.',
+		`returnAll=true: fetches ALL matching records via API-native pagination. Without fields param: capped at ${MAX_RESPONSE_RECORDS} records. With fields param (sparse): no cap — all records returned. Use a narrow fields list for bulk ID/lookup patterns.`,
+		ASCENDING_ID_WARNING,
+		RECENCY_VS_SINCE_UNTIL_RULE.trim(),
+	];
+	return _listAdvancedNotesCache;
+}
 
 const SEARCH_BY_KEYWORD_NOTES: readonly string[] = [
 	"Use 'limit' (default 10) or 'returnAll=true' to control result count from the merged set.",
@@ -888,17 +896,17 @@ function getReadOpParams(): ReadOpParamsMap {
 			{
 				field: 'companyName',
 				type: 'string',
-				description: 'Optional company name signal (contains match).',
+				description: 'Company name signal (contains match).',
 			},
 			{
 				field: 'email',
 				type: 'string',
-				description: 'Optional email signal used to infer domain.',
+				description: 'Email signal used to infer domain.',
 			},
 			{
 				field: 'website',
 				type: 'string',
-				description: 'Optional website/domain signal used for primary match.',
+				description: 'Website/domain signal used for primary match.',
 			},
 			{
 				field: 'limit',
@@ -928,7 +936,7 @@ function getReadOpParams(): ReadOpParamsMap {
 			{
 				field: 'ticketFields',
 				type: 'string',
-				description: 'Optional comma-separated ticket fields to return.',
+				description: 'Comma-separated ticket fields to return.',
 			},
 		],
 	},
@@ -971,7 +979,7 @@ function getReadOpParams(): ReadOpParamsMap {
 			{
 				field: 'destinationCompanyLocationId',
 				type: 'number',
-				description: 'Optional destination location ID.',
+				description: 'Destination location ID.',
 			},
 			{ field: 'copyUdfs', type: 'boolean', description: 'Copy UDFs (default true).' },
 			{
@@ -1100,7 +1108,7 @@ function getReadOpParams(): ReadOpParamsMap {
 			{
 				field: 'rejectReason',
 				type: 'string',
-				description: 'Reason for rejection (recommended for audit trail).',
+				description: "Reason for rejection. Required when rejectReasonPolicy='mandatory'; otherwise include for the audit trail.",
 			},
 		],
 	},
@@ -1115,7 +1123,7 @@ function getReadOpParams(): ReadOpParamsMap {
 			{ field: 'fieldId', type: 'string', description: 'Field ID to list picklist values for.' },
 		],
 		optional: [
-			{ field: 'query', type: 'string', description: 'Optional search term.' },
+			{ field: 'query', type: 'string', description: 'Search term to filter values.' },
 			{ field: 'limit', type: 'number', description: 'Max results (default 50).' },
 			{ field: 'page', type: 'number', description: 'Page number (default 1).' },
 		],
@@ -1263,7 +1271,7 @@ function getOperationPurpose(
 		case 'approve':
 			return `Approve a pending ${resourceLabel} request by numeric ID.`;
 		case 'reject':
-			return `Reject a pending ${resourceLabel} request by numeric ID. Provide an optional rejectReason string.`;
+			return `Reject a pending ${resourceLabel} request by numeric ID. Provide rejectReason (required when rejectReasonPolicy='mandatory').`;
 		case 'describeFields':
 			return buildDescribeFieldsDescription(resourceLabel);
 		case 'listPicklistValues':
@@ -1315,11 +1323,10 @@ function getOperationNotes(resource: string, operation: string): string[] {
 		case 'getUnassigned':
 		case 'getBySLAStatus':
 		case 'getByResource':
-			return [...contractNotes, ...LIST_ADVANCED_NOTES];
 		case 'getMany':
 		case 'getPosted':
 		case 'getUnposted':
-			return [...contractNotes, ...LIST_ADVANCED_NOTES];
+			return [...contractNotes, ...getListAdvancedNotes()];
 		default:
 			return [...contractNotes];
 	}

--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -6,6 +6,7 @@ import { getOperationContractRuleText } from './operation-contracts';
 import { isWriteOperation } from './operation-metadata';
 import { RESOURCES_WITH_TERMINAL_STATUS_EXCLUSION, RESOURCE_EXTRA_HINTS } from './resource-language';
 import { MAX_RESPONSE_RECORDS } from './operation-handlers/operation-dispatch';
+import { READ_PARAM_DESC, fieldsDesc, filtersJsonDesc, returnAllDesc } from './read-param-descriptions';
 
 export const DESCRIPTION_REFERENCE_PLACEHOLDER = '__REFERENCE_UTC__';
 
@@ -745,88 +746,66 @@ const SEARCH_BY_KEYWORD_NOTES: readonly string[] = [
 	"Per-stage cap is 200 records. If a stage hits the cap, set includeNotes/includeTimeEntries=false or narrow the keyword.",
 ];
 
-/** Static parameter map for read and metadata operations */
-const READ_OP_PARAMS: Record<string, { required: OperationParam[]; optional: OperationParam[] }> = {
+type ReadOpParamsMap = Record<string, { required: OperationParam[]; optional: OperationParam[] }>;
+let _readOpParamsCache: ReadOpParamsMap | undefined;
+
+/**
+ * Static parameter map for read and metadata operations. Built lazily (first call, memoized)
+ * rather than as a module-load-time const: this module sits in a circular-import cycle
+ * (tool-executor.ts -> description-builders.ts -> read-param-descriptions.ts ->
+ * operation-dispatch.ts -> tool-executor.ts), and several entries below call
+ * fieldsDesc()/filtersJsonDesc()/returnAllDesc() from read-param-descriptions.ts — calling
+ * those at module-eval time can race the cycle and throw "X is not a function" depending on
+ * which module is required first. Deferring to first actual use avoids the race entirely.
+ */
+function getReadOpParams(): ReadOpParamsMap {
+	if (_readOpParamsCache) return _readOpParamsCache;
+	_readOpParamsCache = {
 	get: {
 		required: [{ field: 'id', type: 'number', description: 'Numeric entity ID.' }],
 		optional: [
-			{ field: 'fields', type: 'string', description: 'Real API field names only (call describeFields for the list). Do not include *_label or *_name fields — auto-added by outputMode=idsAndLabels.' },
+			{ field: 'fields', type: 'string', description: fieldsDesc() },
 		],
 	},
 	getMany: {
 		required: [],
 		optional: [
 			{ field: 'filter_field', type: 'string', description: 'Field to filter on.' },
-			{
-				field: 'filter_op',
-				type: 'string',
-				description:
-					'Operator: eq, noteq, gt, gte, lt, lte, contains, beginsWith, endsWith, exist, notExist, in, notIn.',
-			},
-			{
-				field: 'filter_value',
-				type: 'string',
-				description:
-					"Filter value as string. For reference/picklist fields, human-readable names auto-resolve to IDs. For in/notIn: comma-separate names or IDs ('Neil,Andrew' or '123,456'); each resolved independently — unresolved names with multiple candidates return pendingConfirmations; already-resolved in resolvedElements. Booleans: 'true'/'false'.",
-			},
-			{ field: 'filter_field_2', type: 'string', description: 'Second filter field.' },
-			{ field: 'filter_op_2', type: 'string', description: 'Second filter operator.' },
-			{
-				field: 'filter_value_2',
-				type: 'string',
-				description:
-					"Second filter value as string. For in/notIn, comma-separate values (e.g. '1,2,3').",
-			},
-			{ field: 'filter_logic', type: 'string', description: "'and' (default) or 'or'." },
-			{
-				field: 'filtersJson',
-				type: 'string',
-				description:
-					'JSON IFilterCondition array (mutually exclusive with flat filter_field triplets). No label resolution.',
-			},
-			{
-				field: 'returnAll',
-				type: 'boolean',
-				description:
-					`Fetch ALL matching records via API pagination. Without fields: capped at ${MAX_RESPONSE_RECORDS}. With fields (sparse fieldset): cap lifted — all records returned.`,
-			},
-			{ field: 'limit', type: 'number', description: 'Max records (1-500, default 10).' },
-			{ field: 'offset', type: 'number', description: 'Skip first N records (max 499).' },
+			{ field: 'filter_op', type: 'string', description: READ_PARAM_DESC.filter_op },
+			{ field: 'filter_value', type: 'string', description: READ_PARAM_DESC.filter_value },
+			{ field: 'filter_field_2', type: 'string', description: READ_PARAM_DESC.filter_field_2 },
+			{ field: 'filter_op_2', type: 'string', description: READ_PARAM_DESC.filter_op_2 },
+			{ field: 'filter_value_2', type: 'string', description: READ_PARAM_DESC.filter_value_2 },
+			{ field: 'filter_logic', type: 'string', description: READ_PARAM_DESC.filter_logic },
+			{ field: 'filtersJson', type: 'string', description: filtersJsonDesc() },
+			{ field: 'returnAll', type: 'boolean', description: returnAllDesc() },
+			{ field: 'limit', type: 'number', description: READ_PARAM_DESC.limit },
+			{ field: 'offset', type: 'number', description: READ_PARAM_DESC.offset },
 			{
 				field: 'recency',
 				type: 'string',
 				description: 'Preset window (last_7d, last_30d, etc.) or custom last_Nd.',
 			},
-			{ field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
-			{ field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
-			{ field: 'fields', type: 'string', description: 'Real API field names only (call describeFields for the list). Do not include *_label or *_name fields — auto-added by outputMode=idsAndLabels.' },
-			{ field: 'outputMode', type: 'string', description: "'idsAndLabels' (default): appends label fields automatically (resourceFullName, *_label etc.) — do NOT request these via fields. 'rawIds': numeric IDs only." },
+			{ field: 'since', type: 'string', description: READ_PARAM_DESC.since },
+			{ field: 'until', type: 'string', description: READ_PARAM_DESC.until },
+			{ field: 'fields', type: 'string', description: fieldsDesc() },
+			{ field: 'outputMode', type: 'string', description: READ_PARAM_DESC.outputMode },
 		],
 	},
 	count: {
 		required: [],
 		optional: [
 			{ field: 'filter_field', type: 'string', description: 'Field to filter on.' },
-			{ field: 'filter_op', type: 'string', description: 'Filter operator.' },
-			{
-				field: 'filter_value',
-				type: 'string',
-				description:
-					"Filter value as string. For reference/picklist fields, human-readable names auto-resolve to IDs. For in/notIn: comma-separate names or IDs; each resolved independently.",
-			},
-			{ field: 'filter_field_2', type: 'string', description: 'Second filter field.' },
-			{ field: 'filter_op_2', type: 'string', description: 'Second filter operator.' },
-			{
-				field: 'filter_value_2',
-				type: 'string',
-				description:
-					"Second filter value as string. For in/notIn, comma-separate values (e.g. '1,2,3').",
-			},
-			{ field: 'filter_logic', type: 'string', description: "'and' (default) or 'or'." },
-			{ field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array.' },
+			{ field: 'filter_op', type: 'string', description: READ_PARAM_DESC.filter_op },
+			{ field: 'filter_value', type: 'string', description: READ_PARAM_DESC.filter_value },
+			{ field: 'filter_field_2', type: 'string', description: READ_PARAM_DESC.filter_field_2 },
+			{ field: 'filter_op_2', type: 'string', description: READ_PARAM_DESC.filter_op_2 },
+			{ field: 'filter_value_2', type: 'string', description: READ_PARAM_DESC.filter_value_2 },
+			{ field: 'filter_logic', type: 'string', description: READ_PARAM_DESC.filter_logic },
+			{ field: 'filtersJson', type: 'string', description: filtersJsonDesc() },
 			{ field: 'recency', type: 'string', description: 'Preset window.' },
-			{ field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
-			{ field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
+			{ field: 'since', type: 'string', description: READ_PARAM_DESC.since },
+			{ field: 'until', type: 'string', description: READ_PARAM_DESC.until },
 		],
 	},
 	delete: {
@@ -836,59 +815,49 @@ const READ_OP_PARAMS: Record<string, { required: OperationParam[]; optional: Ope
 	whoAmI: {
 		required: [],
 		optional: [
-			{ field: 'fields', type: 'string', description: 'Real API field names only (call describeFields for the list). Do not include *_label or *_name fields — auto-added by outputMode=idsAndLabels.' },
+			{ field: 'fields', type: 'string', description: fieldsDesc() },
 		],
 	},
 	getPosted: {
 		required: [],
 		optional: [
 			{ field: 'filter_field', type: 'string', description: 'Field to filter on.' },
-			{ field: 'filter_op', type: 'string', description: 'Filter operator.' },
-			{
-				field: 'filter_value',
-				type: 'string',
-				description:
-					"Filter value as string. For reference/picklist fields, human-readable names auto-resolve to IDs. For in/notIn: comma-separate names or IDs; each resolved independently.",
-			},
-			{ field: 'filter_field_2', type: 'string', description: 'Second field to filter on.' },
-			{ field: 'filter_op_2', type: 'string', description: 'Second filter operator.' },
-			{ field: 'filter_value_2', type: 'string', description: 'Second filter value.' },
-			{ field: 'filter_logic', type: 'string', description: "'and' (default) or 'or' — logic between filter pairs." },
-			{ field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array. Mutually exclusive with filter_field.' },
-			{ field: 'returnAll', type: 'boolean', description: 'Fetch ALL matching records.' },
-			{ field: 'limit', type: 'number', description: 'Max records (1-500, default 10).' },
-			{ field: 'offset', type: 'number', description: 'Client-side offset for pagination (0–499).' },
+			{ field: 'filter_op', type: 'string', description: READ_PARAM_DESC.filter_op },
+			{ field: 'filter_value', type: 'string', description: READ_PARAM_DESC.filter_value },
+			{ field: 'filter_field_2', type: 'string', description: READ_PARAM_DESC.filter_field_2 },
+			{ field: 'filter_op_2', type: 'string', description: READ_PARAM_DESC.filter_op_2 },
+			{ field: 'filter_value_2', type: 'string', description: READ_PARAM_DESC.filter_value_2 },
+			{ field: 'filter_logic', type: 'string', description: READ_PARAM_DESC.filter_logic },
+			{ field: 'filtersJson', type: 'string', description: filtersJsonDesc() },
+			{ field: 'returnAll', type: 'boolean', description: returnAllDesc() },
+			{ field: 'limit', type: 'number', description: READ_PARAM_DESC.limit },
+			{ field: 'offset', type: 'number', description: READ_PARAM_DESC.offset },
 			{ field: 'recency', type: 'string', description: 'Preset window.' },
-			{ field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
-			{ field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
-			{ field: 'fields', type: 'string', description: 'Real API field names only (call describeFields for the list). Do not include *_label or *_name fields — auto-added by outputMode=idsAndLabels.' },
-			{ field: 'outputMode', type: 'string', description: "'idsAndLabels' (default): appends label fields automatically (resourceFullName, *_label etc.) — do NOT request these via fields. 'rawIds': numeric IDs only." },
+			{ field: 'since', type: 'string', description: READ_PARAM_DESC.since },
+			{ field: 'until', type: 'string', description: READ_PARAM_DESC.until },
+			{ field: 'fields', type: 'string', description: fieldsDesc() },
+			{ field: 'outputMode', type: 'string', description: READ_PARAM_DESC.outputMode },
 		],
 	},
 	getUnposted: {
 		required: [],
 		optional: [
 			{ field: 'filter_field', type: 'string', description: 'Field to filter on.' },
-			{ field: 'filter_op', type: 'string', description: 'Filter operator.' },
-			{
-				field: 'filter_value',
-				type: 'string',
-				description:
-					"Filter value as string. For reference/picklist fields, human-readable names auto-resolve to IDs. For in/notIn: comma-separate names or IDs; each resolved independently.",
-			},
-			{ field: 'filter_field_2', type: 'string', description: 'Second field to filter on.' },
-			{ field: 'filter_op_2', type: 'string', description: 'Second filter operator.' },
-			{ field: 'filter_value_2', type: 'string', description: 'Second filter value.' },
-			{ field: 'filter_logic', type: 'string', description: "'and' (default) or 'or' — logic between filter pairs." },
-			{ field: 'filtersJson', type: 'string', description: 'JSON IFilterCondition array. Mutually exclusive with filter_field.' },
-			{ field: 'returnAll', type: 'boolean', description: 'Fetch ALL matching records.' },
-			{ field: 'limit', type: 'number', description: 'Max records (1-500, default 10).' },
-			{ field: 'offset', type: 'number', description: 'Client-side offset for pagination (0–499).' },
+			{ field: 'filter_op', type: 'string', description: READ_PARAM_DESC.filter_op },
+			{ field: 'filter_value', type: 'string', description: READ_PARAM_DESC.filter_value },
+			{ field: 'filter_field_2', type: 'string', description: READ_PARAM_DESC.filter_field_2 },
+			{ field: 'filter_op_2', type: 'string', description: READ_PARAM_DESC.filter_op_2 },
+			{ field: 'filter_value_2', type: 'string', description: READ_PARAM_DESC.filter_value_2 },
+			{ field: 'filter_logic', type: 'string', description: READ_PARAM_DESC.filter_logic },
+			{ field: 'filtersJson', type: 'string', description: filtersJsonDesc() },
+			{ field: 'returnAll', type: 'boolean', description: returnAllDesc() },
+			{ field: 'limit', type: 'number', description: READ_PARAM_DESC.limit },
+			{ field: 'offset', type: 'number', description: READ_PARAM_DESC.offset },
 			{ field: 'recency', type: 'string', description: 'Preset window.' },
-			{ field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
-			{ field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
-			{ field: 'fields', type: 'string', description: 'Real API field names only (call describeFields for the list). Do not include *_label or *_name fields — auto-added by outputMode=idsAndLabels.' },
-			{ field: 'outputMode', type: 'string', description: "'idsAndLabels' (default): appends label fields automatically (resourceFullName, *_label etc.) — do NOT request these via fields. 'rawIds': numeric IDs only." },
+			{ field: 'since', type: 'string', description: READ_PARAM_DESC.since },
+			{ field: 'until', type: 'string', description: READ_PARAM_DESC.until },
+			{ field: 'fields', type: 'string', description: fieldsDesc() },
+			{ field: 'outputMode', type: 'string', description: READ_PARAM_DESC.outputMode },
 		],
 	},
 	searchByDomain: {
@@ -1104,10 +1073,10 @@ const READ_OP_PARAMS: Record<string, { required: OperationParam[]; optional: Ope
 			{ field: 'limit', type: 'number', description: 'Max records per branch (1-500, default 10).' },
 			{ field: 'returnAll', type: 'boolean', description: 'Fetch all per branch.' },
 			{ field: 'recency', type: 'string', description: 'Preset window (e.g. last_7d).' },
-			{ field: 'since', type: 'string', description: 'Range start ISO-8601 UTC.' },
-			{ field: 'until', type: 'string', description: 'Range end ISO-8601 UTC.' },
+			{ field: 'since', type: 'string', description: READ_PARAM_DESC.since },
+			{ field: 'until', type: 'string', description: READ_PARAM_DESC.until },
 			{ field: 'excludeTerminalStatuses', type: 'boolean', description: 'Exclude Complete/Cancelled (ticket only, default true).' },
-			{ field: 'fields', type: 'string', description: 'Real API field names only (call describeFields for the list). Do not include *_label or *_name fields — auto-added by outputMode=idsAndLabels.' },
+			{ field: 'fields', type: 'string', description: fieldsDesc() },
 		],
 	},
 	getByYear: {
@@ -1157,7 +1126,9 @@ const READ_OP_PARAMS: Record<string, { required: OperationParam[]; optional: Ope
 		],
 		optional: [],
 	},
-};
+	};
+	return _readOpParamsCache;
+}
 
 function buildWriteParams(
 	writeFields: FieldMeta[],
@@ -1378,7 +1349,7 @@ export function buildOperationDoc(
 	if (WRITE_OPS_WITH_FIELD_METADATA.has(targetOperation)) {
 		parameters = buildWriteParams(writeFields, targetOperation === 'createIfNotExists');
 	} else {
-		parameters = READ_OP_PARAMS[targetOperation] ?? { required: [], optional: [] };
+		parameters = getReadOpParams()[targetOperation] ?? { required: [], optional: [] };
 	}
 
 	const notes = getOperationNotes(resource, targetOperation);

--- a/nodes/Autotask/ai-tools/read-param-descriptions.ts
+++ b/nodes/Autotask/ai-tools/read-param-descriptions.ts
@@ -42,7 +42,11 @@ export function fieldsDesc(): string {
 }
 
 export function filtersJsonDesc(): string {
-	return 'Advanced filters as a JSON array. Mutually exclusive with filter_field/filter_field_2. No label resolution — use numeric IDs.';
+	return (
+		'Advanced filters as a JSON array of condition objects. Mutually exclusive with filter_field/filter_field_2. No label resolution — use numeric IDs. ' +
+		'Each condition: {"field":"<name>","op":"<op>","value":<value>}. Nested AND/OR: {"op":"and"|"or","items":[<cond>,...]}. ' +
+		'in/notIn value is a JSON array (max 500). Call describeFields for field names, listPicklistValues for picklist IDs.'
+	);
 }
 
 export function returnAllDesc(): string {

--- a/nodes/Autotask/ai-tools/read-param-descriptions.ts
+++ b/nodes/Autotask/ai-tools/read-param-descriptions.ts
@@ -1,0 +1,50 @@
+import { MAX_RESPONSE_RECORDS } from './operation-handlers/operation-dispatch';
+
+/**
+ * Single-source descriptions for read-family params that recur across many
+ * operations (getMany, count, getPosted, getUnposted, getByResource, getByYear,
+ * ticket.getByResource) and both consumers (schema-generator.ts Zod .describe(),
+ * description-builders.ts READ_OP_PARAMS). `filter_field` is excluded — it is
+ * resource-branched (enum of real field names vs plain string fallback) and stays
+ * local to schema-generator.ts.
+ */
+export const READ_PARAM_DESC = {
+	filter_op:
+		"Filter operator (optional, default 'eq'). 'notExist' matches empty/null fields, 'exist' matches populated — neither needs filter_value. Others: eq, noteq, gt, gte, lt, lte, contains, beginsWith, endsWith, in, notIn.",
+	filter_op_2: "Second filter operator (optional, default 'eq').",
+	filter_value:
+		"Filter value. Required with filter_field (not needed when filter_op is 'exist' or 'notExist'). Reference/picklist fields: pass the human-readable name (e.g. 'In Progress') — auto-resolved to ID, or pass a numeric ID directly. in/notIn: comma-separate values; each name resolved independently (see resolvedElements/pendingConfirmations in the response). Booleans: 'true'/'false'.",
+	filter_value_2:
+		"Second filter value. Required with filter_field_2 (not needed when filter_op_2 is 'exist' or 'notExist').",
+	filter_field_2:
+		'Second filter field. Provide filter_value_2 with it, or omit the second filter entirely. Requires the first filter. Same field names as filter_field.',
+	filter_logic:
+		"Combine the two filter pairs: 'and' (default) or 'or'. Valid only when both pairs are supplied — sending it with one pair is rejected.",
+	limit: 'Max results (1-500, default 10).',
+	offset:
+		'Skip first N records (0-499). Response includes hasMore/nextOffset. Max 500 total — narrow filters for more.',
+	recency:
+		'Preset time window: last_15m, last_1h, last_2h, last_3h, last_4h, last_6h, last_8h, last_12h, last_24h, last_1d–last_7d, last_14d, last_30d, last_90d. Or last_Nd (N=1–365). Mutually exclusive with since/until.',
+	since:
+		'Range start (ISO-8601 UTC). Lower bound — records at or after this. Mutually exclusive with recency.',
+	until:
+		'Range end (ISO-8601 UTC). Requires since or recency. Mutually exclusive with recency.',
+	outputMode:
+		"'idsAndLabels' (default) appends derived label fields — do NOT list these in fields. 'rawIds' returns numeric IDs only.",
+} as const;
+
+export function fieldsDesc(): string {
+	return (
+		'Sparse fieldset — comma-separated field names to return. Omit for all fields; id is always included. ' +
+		`With returnAll=true, specifying fields lifts the ${MAX_RESPONSE_RECORDS}-record payload cap. ` +
+		'Real API field names only (call describeFields for the list). Do not request *_label/*_name fields — auto-added by outputMode=idsAndLabels.'
+	);
+}
+
+export function filtersJsonDesc(): string {
+	return 'Advanced filters as a JSON array. Mutually exclusive with filter_field/filter_field_2. No label resolution — use numeric IDs.';
+}
+
+export function returnAllDesc(): string {
+	return `Fetch all matching records via cursor pagination. Default false = up to limit. Without fields, payload caps at ${MAX_RESPONSE_RECORDS}; with fields, cap lifted.`;
+}

--- a/nodes/Autotask/ai-tools/read-param-descriptions.ts
+++ b/nodes/Autotask/ai-tools/read-param-descriptions.ts
@@ -28,7 +28,7 @@ export const READ_PARAM_DESC = {
 	since:
 		'Range start (ISO-8601 UTC). Lower bound — records at or after this. Mutually exclusive with recency.',
 	until:
-		'Range end (ISO-8601 UTC). Requires since or recency. Mutually exclusive with recency.',
+		'Range end (ISO-8601 UTC). Upper bound — records at or before this. Requires since. Mutually exclusive with recency.',
 	outputMode:
 		"'idsAndLabels' (default) appends derived label fields — do NOT list these in fields. 'rawIds' returns numeric IDs only.",
 } as const;

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -250,7 +250,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.nullish()
 				.describe(
 					'Resource name, email, or numeric ID (auto-resolved). Required for getByResource and getByYear. ' +
-					"For ticket.getByResource: searches primary (assignedResourceID) and/or secondary (TicketSecondaryResources) assignments based on mode.",
+					"For ticket.getByResource: searches primary (assignedResourceID) and/or secondary (TicketSecondaryResources) assignments per 'mode'.",
 				);
 		}
 
@@ -272,7 +272,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					.min(1)
 					.max(500)
 					.nullish()
-					.describe('Max records per branch (1-500, default 10). Note: combined merged result may exceed limit when mode=both.');
+					.describe('Max records per branch (1-500, default 10). Combined merged result may exceed limit when mode=both.');
 			}
 			if (!shape.fields) {
 				shape.fields = rz
@@ -307,7 +307,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.number()
 				.int()
 				.nullish()
-				.describe('Calendar year (e.g. 2024). Required for getByYear operation.');
+				.describe('Calendar year (e.g. 2024). Required for getByYear.');
 		}
 
 		// rejectReason — used only by reject
@@ -441,15 +441,15 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.companyName = rz
 				.string()
 				.nullish()
-				.describe('Optional company name for contains matching and ranking.');
+				.describe('Company name for contains matching and ranking.');
 			shape.email = rz
 				.string()
 				.nullish()
-				.describe('Optional email used to infer domain for matching.');
+				.describe('Email used to infer domain for matching.');
 			shape.website = rz
 				.string()
 				.nullish()
-				.describe('Optional website/domain used for primary domain matching.');
+				.describe('Website/domain used for primary domain matching.');
 			shape.limit = rz
 				.number()
 				.int()
@@ -494,7 +494,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.ticketFields = rz
 				.string()
 				.nullish()
-				.describe('Optional comma-separated ticket fields to return.');
+				.describe('Comma-separated ticket fields to return.');
 		}
 
 		// summary fields
@@ -509,7 +509,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.number()
 				.nullish()
 				.describe(
-					'Maximum characters for description and resolution fields in the summary. Default 500. Pass 0 for no limit.',
+					'Max characters for summary description/resolution fields (default 500; 0 = no limit).',
 				);
 			shape.includeChildCounts = rz
 				.coerce.boolean()
@@ -563,20 +563,20 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					.describe(
 						hasGetByCompanyAndStatus
 							? 'Company name or numeric companyID (auto-resolved). Required for getByCompanyAndStatus; optional for other ops.'
-							: 'Company name or numeric companyID (auto-resolved). Optional — omit for all companies.',
+							: 'Company name or numeric companyID (auto-resolved). Omit for all companies.',
 					);
 			}
 			if (RESOURCES_WITH_PRIORITY.has(resource) && !shape.priority) {
 				shape.priority = rz
 					.string()
 					.nullish()
-					.describe('Priority picklist label or ID (optional).');
+					.describe('Priority picklist label or ID.');
 			}
 			if (hasGetByCompanyAndStatus && !shape.status) {
 				shape.status = rz
 					.string()
 					.nullish()
-					.describe('Status picklist label or ID (optional). Omit for all statuses.');
+					.describe('Status picklist label or ID. Omit for all statuses.');
 			}
 		}
 
@@ -599,7 +599,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				shape.company = rz
 					.string()
 					.nullish()
-					.describe('Company name or numeric companyID (auto-resolved). Optional.');
+					.describe('Company name or numeric companyID (auto-resolved).');
 			}
 		}
 
@@ -616,19 +616,19 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				shape.company = rz
 					.string()
 					.nullish()
-					.describe('Company name or numeric companyID (auto-resolved). Optional.');
+					.describe('Company name or numeric companyID (auto-resolved).');
 			}
 			if (!shape.status) {
 				shape.status = rz
 					.string()
 					.nullish()
-					.describe('Status picklist label or ID (optional).');
+					.describe('Status picklist label or ID.');
 			}
 			if (RESOURCES_WITH_PRIORITY.has(resource) && !shape.priority) {
 				shape.priority = rz
 					.string()
 					.nullish()
-					.describe('Priority picklist label or ID (optional).');
+					.describe('Priority picklist label or ID.');
 			}
 		}
 
@@ -713,7 +713,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					.string()
 					.nullish()
 					.describe(
-						'JSON object of UDF field name → value pairs for user-defined fields. ' +
+						'JSON object of UDF field name → value pairs. ' +
 						'Keys must exactly match UDF field names as returned by describeFields (mode=write). ' +
 						'Example: {"Customer Size": "Enterprise", "Region": "APAC"}. ' +
 						'For picklist UDFs use the picklist value ID (label resolution not supported for UDFs).',
@@ -752,30 +752,30 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.int()
 				.min(1)
 				.nullish()
-				.describe('Optional destination company location ID.');
+				.describe('Destination company location ID.');
 			shape.destinationContactId = rz
 				.number()
 				.int()
 				.min(1)
 				.nullish()
-				.describe('Optional destination contact ID.');
+				.describe('Destination contact ID.');
 			shape.copyUdfs = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to copy user-defined fields (default true).');
+				.describe('Copy user-defined fields (default true).');
 			shape.copyAttachments = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to copy CI attachments (default true).');
-			shape.copyNotes = rz.coerce.boolean().nullish().describe('Whether to copy notes (default true).');
+				.describe('Copy CI attachments (default true).');
+			shape.copyNotes = rz.coerce.boolean().nullish().describe('Copy notes (default true).');
 			shape.copyNoteAttachments = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to copy note attachments (default true).');
+				.describe('Copy note attachments (default true).');
 			shape.deactivateSource = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to deactivate the source CI after safety checks (default true).');
+				.describe('Deactivate the source CI after safety checks (default true).');
 			shape.idempotencyKey = rz.string().nullish().describe('Optional run key for traceability.');
 			shape.includeMaskedUdfsPolicy = rz
 				.enum(['omit', 'fail'])
@@ -808,7 +808,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.retryJitter = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to use jitter in retry backoff (default true).');
+				.describe('Use jitter in retry backoff (default true).');
 			shape.throttleMaxBytesPer5Min = rz
 				.number()
 				.int()
@@ -854,33 +854,33 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.int()
 				.min(1)
 				.nullish()
-				.describe('Optional destination company location ID.');
+				.describe('Destination company location ID.');
 			shape.skipIfDuplicateEmailFound = rz
 				.coerce.boolean()
 				.nullish()
 				.describe(
-					'Whether to skip move when duplicate email exists on destination (default true).',
+					'Skip the move when a duplicate email exists on the destination (default true).',
 				);
 			shape.copyContactGroups = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to copy contact group memberships (default true).');
+				.describe('Copy contact group memberships (default true).');
 			shape.copyCompanyNotes = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to copy company notes linked to the contact (default true).');
+				.describe('Copy company notes linked to the contact (default true).');
 			shape.copyNoteAttachments = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to copy attachments for copied notes (default true).');
+				.describe('Copy attachments for copied notes (default true).');
 			shape.sourceAuditNote = rz
 				.string()
 				.nullish()
-				.describe('Optional audit note written to the source company context.');
+				.describe('Audit note written to the source company context.');
 			shape.destinationAuditNote = rz
 				.string()
 				.nullish()
-				.describe('Optional audit note written to the destination company context.');
+				.describe('Audit note written to the destination company context.');
 			if (!shape.impersonationResourceId) {
 				shape.impersonationResourceId = rz
 					.coerce.string()
@@ -912,34 +912,34 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.includeTickets = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to include tickets (default false).');
+				.describe('Include tickets (default false).');
 			shape.includeProjects = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to include projects (default false).');
+				.describe('Include projects (default false).');
 			shape.includeServiceCallAssignments = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to reassign service call task/ticket resources (default false).');
+				.describe('Reassign service call task/ticket resources (default false).');
 			shape.includeAppointments = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to reassign appointments (default false).');
+				.describe('Reassign appointments (default false).');
 			shape.includeCompanies = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to transfer companies owned by the source resource (default false).');
+				.describe('Transfer companies owned by the source resource (default false).');
 			shape.companyIdAllowlist = rz
 				.string()
 				.nullish()
 				.describe(
-					'Company IDs to scope the transfer. Applies only when includeCompanies=true.',
+					'Comma-separated company IDs to scope the transfer. Applies only when includeCompanies=true.',
 				);
 			shape.includeOpportunities = rz
 				.coerce.boolean()
 				.nullish()
 				.describe(
-					'Whether to transfer opportunities owned by the source resource (default false).',
+					'Transfer opportunities owned by the source resource (default false).',
 				);
 			shape.dueWindowPreset = rz
 				.enum([
@@ -955,7 +955,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 					'custom',
 				])
 				.nullish()
-				.describe("Optional due window preset. Use 'custom' with dueBeforeCustom.");
+				.describe("Due window preset. Use 'custom' with dueBeforeCustom.");
 			shape.dueBeforeCustom = rz
 				.string()
 				.nullish()
@@ -970,7 +970,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.coerce.boolean()
 				.nullish()
 				.describe(
-					'Whether items with no due date are included (default true, unless due window is set).',
+					'Include items with no due date (default true, unless a due window is set).',
 				);
 			shape.ticketAssignmentMode = rz
 				.enum(['primaryOnly', 'primaryAndSecondary'])
@@ -1004,18 +1004,18 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 				.string()
 				.nullish()
 				.describe(
-					'Status labels to allow. Ignored when statusAllowlistByValue is set. Supply only one of the two.',
+					'Comma-separated status labels to allow. Ignored when statusAllowlistByValue is set. Supply only one of the two.',
 				);
 			shape.statusAllowlistByValue = rz
 				.string()
 				.nullish()
 				.describe(
-					'Status IDs to allow. Takes precedence — when set, statusAllowlistByLabel is ignored. Supply only one of the two.',
+					'Comma-separated status IDs to allow. Takes precedence — when set, statusAllowlistByLabel is ignored. Supply only one of the two.',
 				);
 			shape.addAuditNotes = rz
 				.coerce.boolean()
 				.nullish()
-				.describe('Whether to create per-entity audit notes (default false).');
+				.describe('Create per-entity audit notes (default false).');
 			shape.auditNoteTemplate = rz
 				.string()
 				.nullish()
@@ -1038,7 +1038,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		if (operations.includes('getAvailableRoles')) {
 			if (!shape.resourceID) {
 				shape.resourceID = rz.coerce.string().nullish().describe(
-					'Required for getAvailableRoles. The resource (technician) ID or name to find available roles for.'
+					'Resource (technician) ID or name to find available roles for. Required for getAvailableRoles.'
 				);
 			}
 			if (!shape.ticketID) {
@@ -1085,7 +1085,7 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 						.string()
 						.nullish()
 						.describe(
-							'JSON object of UDF field name → value pairs for user-defined fields. ' +
+							'JSON object of UDF field name → value pairs. ' +
 							'Keys must exactly match UDF field names as returned by describeFields (mode=write). ' +
 							'Example: {"Customer Size": "Enterprise", "Region": "APAC"}. ' +
 							'For picklist UDFs use the picklist value ID (label resolution not supported for UDFs).',

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -315,7 +315,9 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.rejectReason = rz
 				.string()
 				.nullish()
-				.describe('Reason for rejecting the time off request. Recommended for audit trail.');
+				.describe(
+					"Reason for rejecting the time off request. Required when rejectReasonPolicy='mandatory'.",
+				);
 			shape.rejectReasonPolicy = rz
 				.enum(['optional', 'mandatory'])
 				.nullish()
@@ -328,13 +330,13 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		if (resource === 'globalNotesSearch') {
 			if (operations.includes('searchNotes')) {
 				shape['keyword'] = rz.string().nullish().describe(
-					'Text to search across note titles and bodies (contains match). Applied to all 7 note entity types.',
+					'Text to search note titles and bodies (contains match) across all 7 note types. At least one of keyword, since, or until is required.',
 				);
 				shape['since'] = rz.string().nullish().describe(
-					'ISO 8601 datetime — return only notes with createDateTime >= this value.',
+					'ISO-8601 datetime — notes with createDateTime >= this. At least one of keyword, since, or until is required.',
 				);
 				shape['until'] = rz.string().nullish().describe(
-					'ISO 8601 datetime — return only notes with createDateTime <= this value.',
+					'ISO-8601 datetime — notes with createDateTime <= this. At least one of keyword, since, or until is required.',
 				);
 				shape['limit'] = rz.number().int().min(1).max(25).nullish().describe(
 					'Max results per note entity type (default 10, max 25). Total records = 7 × limit at most.',
@@ -930,7 +932,9 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.companyIdAllowlist = rz
 				.string()
 				.nullish()
-				.describe('Optional comma-separated company IDs to scope company transfer.');
+				.describe(
+					'Company IDs to scope the transfer. Applies only when includeCompanies=true.',
+				);
 			shape.includeOpportunities = rz
 				.coerce.boolean()
 				.nullish()
@@ -999,11 +1003,15 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			shape.statusAllowlistByLabel = rz
 				.string()
 				.nullish()
-				.describe('Optional comma-separated status labels to include.');
+				.describe(
+					'Status labels to allow. Ignored when statusAllowlistByValue is set. Supply only one of the two.',
+				);
 			shape.statusAllowlistByValue = rz
 				.string()
 				.nullish()
-				.describe('Optional comma-separated status integer values to include.');
+				.describe(
+					'Status IDs to allow. Takes precedence — when set, statusAllowlistByLabel is ignored. Supply only one of the two.',
+				);
 			shape.addAuditNotes = rz
 				.coerce.boolean()
 				.nullish()

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -6,7 +6,7 @@ import { safeKeys, summariseFields, traceSchemaBuild } from './debug-trace';
 import { getOperationMetadata, isWriteOperation } from './operation-metadata';
 import { TYPED_REFERENCE_STRATEGIES } from '../helpers/typed-reference';
 import { RESOURCES_WITH_PRIORITY, RESOURCES_WITH_TERMINAL_STATUS_EXCLUSION } from './resource-language';
-import { MAX_RESPONSE_RECORDS } from './operation-handlers/operation-dispatch';
+import { READ_PARAM_DESC, fieldsDesc, filtersJsonDesc, returnAllDesc } from './read-param-descriptions';
 
 /** Picklist inlining threshold — at or below this count, inline all values; above, tell LLM to call listPicklistValues. */
 const INLINE_PICKLIST_THRESHOLD = 4;
@@ -141,17 +141,8 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		'in',
 		'notIn',
 	]);
-	const rFilterValueSchema = rz
-		.string()
-		.describe(
-			"Filter value as string. For reference/picklist fields, pass human-readable name (e.g. 'In Progress', 'Contoso', 'High') — auto-resolves to ID, or pass numeric ID directly. For in/notIn: comma-separate names or IDs (e.g. 'Neil,Andrew' or '123,456'). Each name resolved independently; names with multiple candidates return pendingConfirmations, already-resolved names shown in resolvedElements. Booleans: 'true'/'false'.",
-		);
-	const rRecencySchema = rz
-		.string()
-		.nullish()
-		.describe(
-			'Preset time window: last_15m, last_1h, last_2h, last_3h, last_4h, last_6h, last_8h, last_12h, last_24h, last_1d–last_7d, last_14d, last_30d, last_90d. Or last_Nd (N=1–365). Mutually exclusive with since/until.',
-		);
+	const rFilterValueSchema = rz.string().describe(READ_PARAM_DESC.filter_value);
+	const rRecencySchema = rz.string().nullish().describe(READ_PARAM_DESC.recency);
 
 	function buildUnifiedSchema(
 		resource: string,
@@ -291,16 +282,10 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 			}
 			if (!shape.recency) shape.recency = rRecencySchema;
 			if (!shape.since) {
-				shape.since = rz
-					.string()
-					.nullish()
-					.describe('Range start (ISO-8601; e.g. 2026-01-01T09:00:00Z). Overrides recency.');
+				shape.since = rz.string().nullish().describe(READ_PARAM_DESC.since);
 			}
 			if (!shape.until) {
-				shape.until = rz
-					.string()
-					.nullish()
-					.describe('Range end (ISO-8601). Requires since or recency.');
+				shape.until = rz.string().nullish().describe(READ_PARAM_DESC.until);
 			}
 			if (!shape.excludeTerminalStatuses) {
 				shape.excludeTerminalStatuses = rz
@@ -387,61 +372,32 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 
 		// fields — column selection
 		if (hasGetFamily || hasCreate) {
-			shape.fields = rz
-				.string()
-				.nullish()
-				.describe(
-					`Sparse fieldset — comma-separated field names to return. Omit for all fields. The id field is always included automatically. ` +
-					`Reduces payload size significantly for entities with many fields. ` +
-					`With returnAll=true, specifying fields lifts the ${MAX_RESPONSE_RECORDS}-record payload cap — all matching records are returned. ` +
-					`Real API field names only (call describeFields for the full list). Do not request *_label or *_name fields — those are auto-added by outputMode=idsAndLabels.`,
-				);
+			shape.fields = rz.string().nullish().describe(fieldsDesc());
 		}
 
 		// Filter fields for list operations
 		const hasSearchByKeywordForListShared = operations.includes('searchByKeyword');
 		if (hasListFamily || hasSearchByKeywordForListShared) {
 			const fieldNames = readFields.filter((f) => !f.udf && isValidSchemaKey(f.id)).map((f) => f.id);
+			const filterFieldPairClause =
+				"Field to filter on. Provide filter_value with it (not needed when filter_op is 'exist'/'notExist'). For 'older than'/upper-bound date queries use a date field (createDate, lastActivityDate, dueDateTime) with filter_op='lt'.";
 			const filterFieldDesc =
-				"Field to filter on. Use operation 'describeFields' to see valid field names. For 'older than' / upper-bound date queries use filter_field with a date field + filter_op='lt'.";
+				`${filterFieldPairClause} Use operation 'describeFields' to see valid field names.`;
 			shape.filter_field =
 				fieldNames.length > 0
 					? rz
 							.enum(fieldNames as [string, ...string[]])
 							.nullish()
-							.describe("Field to filter on. For 'older than' / upper-bound date queries, use a date field (createDate, lastActivityDate, dueDateTime) with filter_op='lt'.")
+							.describe(filterFieldPairClause)
 					: rz.string().nullish().describe(filterFieldDesc);
-			shape.filter_op = rFilterOpEnum.nullish().describe("Filter operator. Use 'notExist' for unassigned/empty/null fields (no filter_value needed). Use 'exist' for populated fields. Other operators: eq (equals), noteq (not equals), gt/gte/lt/lte (numeric/date comparisons), contains/beginsWith/endsWith (text), in/notIn (array of values).");
+			shape.filter_op = rFilterOpEnum.nullish().describe(READ_PARAM_DESC.filter_op);
 			shape.filter_value = rFilterValueSchema.nullish();
-			shape.filter_field_2 = rz
-				.string()
-				.nullish()
-				.describe(
-					'Second filter field — same valid values as filter_field. Supports date fields with filter_op_2 for bounded date ranges.',
-				);
-			shape.filter_op_2 = rFilterOpEnum.nullish().describe('Second filter operator');
-			shape.filter_value_2 = rFilterValueSchema.nullish().describe('Second filter value');
-			shape.filter_logic = rz
-				.enum(['and', 'or'])
-				.nullish()
-				.describe(
-					"Combiner between the two filter pairs: 'and' (default) or 'or'.",
-				);
-			shape.limit = rz
-				.number()
-				.int()
-				.min(1)
-				.max(500)
-				.nullish()
-				.describe('Max results (1-500, default 10)');
-			shape.offset = rz
-				.number()
-				.int()
-				.min(0)
-				.nullish()
-				.describe(
-					'Skip first N records (0–499). Response includes hasMore/nextOffset. Max 500 total — narrow filters for more.',
-				);
+			shape.filter_field_2 = rz.string().nullish().describe(READ_PARAM_DESC.filter_field_2);
+			shape.filter_op_2 = rFilterOpEnum.nullish().describe(READ_PARAM_DESC.filter_op_2);
+			shape.filter_value_2 = rFilterValueSchema.nullish().describe(READ_PARAM_DESC.filter_value_2);
+			shape.filter_logic = rz.enum(['and', 'or']).nullish().describe(READ_PARAM_DESC.filter_logic);
+			shape.limit = rz.number().int().min(1).max(500).nullish().describe(READ_PARAM_DESC.limit);
+			shape.offset = rz.number().int().min(0).nullish().describe(READ_PARAM_DESC.offset);
 			shape.recency = rRecencySchema;
 			const dateFields = readFields
 				.filter((f) => !f.udf && isValidSchemaKey(f.id) && f.type.toLowerCase().includes('date'))
@@ -454,42 +410,14 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 						`Date/time field for recency/since/until. Available: ${dateFields.join(', ')}. Default: first available.`,
 					);
 			}
-			shape.since = rz
-				.string()
-				.nullish()
-				.describe(
-					'Range start (ISO-8601; e.g. 2026-01-01T09:00:00 or 2026-01-01T09:00:00Z). Overrides recency.',
-				);
-			shape.until = rz
-				.string()
-				.nullish()
-				.describe(
-					'Range end (ISO-8601). Requires since or recency.',
-				);
-			shape.filtersJson = rz.string().nullish().describe(
-					`Advanced filters as JSON array of Autotask IFilterCondition objects. Mutually exclusive with filter_field. No label resolution — use numeric IDs for all values including in/notIn (for name-based in/notIn use the filter_value param path instead). Dates UTC ISO-8601. ` +
-				`Supports: eq/noteq/gt/gte/lt/lte/contains/beginsWith/endsWith/exist/notExist/in/notIn. ` +
-				`in/notIn value must be a JSON array (max 500 values per Autotask API limit). ` +
-				`Nested AND group: [{"op":"and","items":[<cond1>,<cond2>]}]. ` +
-				`Nested OR group: [{"op":"or","items":[<cond1>,<cond2>]}]. ` +
-				`Each condition shape: {"field":"<fieldName>","op":"<op>","value":<value>}. ` +
-				`Call describeFields for valid field names on this resource, and listPicklistValues for valid picklist IDs.`,
-				);
-			shape.returnAll = rz
-				.coerce.boolean()
-				.nullish()
-				.describe(
-					`Fetch ALL matching records via API cursor pagination. Default false = up to limit. ` +
-				`Without fields: payload capped at ${MAX_RESPONSE_RECORDS} records. ` +
-				`With fields param (sparse fieldset): cap lifted — all records returned. ` +
-				`Pair returnAll=true with a narrow fields list for efficient bulk ID/lookup patterns.`,
-				);
+			shape.since = rz.string().nullish().describe(READ_PARAM_DESC.since);
+			shape.until = rz.string().nullish().describe(READ_PARAM_DESC.until);
+			shape.filtersJson = rz.string().nullish().describe(filtersJsonDesc());
+			shape.returnAll = rz.coerce.boolean().nullish().describe(returnAllDesc());
 			shape.outputMode = rz
 				.enum(['idsAndLabels', 'rawIds'])
 				.nullish()
-				.describe(
-					"'idsAndLabels' (default): appends derived label fields to results (e.g. resourceID → resourceFullName + resourceEmail; picklist IDs → *_label). Do NOT include these in the fields param — they are auto-added. 'rawIds': numeric IDs only.",
-				);
+				.describe(READ_PARAM_DESC.outputMode);
 
 			// excludeTerminalStatuses — only for resources that have terminal status semantics
 			if (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

Makes the AI Tools schema/description text runtime-accurate and concise. Resolves #116: the `getMany` filter descriptions gave an LLM no signal that a filter field and its value are a linked pair, so models emitted a partial second-filter clause (empty `filter_value_2`) that the node correctly rejected as `INVALID_FILTER_CONSTRAINT` — preventable friction, not a functional bug.

An audit found #116 was one instance of a broader class of description problems, and the descriptions were verbose in general. This PR fixes both.

## Changes

**Cross-field constraint clauses (now stated on every participating field, verified against runtime enforcement):**
- `filter_field`/`filter_value` (and the `_2` pair): provide the field and value together; operator is optional and defaults to `eq`; value not needed for `exist`/`notExist`. (#116)
- `filter_logic`: valid only when both filter pairs are present — rejected with one (previously undocumented).
- `since`: corrected from "overrides recency" (which the runtime actually rejects) to **mutually exclusive with recency**; `until` requires `since` or `recency`.
- `globalNotesSearch`: at least one of `keyword`/`since`/`until` is required.
- `transferOwnership`: `companyIdAllowlist` applies only when `includeCompanies=true`; `statusAllowlistByValue` takes precedence over `statusAllowlistByLabel`.
- `rejectReason`: required when `rejectReasonPolicy='mandatory'`.

**Concision sweep:** ~60 tool/field description strings rewritten to tight-imperative phrasing — filler removed, every semantic token (field names, enum values, defaults, examples, bounds, `describeFields`/`listPicklistValues` hints) preserved.

**Single-source read-param descriptions:** extracted the descriptions shared between the Zod schema and the `describeOperation` docs into one module, so cross-field constraints are stated once and cannot drift between the two.

## Scope / safety

Description text only — no change to validation logic, filter semantics, Zod field types, or field keys. The two `getReadOpParams()`/`getListAdvancedNotes()` refactors are behaviour-preserving lazy getters that also close a pre-existing "capped at undefined" hazard from a module-init import cycle.

## Verification

- `pnpm build` exits 0.
- Offline unit suite green, including a new assertion test that every constraint clause is present in the built schema (read via `zod-to-json-schema`, the same path n8n's `normalizeToolSchema` uses).
- Independent review confirmed zero semantic-token loss across the sweep and runtime-accuracy of every constraint clause.
