### PR TITLE
fix: route CompanyAlert create/update/delete through parent-scoped path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.27.0] - 2026-07-24
+
+### Fixed
+- `CompanyAlert` create/update/delete failed on both the standard node and AI Tools node because its entity metadata declared all operations as flat `'self'` paths (`/CompanyAlerts/`), but the Autotask REST API only accepts create/update/delete for this entity under the parent-scoped path (`/Companies/{companyID}/Alerts`) — the flat path only ever supported query/count (issue #119). `entities.ts` now marks `CompanyAlert` as `childOf: 'Company'` with `parentIdField: 'companyID'` and `CREATE`/`UPDATE`/`DELETE` set to `'parent'` (`QUERY`/`COUNT` stay `'self'`), mirroring the existing `CompanyNote` pattern. Both nodes share the same generic URL-building and dispatch code paths off this metadata, so the one-line fix covers both.
+
+### Changed
+- `companyAlert` is now exposed as an AI Tools resource (`autotask_companyAlert`). No AI-tools-specific code was needed — the tool resource list, schema generation, and parent-scoping are all derived from the same `entities.ts` metadata fixed above.
+
 ## [2.26.4] - 2026-07-22
 
 ### Fixed

--- a/nodes/Autotask/constants/entities.ts
+++ b/nodes/Autotask/constants/entities.ts
@@ -22,7 +22,7 @@ export const AUTOTASK_ENTITIES: IEntityMetadata[] = [
 		hasUserDefinedFields: true,
 		supportsWebhookCallouts: true,
 	},
-	{ name: 'CompanyAlert', operations: { [OperationType.CREATE]: 'self', [OperationType.UPDATE]: 'self', [OperationType.QUERY]: 'self', [OperationType.DELETE]: 'self', [OperationType.COUNT]: 'self' } },
+	{ name: 'CompanyAlert', childOf: 'Company', subname: 'Alerts', parentIdField: 'companyID', operations: { [OperationType.CREATE]: 'parent', [OperationType.UPDATE]: 'parent', [OperationType.QUERY]: 'self', [OperationType.DELETE]: 'parent', [OperationType.COUNT]: 'self' } },
 	{ name: 'CompanyAttachment', aiDescription: 'Attachment records scoped to a Company parent record.', childOf: 'Company', subname: 'Attachment', isAttachment: true, operations: { [OperationType.CREATE]: 'parent', [OperationType.DELETE]: 'parent' } },
 	{ name: 'CompanyNote', aiDescription: 'Company Note records scoped to a Company parent record.', childOf: 'Company', subname: 'Notes', parentIdField: 'companyID', operations: { [OperationType.CREATE]: 'parent', [OperationType.UPDATE]: 'parent', [OperationType.QUERY]: 'self', [OperationType.COUNT]: 'self' } },
 	{ name: 'CompanyNoteAttachment', aiDescription: 'Attachment records scoped to a Company Note parent record.', childOf: 'CompanyNote', subname: 'Attachment', parentChain: ['Company', 'CompanyNote'], isAttachment: true, operations: { [OperationType.CREATE]: 'parent', [OperationType.DELETE]: 'parent' } },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.26.4",
+  "version": "2.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-autotask",
-      "version": "2.26.4",
+      "version": "2.27.0",
       "license": "MIT",
       "dependencies": {
         "change-case": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.26.4",
+  "version": "2.27.0",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- Fixes #119 — `CompanyAlert` create/update/delete failed on both the standard node and the AI Tools node because `entities.ts` declared all operations as flat `'self'` paths (`/CompanyAlerts/`), but the Autotask API only accepts create/update/delete for this entity under the parent-scoped path (`/Companies/{companyID}/Alerts`). Flat path only ever supported query/count.
- Fix is a single `entities.ts` metadata change — `CompanyAlert` now declares `childOf: 'Company'` / `parentIdField: 'companyID'` with `CREATE`/`UPDATE`/`DELETE` set to `'parent'`, mirroring the existing `CompanyNote` entry. Both nodes share the same generic URL-building and dispatch code off this metadata, so one change covers both.
- As a result, `companyAlert` is now also exposed as an AI Tools resource (`autotask_companyAlert`) — no additional code needed, since the AI Tools resource list, schema generation, and parent-scoping are all data-driven off the same metadata.
- Version bump to 2.27.0 (minor) with CHANGELOG entry.

## Test plan
- [x] `pnpm build` exits 0
- [ ] Standard node: create/update/delete a Company Alert scoped to a Company, confirm correct `/Companies/{id}/Alerts` routing
- [ ] AI Tools node: confirm `autotask_companyAlert` tool is available and create/update/delete route correctly