### PR TITLE
fix: accept numeric filter_value in AI-tools getMany/count (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the n8n-nodes-autotask project will be documented in this file.
 
+## [2.27.1] - 2026-07-24
+
+### Fixed
+- AI Tools: `getMany`/`count` filters no longer reject a JSON numeric `filter_value`/`filter_value_2` (issue #121). The schema declared these as `rz.string()`, so an MCP/Copilot-Studio-style client emitting an unquoted number — e.g. `filter_value: 0` for `companyID noteq 0` — failed Zod validation with "Expected string, received number", forcing the model into a count-all / count-one / subtract workaround instead of one filtered call. Changed to `rz.coerce.string()`, matching the repo convention for any field compared against IDs (the string `"0"` already worked). Covers both the `func()` and `execute()` paths.
+- AI Tools: `hasProvidedValue()` treated the number `0` (and negatives) as "not provided" via a `value > 0` branch. On the Agent-V3 `execute()` path — which passes raw `item.json` without Zod coercion — a numeric `0` filter value or an `id: 0` (the root Company record) was wrongly seen as absent, tripping "filter value required" / xor-group validation. Now any finite number counts as provided.
+
+### Changed
+- AI Tools: `getMany` description now shows the exclude-a-value pattern explicitly (`filter_op='noteq'`, e.g. `companyID noteq 0`, or `'notIn'` with a comma-separated list) and steers away from count-and-subtract — both operators were already fully functional but had no example, the likely reason the model in #121 reached for the workaround.
+- AI Tools: `filtersJson` description now states it must be a JSON-*encoded string* (not a native array/object) with an inline example, so clients stop sending structured objects and getting an opaque type-mismatch.
+
 ## [2.27.0] - 2026-07-24
 
 ### Fixed

--- a/nodes/Autotask/ai-tools/description-builders.ts
+++ b/nodes/Autotask/ai-tools/description-builders.ts
@@ -163,6 +163,7 @@ export function buildGetManyDescription(
 		`Search ${resourceLabel} with up to two filters (AND default; filter_logic='or' for either-match; use filtersJson for 3+ filters or nested groups). ` +
 		`Example: filter_field='companyName', filter_op='contains', filter_value='Acme'. ` +
 		`Picklist/reference fields accept names (auto-resolved). Use filter_op='notExist'/'exist' for null checks. ` +
+		`Exclude a value in one call: filter_op='noteq' (e.g. companyID noteq 0), or 'notIn' with a comma-separated list — never count-and-subtract. ` +
 		terminalHint +
 		`Filterable: ${fieldList}. ` +
 		`${ASCENDING_ID_WARNING} ` +

--- a/nodes/Autotask/ai-tools/operation-contracts.ts
+++ b/nodes/Autotask/ai-tools/operation-contracts.ts
@@ -81,7 +81,9 @@ export function hasProvidedValue(value: unknown): boolean {
 	if (value === undefined || value === null) return false;
 	if (typeof value === 'string') return value.trim() !== '';
 	if (Array.isArray(value)) return value.length > 0;
-	if (typeof value === 'number') return Number.isFinite(value) && value > 0;
+	// Any finite number counts as provided — 0 is a valid filter value and a valid id
+	// (the root Company record has id=0). value>0 wrongly dropped both.
+	if (typeof value === 'number') return Number.isFinite(value);
 	return true;
 }
 

--- a/nodes/Autotask/ai-tools/read-param-descriptions.ts
+++ b/nodes/Autotask/ai-tools/read-param-descriptions.ts
@@ -43,7 +43,7 @@ export function fieldsDesc(): string {
 
 export function filtersJsonDesc(): string {
 	return (
-		'Advanced filters as a JSON array of condition objects. Mutually exclusive with filter_field/filter_field_2. No label resolution — use numeric IDs. ' +
+		'Advanced filters as a JSON-encoded string (not a native array/object) — e.g. \'[{"field":"companyID","op":"noteq","value":0}]\'. Mutually exclusive with filter_field/filter_field_2. No label resolution — use numeric IDs. ' +
 		'Each condition: {"field":"<name>","op":"<op>","value":<value>}. Nested AND/OR: {"op":"and"|"or","items":[<cond>,...]}. ' +
 		'in/notIn value is a JSON array (max 500). Call describeFields for field names, listPicklistValues for picklist IDs.'
 	);

--- a/nodes/Autotask/ai-tools/schema-generator.ts
+++ b/nodes/Autotask/ai-tools/schema-generator.ts
@@ -141,7 +141,10 @@ export function getRuntimeSchemaBuilders(rz: RuntimeZod) {
 		'in',
 		'notIn',
 	]);
-	const rFilterValueSchema = rz.string().describe(READ_PARAM_DESC.filter_value);
+	// coerce.string (not plain string) so MCP/Copilot Studio-style clients that emit
+	// JSON numbers (e.g. filter_value 0 for `companyID noteq 0`) aren't rejected —
+	// matches the repo convention for any field compared against IDs.
+	const rFilterValueSchema = rz.coerce.string().describe(READ_PARAM_DESC.filter_value);
 	const rRecencySchema = rz.string().nullish().describe(READ_PARAM_DESC.recency);
 
 	function buildUnifiedSchema(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-autotask",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "license": "MIT",
       "dependencies": {
         "change-case": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-autotask",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "description": "n8n node for Autotask PSA integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

Fixes #121. A real MCP-agent interaction with the `autotask_ticket` tool — *"how many open tickets assigned to me are for a company other than my own?"* — should reduce to **one** filtered `count` call (`companyID noteq 0`). Instead, repeated schema-validation failures forced the model into a count-all / count-one / subtract workaround (`323 - 169 = 154`). Numerically correct, but avoidable friction.

The issue was filed as a well-researched, code-verified report. I re-verified each of its 5 findings against the current code before touching anything, fixed the ones on the reported path, and deferred the one the reporter themselves flagged as optional/separate.

## Root cause (both confirmed)

1. **`filter_value` / `filter_value_2` were `rz.string()`** (`schema-generator.ts:144`, applied `:396,:399`). An MCP/Copilot-Studio client that emits an unquoted JSON number — e.g. `filter_value: 0` for `companyID noteq 0` — failed Zod with *"Expected string, received number"* on both the `func()` and `execute()` paths. The string `"0"` already worked. This contradicted the repo's own convention (per `CLAUDE.md`) of `rz.coerce.string()` for any field compared against IDs. → **changed to `rz.coerce.string()`**.

2. **`buildGetManyDescription` never mentioned `noteq`/`notIn`** despite both being fully functional operators — the likely reason the model reached for count-and-subtract with no example to follow. → **added a compact exclude-a-value example** (`companyID noteq 0`, or `notIn` with a comma-separated list).

## Also fixed in the same path

- **`hasProvidedValue()` treated numeric `0` (and negatives) as "not provided"** via a `value > 0` branch (`operation-contracts.ts:84`). The report called this unreachable, but it's reachable on the **Agent-V3 `execute()` path** (raw `item.json`, no Zod coercion), where a numeric `0` filter value — or an `id: 0`, the root Company record — was wrongly seen as absent, tripping "filter value required" / xor-group validation. → **any finite number now counts as provided.**
- **`filtersJson` description** now states it must be a JSON-*encoded string* (not a native array/object), with an inline example — clients were sending structured objects and getting an opaque type-mismatch.

## Out of scope (deferred, noted on the issue)

Finding #3 — the hardcoded `[5, 8]` terminal-status pair for `excludeTerminalStatuses` and the `isActive`/`isSystem` stripping in `listPicklistValues()`. The reporter marked this optional/larger, and it isn't on the path this interaction hit (the symptom was a `companyID` filter, not status). It's a separate custom-status concern; leaving it for a dedicated change rather than widening this fix.

## Verification

- `pnpm build` exits 0.
- Full offline unit suite: **137 passed**, plus a new regression test asserting (a) `filter_value: 0` coerces to `"0"` through the built schema and (b) the `getMany` description contains `noteq`/`notIn`. The only 3 failing tests are the pre-existing `langchain-anchor-fallback` suite, which fails by local environment (no resident n8n LangChain tree), unrelated to this change.
- Behaviour of `hasProvidedValue` spot-checked against the built output: `0`→provided, `-3`→provided, `NaN`/`null`/`""`→not provided, `"0"`→provided.

## Scope / safety

Zod field type, one guard, and description text only — no change to filter semantics, tool names, or the result envelope.

